### PR TITLE
Implement a functional hat-spline forward path for KAN layers: compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,35 @@ println("Tensors: ${gguf.tensors.size}")
 
 See CHANGELOG.md for the full list.
 
+## Experimental: Kolmogorov–Arnold Networks (KAN)
+
+SKaiNET includes an initial KAN layer implementation that you can wire into the NN DSL. A KAN layer expands each input feature by a learnable grid of basis coefficients and then mixes them with a linear projection, with optional bias and residual connection.
+
+- Current status: experimental/preview. API and behavior may change.
+- Forward path uses broadcasted basis expansion and a matmul mixing step.
+- `gridSize`, `useBias`, `useResidual`, and a custom `baseActivation` are supported. The `degree` parameter is reserved for future spline/basis functions and is not yet used.
+
+Quick usage example:
+
+```kotlin
+val model = nn {
+    input(64)
+    dense(out = 64)
+    // Add a KAN layer that keeps the same dimensionality and uses a residual connection
+    kanLayer(outputDim = 64, gridSize = 16, useResidual = true)
+    dense(out = 10)
+}
+```
+
+Notes and limitations:
+- Works with the default CPU backend; performance tuning and specialized kernels may arrive later.
+- Residuals are applied only when `outputDim == inputDim`.
+- You can customize initializers for the mixing weights, basis, and bias via the DSL block.
+
+See source for details:
+- skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/KanDsl.kt
+- skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/KanLayer.kt
+
 ## License
 
 MIT — see LICENSE.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ include("skainet-lang:skainet-lang-core")
 include("skainet-lang:skainet-lang-models")
 include("skainet-lang:skainet-lang-ksp-annotations")
 include("skainet-lang:skainet-lang-ksp-processor")
+include("skainet-lang:skainet-kan")
 
 
 // ====== COMPILE
@@ -47,4 +48,3 @@ include("skainet-io:skainet-io-gguf")
 
 // ====== APPS
 //include("skainet-apps:skainet-KGPChat")
-

--- a/skainet-lang/skainet-kan/build.gradle.kts
+++ b/skainet-lang/skainet-kan/build.gradle.kts
@@ -1,0 +1,64 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.kover)
+    alias(libs.plugins.binary.compatibility.validator)
+}
+
+kotlin {
+    explicitApi()
+
+    androidTarget {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+
+    iosArm64()
+    iosSimulatorArm64()
+    macosArm64()
+    linuxX64()
+    linuxArm64()
+
+    jvm()
+
+    js {
+        browser()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":skainet-lang:skainet-lang-core"))
+            implementation(libs.kotlinx.coroutines)
+        }
+
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(project(":skainet-backends:skainet-backend-cpu"))
+        }
+    }
+}
+
+android {
+    namespace = "sk.ainet.lang.kan"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}

--- a/skainet-lang/skainet-kan/gradle.properties
+++ b/skainet-lang/skainet-kan/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-lang-kan
+POM_NAME=skainet neural network scripting API

