### PR TITLE
feat(metrics): add Metric interface and Accuracy implementation

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/metrics/AccuracyTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/metrics/AccuracyTest.kt
@@ -1,0 +1,244 @@
+package sk.ainet.exec.metrics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.Phase
+import sk.ainet.lang.nn.metrics.Accuracy
+import sk.ainet.lang.nn.metrics.accuracy
+import sk.ainet.lang.nn.metrics.binaryAccuracy
+import sk.ainet.lang.nn.metrics.computeForBatch
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Int32
+
+class AccuracyTest {
+
+    private val ctx = DirectCpuExecutionContext(phase = Phase.EVAL)
+
+    private fun tensor(shape: Shape, data: FloatArray): Tensor<FP32, Float> =
+        ctx.fromFloatArray(shape, FP32::class, data)
+
+    private fun intTensor(shape: Shape, data: IntArray): Tensor<Int32, Int> =
+        ctx.fromIntArray(shape, Int32::class, data)
+
+    @Test
+    fun accuracy_with_index_targets_all_correct() {
+        // Predictions: batch of 4, 3 classes
+        // Shape: [4, 3]
+        val preds = tensor(
+            Shape(4, 3),
+            floatArrayOf(
+                0.1f, 0.2f, 0.7f,  // predicts class 2
+                0.8f, 0.1f, 0.1f,  // predicts class 0
+                0.1f, 0.8f, 0.1f,  // predicts class 1
+                0.3f, 0.3f, 0.4f   // predicts class 2
+            )
+        )
+
+        // Targets: class indices
+        val targets = intTensor(Shape(4), intArrayOf(2, 0, 1, 2))
+
+        val metric = accuracy()
+        metric.update(preds, targets, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_with_index_targets_partial_correct() {
+        // Predictions: batch of 4, 3 classes
+        val preds = tensor(
+            Shape(4, 3),
+            floatArrayOf(
+                0.1f, 0.2f, 0.7f,  // predicts class 2
+                0.8f, 0.1f, 0.1f,  // predicts class 0
+                0.1f, 0.8f, 0.1f,  // predicts class 1
+                0.3f, 0.3f, 0.4f   // predicts class 2
+            )
+        )
+
+        // Targets: 2 correct, 2 wrong
+        val targets = intTensor(Shape(4), intArrayOf(2, 1, 1, 0))  // class 2 correct, class 1 wrong, class 1 correct, class 2 wrong
+
+        val metric = accuracy()
+        metric.update(preds, targets, ctx)
+
+        assertEquals(0.5, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_with_soft_targets() {
+        // Predictions: batch of 3, 3 classes
+        val preds = tensor(
+            Shape(3, 3),
+            floatArrayOf(
+                0.1f, 0.2f, 0.7f,  // predicts class 2
+                0.8f, 0.1f, 0.1f,  // predicts class 0
+                0.1f, 0.8f, 0.1f   // predicts class 1
+            )
+        )
+
+        // One-hot encoded targets
+        val targets = tensor(
+            Shape(3, 3),
+            floatArrayOf(
+                0f, 0f, 1f,  // class 2
+                1f, 0f, 0f,  // class 0
+                0f, 1f, 0f   // class 1
+            )
+        )
+
+        val metric = accuracy()
+        metric.update(preds, targets, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_accumulates_over_batches() {
+        val metric = accuracy()
+
+        // First batch: 2 correct out of 2
+        val preds1 = tensor(Shape(2, 2), floatArrayOf(0.9f, 0.1f, 0.1f, 0.9f))
+        val targets1 = intTensor(Shape(2), intArrayOf(0, 1))
+        metric.update(preds1, targets1, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+
+        // Second batch: 1 correct out of 2
+        val preds2 = tensor(Shape(2, 2), floatArrayOf(0.9f, 0.1f, 0.9f, 0.1f))  // predicts 0, 0
+        val targets2 = intTensor(Shape(2), intArrayOf(0, 1))  // expects 0, 1
+        metric.update(preds2, targets2, ctx)
+
+        // Total: 3 correct out of 4
+        assertEquals(0.75, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_reset_clears_state() {
+        val metric = accuracy()
+
+        // Add some data
+        val preds = tensor(Shape(2, 2), floatArrayOf(0.9f, 0.1f, 0.1f, 0.9f))
+        val targets = intTensor(Shape(2), intArrayOf(0, 1))
+        metric.update(preds, targets, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+
+        // Reset
+        metric.reset()
+
+        // Should be 0 after reset (no data)
+        assertEquals(0.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_compute_for_batch_helper() {
+        val preds = tensor(Shape(2, 2), floatArrayOf(0.9f, 0.1f, 0.1f, 0.9f))
+        val targets = intTensor(Shape(2), intArrayOf(0, 1))
+
+        val metric = accuracy()
+        val result = metric.computeForBatch(preds, targets, ctx)
+
+        assertEquals(1.0, result, 1e-6)
+    }
+
+    @Test
+    fun binary_accuracy_with_threshold() {
+        // Binary classification with sigmoid-like outputs
+        val preds = tensor(
+            Shape(4, 1),
+            floatArrayOf(
+                0.3f,  // < 0.5, predicts 0
+                0.7f,  // > 0.5, predicts 1
+                0.6f,  // > 0.5, predicts 1
+                0.4f   // < 0.5, predicts 0
+            )
+        )
+
+        val targets = intTensor(Shape(4), intArrayOf(0, 1, 1, 0))
+
+        val metric = binaryAccuracy()
+        metric.update(preds, targets, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun binary_accuracy_with_custom_threshold() {
+        val preds = tensor(Shape(4, 1), floatArrayOf(0.6f, 0.8f, 0.65f, 0.5f))
+
+        // With threshold 0.7: predictions are 0, 1, 0, 0
+        val targets = intTensor(Shape(4), intArrayOf(0, 1, 0, 0))
+
+        val metric = Accuracy(threshold = 0.7f)
+        metric.update(preds, targets, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_with_batch_dimension() {
+        // Shape: [batch=2, seq=3, classes=4]
+        val preds = tensor(
+            Shape(2, 3, 4),
+            floatArrayOf(
+                // Batch 0
+                0.1f, 0.2f, 0.3f, 0.4f,  // seq 0: predicts class 3
+                0.4f, 0.3f, 0.2f, 0.1f,  // seq 1: predicts class 0
+                0.1f, 0.4f, 0.3f, 0.2f,  // seq 2: predicts class 1
+                // Batch 1
+                0.1f, 0.1f, 0.7f, 0.1f,  // seq 0: predicts class 2
+                0.4f, 0.3f, 0.2f, 0.1f,  // seq 1: predicts class 0
+                0.1f, 0.1f, 0.1f, 0.7f   // seq 2: predicts class 3
+            )
+        )
+
+        // Targets shape: [batch=2, seq=3]
+        val targets = intTensor(
+            Shape(2, 3),
+            intArrayOf(
+                3, 0, 1,  // Batch 0: all correct
+                2, 0, 3   // Batch 1: all correct
+            )
+        )
+
+        val metric = accuracy(dim = -1)  // class dimension is last
+        metric.update(preds, targets, ctx)
+
+        assertEquals(1.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_empty_returns_zero() {
+        val metric = accuracy()
+        assertEquals(0.0, metric.compute(), 1e-6)
+    }
+
+    @Test
+    fun accuracy_name_property() {
+        val metric = accuracy()
+        assertEquals("accuracy", metric.name)
+    }
+
+    @Test
+    fun accuracy_all_wrong() {
+        val preds = tensor(
+            Shape(3, 2),
+            floatArrayOf(
+                0.9f, 0.1f,  // predicts 0
+                0.9f, 0.1f,  // predicts 0
+                0.9f, 0.1f   // predicts 0
+            )
+        )
+
+        val targets = intTensor(Shape(3), intArrayOf(1, 1, 1))
+
+        val metric = accuracy()
+        metric.update(preds, targets, ctx)
+
+        assertEquals(0.0, metric.compute(), 1e-6)
+    }
+}

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/metrics/Accuracy.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/metrics/Accuracy.kt
@@ -1,0 +1,267 @@
+package sk.ainet.lang.nn.metrics
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.types.FP16
+import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Int32
+
+/**
+ * Classification accuracy metric.
+ *
+ * Computes the fraction of predictions that match the target labels.
+ * Supports both hard targets (class indices) and soft targets (one-hot or probabilities).
+ *
+ * For predictions, the class with maximum value along [dim] is selected.
+ * For soft targets, the class with maximum value is used as the ground truth.
+ * For hard targets (Int32), the value directly represents the class index.
+ *
+ * @param dim The dimension along which to find the predicted class (default: -1, last dimension)
+ * @param threshold Optional threshold for binary classification. If provided, predictions > threshold
+ *                  are classified as class 1, otherwise class 0. Only applicable when dim size is 1 or 2.
+ */
+public class Accuracy(
+    private val dim: Int = -1,
+    private val threshold: Float? = null
+) : Metric {
+
+    override val name: String = "accuracy"
+
+    private var correctCount: Long = 0
+    private var totalCount: Long = 0
+
+    override fun <T : DType, V> update(
+        predictions: Tensor<T, V>,
+        targets: Tensor<out DType, *>,
+        ctx: ExecutionContext
+    ) {
+        validatePredictions(predictions)
+        val classDim = normalizeDim(dim, predictions.rank)
+
+        val (batchCorrect, batchTotal) = when (targets.dtype) {
+            Int32::class -> {
+                @Suppress("UNCHECKED_CAST")
+                computeWithIndexTargets(predictions, targets as Tensor<Int32, Int>, classDim)
+            }
+            FP32::class, FP16::class -> {
+                @Suppress("UNCHECKED_CAST")
+                computeWithSoftTargets(predictions, targets as Tensor<out DType, *>, classDim)
+            }
+            else -> error("Unsupported target dtype for Accuracy: ${targets.dtype}")
+        }
+
+        correctCount += batchCorrect
+        totalCount += batchTotal
+    }
+
+    override fun compute(): Double {
+        if (totalCount == 0L) return 0.0
+        return correctCount.toDouble() / totalCount.toDouble()
+    }
+
+    override fun reset() {
+        correctCount = 0
+        totalCount = 0
+    }
+
+    private fun <T : DType, V> computeWithIndexTargets(
+        predictions: Tensor<T, V>,
+        targets: Tensor<Int32, Int>,
+        classDim: Int
+    ): Pair<Long, Long> {
+        // Validate shapes: targets should have one less dimension than predictions
+        // (the class dimension is removed)
+        require(targets.rank == predictions.rank - 1) {
+            "Accuracy expected target rank ${predictions.rank - 1} for class indices, got ${targets.rank}"
+        }
+        validateIndexTargetShapes(predictions, targets, classDim)
+
+        val classCount = predictions.shape[classDim]
+        var correct = 0L
+        var total = 0L
+
+        // Iterate over all samples
+        iterateOverSamples(targets.shape.dimensions) { sampleIdx ->
+            val targetClass = targets.data.get(*sampleIdx)
+            val predictedClass = if (threshold != null && classCount <= 2) {
+                // Binary classification with threshold
+                val logitIdx = insertClassIndex(sampleIdx, if (classCount == 2) 1 else 0, classDim, predictions.rank)
+                val logit = predictions.data.get(*logitIdx) as Float
+                if (logit > threshold) 1 else 0
+            } else {
+                // Multi-class: argmax along class dimension
+                argmax(predictions, sampleIdx, classDim)
+            }
+
+            if (predictedClass == targetClass) {
+                correct++
+            }
+            total++
+        }
+
+        return correct to total
+    }
+
+    private fun <T : DType, V> computeWithSoftTargets(
+        predictions: Tensor<T, V>,
+        targets: Tensor<out DType, *>,
+        classDim: Int
+    ): Pair<Long, Long> {
+        // Soft targets should have the same shape as predictions
+        require(predictions.shape == targets.shape) {
+            "Accuracy with soft targets requires matching shapes, got ${predictions.shape.dimensions.contentToString()} vs ${targets.shape.dimensions.contentToString()}"
+        }
+
+        val classCount = predictions.shape[classDim]
+        var correct = 0L
+        var total = 0L
+
+        // Get shape without the class dimension for iteration
+        val sampleShape = predictions.shape.dimensions.filterIndexed { i, _ -> i != classDim }.toIntArray()
+
+        iterateOverSamples(sampleShape) { sampleIdx ->
+            val predictedClass = if (threshold != null && classCount <= 2) {
+                val logitIdx = insertClassIndex(sampleIdx, if (classCount == 2) 1 else 0, classDim, predictions.rank)
+                val logit = predictions.data.get(*logitIdx) as Float
+                if (logit > threshold) 1 else 0
+            } else {
+                argmax(predictions, sampleIdx, classDim)
+            }
+
+            val targetClass = argmaxTarget(targets, sampleIdx, classDim)
+
+            if (predictedClass == targetClass) {
+                correct++
+            }
+            total++
+        }
+
+        return correct to total
+    }
+
+    private fun <T : DType, V> argmax(
+        tensor: Tensor<T, V>,
+        sampleIdx: IntArray,
+        classDim: Int
+    ): Int {
+        val classCount = tensor.shape[classDim]
+        var maxIdx = 0
+        var maxVal = Float.NEGATIVE_INFINITY
+
+        for (c in 0 until classCount) {
+            val fullIdx = insertClassIndex(sampleIdx, c, classDim, tensor.rank)
+            val value = tensor.data.get(*fullIdx) as Float
+            if (value > maxVal) {
+                maxVal = value
+                maxIdx = c
+            }
+        }
+        return maxIdx
+    }
+
+    private fun argmaxTarget(
+        tensor: Tensor<out DType, *>,
+        sampleIdx: IntArray,
+        classDim: Int
+    ): Int {
+        val classCount = tensor.shape[classDim]
+        var maxIdx = 0
+        var maxVal = Float.NEGATIVE_INFINITY
+
+        for (c in 0 until classCount) {
+            val fullIdx = insertClassIndex(sampleIdx, c, classDim, tensor.rank)
+            val value = when (tensor.dtype) {
+                FP32::class -> tensor.data.get(*fullIdx) as Float
+                FP16::class -> (tensor.data.get(*fullIdx) as Number).toFloat()
+                else -> error("Unsupported dtype")
+            }
+            if (value > maxVal) {
+                maxVal = value
+                maxIdx = c
+            }
+        }
+        return maxIdx
+    }
+
+    private fun insertClassIndex(
+        baseIdx: IntArray,
+        cls: Int,
+        classDim: Int,
+        outRank: Int
+    ): IntArray {
+        val result = IntArray(outRank)
+        var bi = 0
+        for (i in 0 until outRank) {
+            if (i == classDim) {
+                result[i] = cls
+            } else {
+                result[i] = baseIdx[bi++]
+            }
+        }
+        return result
+    }
+
+    private fun validateIndexTargetShapes(
+        preds: Tensor<*, *>,
+        targets: Tensor<*, *>,
+        classDim: Int
+    ) {
+        val predDims = preds.shape.dimensions
+        val targetDims = targets.shape.dimensions
+        var ti = 0
+        for (pi in predDims.indices) {
+            if (pi == classDim) continue
+            require(predDims[pi] == targetDims[ti]) {
+                "Accuracy target shape mismatch at dim $pi: expected ${predDims[pi]}, got ${targetDims[ti]}"
+            }
+            ti++
+        }
+    }
+
+    private fun <T : DType, V> validatePredictions(preds: Tensor<T, V>) {
+        require(preds.dtype == FP32::class || preds.dtype == FP16::class) {
+            "Accuracy requires floating point predictions, got ${preds.dtype}"
+        }
+    }
+
+    private fun normalizeDim(dim: Int, rank: Int): Int {
+        val nd = if (dim < 0) dim + rank else dim
+        require(nd in 0 until rank) { "Dimension $dim out of range for rank $rank" }
+        return nd
+    }
+
+    private inline fun iterateOverSamples(shape: IntArray, action: (IntArray) -> Unit) {
+        if (shape.isEmpty()) {
+            action(IntArray(0))
+            return
+        }
+
+        val idx = IntArray(shape.size)
+        val total = shape.fold(1) { acc, d -> acc * d }
+
+        repeat(total) {
+            action(idx)
+            // Increment index
+            for (d in shape.lastIndex downTo 0) {
+                idx[d]++
+                if (idx[d] < shape[d]) break
+                idx[d] = 0
+            }
+        }
+    }
+}
+
+/**
+ * Factory function for Accuracy metric.
+ *
+ * @param dim The dimension along which to find the predicted class (default: -1)
+ * @param threshold Optional threshold for binary classification
+ */
+public fun accuracy(dim: Int = -1, threshold: Float? = null): Metric = Accuracy(dim, threshold)
+
+/**
+ * Binary accuracy metric with a threshold of 0.5.
+ * Useful for binary classification problems with sigmoid outputs.
+ */
+public fun binaryAccuracy(threshold: Float = 0.5f): Metric = Accuracy(dim = -1, threshold = threshold)

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/metrics/Metric.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/metrics/Metric.kt
@@ -1,0 +1,70 @@
+package sk.ainet.lang.nn.metrics
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+
+/**
+ * Interface for evaluation metrics that accumulate statistics over batches.
+ *
+ * Metrics follow a stateful accumulation pattern:
+ * 1. Call [update] for each batch of predictions/targets
+ * 2. Call [compute] to get the accumulated metric value
+ * 3. Call [reset] to start a new evaluation epoch
+ *
+ * Example usage:
+ * ```kotlin
+ * val accuracy = Accuracy()
+ * for ((x, y) in validationData) {
+ *     val preds = model.forward(x, ctx)
+ *     accuracy.update(preds, y, ctx)
+ * }
+ * println("Validation accuracy: ${accuracy.compute()}")
+ * accuracy.reset()
+ * ```
+ */
+public interface Metric {
+    /**
+     * The name of this metric for display purposes.
+     */
+    public val name: String
+
+    /**
+     * Update the metric state with a batch of predictions and targets.
+     *
+     * @param predictions Model outputs (logits or probabilities)
+     * @param targets Ground truth labels (class indices or one-hot encoded)
+     * @param ctx Execution context for tensor operations
+     */
+    public fun <T : DType, V> update(
+        predictions: Tensor<T, V>,
+        targets: Tensor<out DType, *>,
+        ctx: ExecutionContext
+    )
+
+    /**
+     * Compute the metric value from accumulated statistics.
+     *
+     * @return The computed metric value (e.g., accuracy percentage)
+     */
+    public fun compute(): Double
+
+    /**
+     * Reset the accumulated statistics to start a fresh evaluation.
+     */
+    public fun reset()
+}
+
+/**
+ * Convenience function to compute a metric for a single batch without accumulation.
+ * Returns the metric value directly.
+ */
+public fun <T : DType, V> Metric.computeForBatch(
+    predictions: Tensor<T, V>,
+    targets: Tensor<out DType, *>,
+    ctx: ExecutionContext
+): Double {
+    reset()
+    update(predictions, targets, ctx)
+    return compute()
+}


### PR DESCRIPTION
Implement a metrics system for model evaluation with:
- Metric interface with update/compute/reset pattern
- Accuracy metric for classification tasks
  - Supports hard targets (class indices as Int32)
  - Supports soft targets (one-hot or probability distributions)
  - Configurable class dimension
  - Binary classification with threshold support
  - Batch accumulation across multiple update calls
- Factory functions: accuracy(), binaryAccuracy()
- Helper function: computeForBatch() for single-batch evaluation

Comprehensive test coverage including:
- All correct / partial correct / all wrong scenarios
- Soft target handling
- Multi-batch accumulation
- State reset
- Binary classification with custom thresholds
- Multi-dimensional inputs (batch + sequence)

Implements: #296
Related-To: #290