--- a/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/Akn.kt
+++ b/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/Akn.kt
@@ -1,0 +1,73 @@
+package sk.ainet.lang.kan
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.dsl.BiasScope
+import sk.ainet.lang.nn.dsl.BiasScopeImpl
+import sk.ainet.lang.nn.dsl.WeightsScope
+import sk.ainet.lang.nn.dsl.WeightsScopeImpl
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import kotlin.reflect.KClass
+
+/**
+ * Public NN module alias for Kolmogorov–Arnold Network (AKN).
+ * This exposes the same implementation the DSL uses (KanLayer) for direct creation without the DSL.
+ */
+public typealias AknConfig = KanConfig
+public typealias Akn<T, V> = KanLayer<T, V>
+
+/**
+ * Factory to create an AKN module directly (without the kanLayer DSL helper).
+ * Mirrors defaults and initializer hooks used by the DSL.
+ */
+public fun <T : DType, V> createAkn(
+    executionContext: ExecutionContext,
+    dtype: KClass<T>,
+    inputDim: Int,
+    outputDim: Int,
+    gridSize: Int = 16,
+    degree: Int = 3,
+    useBias: Boolean = true,
+    useResidual: Boolean = false,
+    name: String = "akn",
+    baseActivation: (Tensor<T, V>) -> Tensor<T, V> = { it },
+    weightsInit: WeightsScope<T, V>.(Shape) -> Tensor<T, V> = { randn(std = 0.02f) },
+    basisInit: WeightsScope<T, V>.(Shape) -> Tensor<T, V> = { uniform(min = -0.5f, max = 0.5f) },
+    biasInit: BiasScope<T, V>.(Shape) -> Tensor<T, V> = { zeros() }
+): Akn<T, V> {
+    require(outputDim > 0) { "AKN requires outputDim > 0." }
+    require(gridSize > 0) { "AKN requires gridSize > 0." }
+    require(inputDim > 0) { "AKN requires inputDim > 0." }
+
+    val weightsShape = Shape(outputDim, inputDim * gridSize)
+    val basisShape = Shape(inputDim, gridSize)
+    val biasShape = Shape(outputDim)
+
+    val wScope = WeightsScopeImpl<T, V>(executionContext, weightsShape, dtype)
+    val bScope = WeightsScopeImpl<T, V>(executionContext, basisShape, dtype)
+    val weights = weightsInit.invoke(wScope, weightsShape)
+    val basis = basisInit.invoke(bScope, basisShape)
+    val bias = if (useBias) {
+        val biasScope = BiasScopeImpl<T, V>(executionContext, biasShape, dtype)
+        biasInit.invoke(biasScope, biasShape)
+    } else null
+
+    val config = KanConfig(
+        inputDim = inputDim,
+        outputDim = outputDim,
+        gridSize = gridSize,
+        degree = degree,
+        useBias = useBias,
+        useResidual = useResidual
+    )
+
+    return KanLayer(
+        config = config,
+        baseActivation = baseActivation,
+        initMixingWeights = weights,
+        initBasis = basis,
+        initBias = bias,
+        name = name
+    )
+}

--- a/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/KanDsl.kt
+++ b/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/KanDsl.kt
@@ -1,0 +1,155 @@
+package sk.ainet.lang.kan
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.dsl.NeuralNetworkDsl
+import sk.ainet.lang.nn.dsl.NeuralNetworkDslImpl
+import sk.ainet.lang.nn.dsl.NetworkDsl
+import sk.ainet.lang.nn.dsl.NetworkDslItem
+import sk.ainet.lang.nn.dsl.StageImpl
+import sk.ainet.lang.nn.dsl.BiasScope
+import sk.ainet.lang.nn.dsl.BiasScopeImpl
+import sk.ainet.lang.nn.dsl.WeightsScope
+import sk.ainet.lang.nn.dsl.WeightsScopeImpl
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import kotlin.reflect.KClass
+
+/**
+ * DSL surface for configuring a Kolmogorov–Arnold Network layer.
+ */
+@NetworkDsl
+public interface KAN<T : DType, V> : NetworkDslItem {
+    public var outputDim: Int
+    public var gridSize: Int
+    public var degree: Int
+    public var useBias: Boolean
+    public var useResidual: Boolean
+    public var baseActivation: (Tensor<T, V>) -> Tensor<T, V>
+    public fun weights(initBlock: WeightsScope<T, V>.(Shape) -> Tensor<T, V>)
+    public fun basis(initBlock: WeightsScope<T, V>.(Shape) -> Tensor<T, V>)
+    public fun bias(initBlock: BiasScope<T, V>.(Shape) -> Tensor<T, V>)
+}
+
+public class KanDslImpl<T : DType, V>(
+    override val executionContext: ExecutionContext,
+    private val dtype: KClass<T>,
+    initialOutputDim: Int,
+    private val id: String
+) : KAN<T, V> {
+    override var outputDim: Int = initialOutputDim
+    override var gridSize: Int = 16
+    override var degree: Int = 3
+    override var useBias: Boolean = true
+    override var useResidual: Boolean = false
+    override var baseActivation: (Tensor<T, V>) -> Tensor<T, V> = { it }
+    public var weightsInit: WeightsScope<T, V>.(Shape) -> Tensor<T, V> = { randn(std = 0.02f) }
+    public var basisInit: WeightsScope<T, V>.(Shape) -> Tensor<T, V> = { uniform(min = -0.5f, max = 0.5f) }
+    public var biasInit: BiasScope<T, V>.(Shape) -> Tensor<T, V> = { zeros() }
+
+    override fun weights(initBlock: WeightsScope<T, V>.(Shape) -> Tensor<T, V>) {
+        weightsInit = initBlock
+    }
+
+    override fun basis(initBlock: WeightsScope<T, V>.(Shape) -> Tensor<T, V>) {
+        basisInit = initBlock
+    }
+
+    override fun bias(initBlock: BiasScope<T, V>.(Shape) -> Tensor<T, V>) {
+        biasInit = initBlock
+    }
+
+    public fun create(
+        inputDim: Int,
+        mixingWeights: Tensor<T, V>,
+        basis: Tensor<T, V>,
+        bias: Tensor<T, V>?
+    ): KanLayer<T, V> = KanLayer(
+        config = KanConfig(
+            inputDim = inputDim,
+            outputDim = outputDim,
+            gridSize = gridSize,
+            degree = degree,
+            useBias = useBias,
+            useResidual = useResidual
+        ),
+        baseActivation = baseActivation,
+        initMixingWeights = mixingWeights,
+        initBasis = basis,
+        initBias = bias,
+        name = id
+    )
+}
+
+/**
+ * Adds a KAN layer to the existing network DSL.
+ *
+ * Note: The current implementation expands inputs with a learnable basis per
+ * feature and mixes them via a linear projection. The `degree` parameter is
+ * reserved for future spline/basis variants and is not yet used.
+ */
+public inline fun <reified T : DType, V> NeuralNetworkDsl<T, V>.kanLayer(
+    outputDim: Int,
+    gridSize: Int = 16,
+    degree: Int = 3,
+    useBias: Boolean = true,
+    useResidual: Boolean = false,
+    id: String = "",
+    noinline baseActivation: (Tensor<T, V>) -> Tensor<T, V> = { it },
+    content: KAN<T, V>.() -> Unit = {}
+) {
+    val resolvedId = id.ifEmpty {
+        when (this) {
+            is NeuralNetworkDslImpl<*, *> -> "kan-${this.modules.size}"
+            is StageImpl<*, *> -> "kan-${this.modules.size}"
+            else -> "kan"
+        }
+    }
+    val impl = KanDslImpl<T, V>(
+        executionContext = executionContext,
+        dtype = T::class,
+        initialOutputDim = outputDim,
+        id = resolvedId
+    )
+    impl.gridSize = gridSize
+    impl.degree = degree
+    impl.useBias = useBias
+    impl.useResidual = useResidual
+    impl.baseActivation = baseActivation
+    impl.content()
+
+    require(outputDim > 0) { "KAN layer requires outputDim > 0." }
+    require(gridSize > 0) { "KAN layer requires gridSize > 0." }
+    val inputDim = when (this) {
+        is NeuralNetworkDslImpl<T, V> -> this.lastDimension
+        is StageImpl<T, V> -> this.lastDimension
+        else -> error("KAN layers are supported only on the default SKaiNET DSL implementations")
+    }
+    require(inputDim > 0) { "KAN layer requires a known input dimension; call input(...) before kanLayer()." }
+
+    val weightsShape = Shape(outputDim, inputDim * gridSize)
+    val basisShape = Shape(inputDim, gridSize)
+    val biasShape = Shape(outputDim)
+    val weightsScope = WeightsScopeImpl<T, V>(executionContext, weightsShape, T::class)
+    val weightsTensor = impl.weightsInit.invoke(weightsScope, weightsShape)
+    val basisScope = WeightsScopeImpl<T, V>(executionContext, basisShape, T::class)
+    val basisTensor = impl.basisInit.invoke(basisScope, basisShape)
+    val biasTensor = if (impl.useBias) {
+        val biasScope = BiasScopeImpl<T, V>(executionContext, biasShape, T::class)
+        impl.biasInit.invoke(biasScope, biasShape)
+    } else null
+
+    when (this) {
+        is NeuralNetworkDslImpl<T, V> -> {
+            this.modules += impl.create(inputDim, weightsTensor, basisTensor, biasTensor)
+            this.lastDimension = outputDim
+        }
+
+        is StageImpl<T, V> -> {
+            this.modules += impl.create(inputDim, weightsTensor, basisTensor, biasTensor)
+            this.lastDimension = outputDim
+        }
+
+        else -> error("KAN layers are supported only on the default SKaiNET DSL implementations")
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/KanLayer.kt
+++ b/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/KanLayer.kt
@@ -1,0 +1,115 @@
+package sk.ainet.lang.kan
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.topology.ModuleParameter
+import sk.ainet.lang.nn.topology.ModuleParameters
+import sk.ainet.lang.nn.topology.bias
+import sk.ainet.lang.nn.topology.weights
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import kotlin.math.PI
+import kotlin.math.max
+
+/**
+ * Configuration for a Kolmogorov–Arnold Network layer.
+ */
+public data class KanConfig(
+    val inputDim: Int,
+    val outputDim: Int,
+    val gridSize: Int = 16,
+    val degree: Int = 3,
+    val useBias: Boolean = true,
+    val useResidual: Boolean = false,
+    val regularization: KanRegularization = KanRegularization(),
+    val gridMin: Float = 0.0f,
+    val gridMax: Float = (PI / 2).toFloat()
+)
+
+/**
+ * Simple regularization hints for future spline/mixing penalties.
+ */
+public data class KanRegularization(
+    val splineSmoothness: Double = 0.0,
+    val sparsity: Double = 0.0
+)
+
+/**
+ * Stub implementation for a Kolmogorov–Arnold Network layer.
+ *
+ * The forward path intentionally throws until the spline basis and mixing
+ * logic are implemented. The class still wires into the DSL so models can
+ * be composed before kernels land.
+ */
+public class KanLayer<T : DType, V>(
+    public val config: KanConfig,
+    public val baseActivation: (Tensor<T, V>) -> Tensor<T, V>,
+    initMixingWeights: Tensor<T, V>,
+    initBasis: Tensor<T, V>,
+    initBias: Tensor<T, V>?,
+    override val name: String
+) : Module<T, V>(), ModuleParameters<T, V> {
+
+    override val params: List<ModuleParameter<T, V>> = listOfNotNull(
+        ModuleParameter.WeightParameter("$name.mixing_weight", initMixingWeights),
+        ModuleParameter.WeightParameter("$name.basis", initBasis),
+        initBias?.let { ModuleParameter.BiasParameter("$name.bias", it) }
+    )
+
+    override val modules: List<Module<T, V>> = emptyList()
+
+    override fun forward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> {
+        val ops = input.ops
+        val weightParams = params.filterIsInstance<ModuleParameter.WeightParameter<T, V>>()
+        val mixing = weightParams.first { it.name.contains("mixing", ignoreCase = true) }.value
+        val basis = weightParams.first { it.name.contains("basis", ignoreCase = true) }.value
+        val bias = params.filterIsInstance<ModuleParameter.BiasParameter<T, V>>().firstOrNull()?.value
+
+        // Collapse higher-rank inputs to [batch, features] to align with the mixing step.
+        val base = when (input.rank) {
+            1 -> ops.unsqueeze(input, 0)
+            2 -> input
+            else -> ops.flatten(input, startDim = 1, endDim = -1)
+        }
+
+        // Hat basis evaluation per input dimension:
+        val batch = base.shape.dimensions[0]
+        val step = if (config.gridSize > 1) (config.gridMax - config.gridMin) / (config.gridSize - 1) else config.gridMax - config.gridMin
+        val centersData = FloatArray(config.inputDim * config.gridSize) { idx ->
+            val g = idx % config.gridSize
+            config.gridMin + step * g
+        }
+        val centers = ctx.fromFloatArray<T, V>(Shape(config.inputDim, config.gridSize), basis.dtype, centersData)
+
+        val baseExp = ops.unsqueeze(base, base.rank) // [batch, in, 1]
+        val centersExp = ops.unsqueeze(centers, dim = 0) // [1, in, grid]
+        val diff = ops.subtract(baseExp, centersExp)
+        val absDiff = ops.add(ops.relu(diff), ops.relu(ops.subtract(centersExp, baseExp)))
+
+        val widthScalar = max(step, 1e-6f)
+        val widthTensor = ctx.full<T, V>(Shape(1, 1, 1), basis.dtype, widthScalar)
+        val absOverW = ops.divide(absDiff, widthTensor)
+        val oneTensor = ctx.full<T, V>(Shape(1, 1, 1), basis.dtype, 1.0f)
+        val hat = ops.relu(ops.subtract(oneTensor, absOverW)) // [batch, in, grid]
+
+        val basisExp = ops.unsqueeze(basis, dim = 0)
+        val weightedHat = ops.multiply(hat, basisExp)
+        val expanded = ops.reshape(weightedHat, Shape(batch, config.inputDim * config.gridSize))
+
+        val mixed = ops.matmul(expanded, ops.transpose(mixing))
+        val biased = if (bias != null) {
+            val biasAdjusted = if (bias.rank == 1) ops.unsqueeze(bias, 0) else bias
+            ops.add(mixed, biasAdjusted)
+        } else {
+            mixed
+        }
+        val activated = baseActivation(biased)
+
+        return when {
+            input.rank == 1 -> ops.squeeze(activated, dim = 0)
+            config.useResidual && config.outputDim == config.inputDim -> ops.add(activated, base)
+            else -> activated
+        }
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/examples/SineKan.kt
+++ b/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/examples/SineKan.kt
@@ -1,0 +1,23 @@
+package sk.ainet.lang.kan.examples
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.kan.kanLayer
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.definition
+import sk.ainet.lang.nn.dsl.sequential
+import sk.ainet.lang.types.FP32
+
+/**
+ * Minimal KAN-based approximator for y = sin(x) on [0, pi/2].
+ *
+ * Uses a single KAN layer with a small grid and identity activation; basis/mixing
+ * tensors are learnable via the usual parameter updates.
+ */
+public fun sineKan(executionContext: ExecutionContext): Module<FP32, Float> = definition {
+    sequential<FP32, Float>(executionContext) {
+        input(1, "input")
+        kanLayer(outputDim = 1, gridSize = 16, degree = 3, id = "sine-kan") {
+            baseActivation = { it } // identity to let spline/mixing do the work
+        }
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/examples/SineKanPretrained.kt
+++ b/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/examples/SineKanPretrained.kt
@@ -1,0 +1,125 @@
+package sk.ainet.lang.kan.examples
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.kan.kanLayer
+import sk.ainet.lang.nn.Module
+import sk.ainet.lang.nn.definition
+import sk.ainet.lang.nn.dsl.sequential
+import sk.ainet.lang.types.FP32
+
+/**
+ * A tiny, fixed KAN-based approximator for y = sin(x) on the interval [0, π/2].
+ * It consists of a single KAN layer whose basis, mixer weights and bias were
+ * exported from the accompanying PyTorch script in `piekan/train.py`, and are
+ * embedded here as constants. At runtime, it builds a Module with those values
+ * frozen, serving as a lightweight, dependency-free example of loading
+ * pretrained KAN parameters in Kotlin.
+ *
+ * What it is:
+ * - A minimal, ready-to-use example demonstrating how to instantiate a KAN layer
+ *   with predetermined basis/weights/bias to approximate sin(x) on a narrow
+ *   domain.
+ * - Deterministic and non-trainable in this form; it does not modify parameters
+ *   during execution.
+ *
+ * What it is not:
+ * - Not a general-purpose sine model outside [0, π/2]; quality may degrade
+ *   beyond the trained range.
+ * - Not a full KAN stack or training pipeline; it omits optimizers, loss, and
+ *   data handling, focusing solely on inference with fixed parameters.
+ */
+public object SineKanPretrained {
+
+    public val basisValues: FloatArray = floatArrayOf(
+        -0.61100733f,
+        -0.54657453f,
+        0.46215805f,
+        0.43084604f,
+        0.09301915f,
+        -0.35296658f,
+        0.47887635f,
+        0.7482730f,
+        -0.60586500f,
+        0.63107467f,
+        0.95884424f,
+        0.82173777f,
+        0.76084960f,
+        -1.0838321f,
+        -0.83811396f,
+        1.101861f
+    )
+    public val mixingValues: FloatArray = floatArrayOf(
+        0.65286535f,
+        0.53845954f,
+        -0.41289636f,
+        -0.2080267f,
+        0.08796077f,
+        -0.2876495f,
+        0.3955012f,
+        0.36192146f,
+        -0.56926537f,
+        0.65100110f,
+        0.4879738f,
+        0.6272730f,
+        0.72681934f,
+        -0.5352414f,
+        -0.7117360f,
+        0.54629606f
+    )
+    public val biasValues: FloatArray = floatArrayOf(0.3989265f)
+
+    /**
+     * Build the pretrained KAN module with fixed weights/basis/bias.
+     */
+    public fun create(executionContext: ExecutionContext): Module<FP32, Float> = definition {
+        sequential<FP32, Float> {
+            input(1, "input")
+            kanLayer(outputDim = 1, gridSize = 16, degree = 3, id = "sine-kan-pretrained") {
+                baseActivation = { it } // identity; spline+mixer encode the fit
+                weights { _ -> fromArray(mixingValues) }
+                basis { _ -> fromArray(basisValues) }
+                bias { _ -> fromArray(biasValues) }
+            }
+        }
+    }
+
+    /**
+     * Produce a minimal Graphviz/DOT visualization of this tiny pretrained KAN.
+     * This does not depend on any external Graphviz library — it just returns
+     * a DOT string that you can render with the `dot` tool or any Graphviz viewer.
+     *
+     * The graph shows a single input feeding into the fixed KAN layer node,
+     * and annotates that node with concise parameter summaries (counts).
+     *
+     * Example usage:
+     * - Save to file: println(SineKanPretrained.toGraphvizDot()) > sine_kan.dot
+     * - Render PNG:   dot -Tpng sine_kan.dot -o sine_kan.png
+     */
+    public fun toGraphvizDot(rankdir: String = "LR"): String {
+        require(rankdir == "LR" || rankdir == "TB") { "rankdir must be either 'LR' or 'TB'" }
+
+        val inputId = "input"
+        val kanId = "sine_kan_pretrained"
+
+        val basisCount = basisValues.size
+        val weightCount = mixingValues.size
+        val biasCount = biasValues.size
+
+        val label = buildString {
+            append("KAN Layer | id: sine-kan-pretrained\\n")
+            append("gridSize: 16, degree: 3\\n")
+            append("basis: ").append(basisCount)
+            append(", weights: ").append(weightCount)
+            append(", bias: ").append(biasCount)
+        }
+
+        return buildString {
+            appendLine("digraph {")
+            appendLine("    rankdir=$rankdir;")
+            appendLine("    $inputId [label=\"input | x\", shape=record, style=filled, fillcolor=lightblue];")
+            appendLine("    $kanId [label=\"$label\", shape=record];")
+            appendLine("    $inputId -> $kanId;")
+            appendLine("}")
+        }
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/simple_nn_dsl.kt
+++ b/skainet-lang/skainet-kan/src/commonMain/kotlin/sk/ainet/lang/kan/simple_nn_dsl.kt
@@ -1,0 +1,27 @@
+package sk.ainet.lang.kan
+
+/**
+ * Legacy scratch DSL sample retained for reference only.
+ * The body is commented out to keep the module buildable under explicit API.
+ */
+/*
+definition<FP32, Float> {
+    network(ctx) {
+        input(1, "input")
+        dense(16, "hidden-1") {
+            weights { zeros() }
+            bias { zeros() }
+            activation = { tensor -> with(tensor) { relu() } }
+        }
+        dense(16, "hidden-2") {
+            weights { zeros() }
+            bias { zeros() }
+            activation = { tensor -> with(tensor) { relu() } }
+        }
+        dense(1, "output") {
+            weights { zeros() }
+            bias { zeros() }
+        }
+    }
+}
+*/

--- a/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/AknModuleIntegrationTest.kt
+++ b/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/AknModuleIntegrationTest.kt
@@ -1,0 +1,39 @@
+package sk.ainet.lang.kan
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import sk.ainet.lang.nn.DefaultNeuralNetworkExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+
+class AknModuleIntegrationTest {
+
+    private val ctx = DefaultNeuralNetworkExecutionContext()
+
+    @Test
+    fun `akn module builds and runs without DSL`() {
+        val inputDim = 4
+        val outputDim = 3
+        val grid = 2
+
+        val akn = createAkn<FP32, Float>(
+            executionContext = ctx,
+            dtype = FP32::class,
+            inputDim = inputDim,
+            outputDim = outputDim,
+            gridSize = grid,
+            name = "akn-test",
+            weightsInit = { ones() },
+            basisInit = { ones() },
+            biasInit = { zeros() }
+        )
+
+        val input = ctx.fromFloatArray<FP32, Float>(
+            Shape(inputDim), FP32::class,
+            floatArrayOf(1f, 2f, 3f, 4f)
+        )
+
+        val output = akn.forward(input, ctx)
+        assertEquals(Shape(outputDim), output.shape, "AKN output should match requested outputDim")
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/KanDslIntegrationTest.kt
+++ b/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/KanDslIntegrationTest.kt
@@ -1,0 +1,38 @@
+package sk.ainet.lang.kan
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import sk.ainet.lang.nn.DefaultNeuralNetworkExecutionContext
+import sk.ainet.lang.nn.definition
+import sk.ainet.lang.nn.dsl.sequential
+import sk.ainet.lang.nn.topology.MLP
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+
+class KanDslIntegrationTest {
+
+    private val ctx = DefaultNeuralNetworkExecutionContext()
+
+    @Test
+    fun `kanLayer builds and runs with DSL`() {
+        val model = definition<FP32, Float> {
+            sequential {
+                input(4)
+                kanLayer(outputDim = 3, gridSize = 2) {
+                    weights { ones() }
+                    bias { zeros() }
+                }
+            }
+        }
+
+        // MLP wrapper should contain a KanLayer child
+        val asMlp = model as MLP<FP32, Float>
+        assertTrue(asMlp.modules.any { it is KanLayer<*, *> }, "KAN layer should be present in MLP modules")
+
+        val input = ctx.fromFloatArray<FP32, Float>(Shape(4), FP32::class, floatArrayOf(1f, 2f, 3f, 4f))
+        val output = model.forward(input, ctx)
+
+        assertEquals(Shape(3), output.shape, "KAN output should match requested outputDim")
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/examples/SineKanPretrainedGraphvizTest.kt
+++ b/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/examples/SineKanPretrainedGraphvizTest.kt
@@ -1,0 +1,25 @@
+package sk.ainet.lang.kan.examples
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SineKanPretrainedGraphvizTest {
+
+    @Test
+    fun toGraphvizDot_producesReasonableDot() {
+        val dot = SineKanPretrained.toGraphvizDot()
+
+        print(dot)
+
+        // Basic DOT structure
+        assertTrue(dot.contains("digraph"), "DOT should start with digraph")
+        // Nodes
+        assertTrue(dot.contains("input"), "Should contain input node")
+        assertTrue(dot.contains("sine_kan_pretrained"), "Should contain KAN node id")
+        // Edge
+        assertTrue(dot.contains("input -> sine_kan_pretrained"), "Should contain edge from input to KAN")
+        // Some metadata
+        assertTrue(dot.contains("gridSize: 16"), "Should mention grid size")
+        assertTrue(dot.contains("degree: 3"), "Should mention degree")
+    }
+}

--- a/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/examples/SineKanPretrainedTest.kt
+++ b/skainet-lang/skainet-kan/src/commonTest/kotlin/sk/ainet/lang/kan/examples/SineKanPretrainedTest.kt
@@ -1,0 +1,31 @@
+package sk.ainet.lang.kan.examples
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.FP32
+
+class SineKanPretrainedTest {
+
+    @Test
+    fun `pretrained sine matches math sin within tolerance`() {
+        val ctx = DirectCpuExecutionContext()
+        val model = SineKanPretrained.create(ctx)
+
+        val angles = listOf(0.0f, (PI / 6).toFloat(), (PI / 4).toFloat(), (PI / 3).toFloat(), (PI / 2).toFloat())
+        val tol = 0.001
+
+        angles.forEach { angle ->
+            val input = ctx.fromFloatArray<FP32, Float>(Shape(1), FP32::class, floatArrayOf(angle))
+            val output = model.forward(input, ctx)
+            val predicted = output.data[0]
+            val expected = sin(angle.toDouble()).toFloat()
+            val delta = abs(predicted - expected)
+            assertTrue(delta <= tol, "angle=$angle expected=$expected got=$predicted delta=$delta")
+        }
+    }
+}


### PR DESCRIPTION
  uniform grid centers, evaluate a triangular basis per input, weight by
  learnable basis, then mix/bias/activate for output (skainet-lang/skainet-kan/
  src/commonMain/kotlin/sk/ainet/lang/kan/KanLayer.kt).