### PR TITLE
feat(ops): add Conv1d and Conv3d operations

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
@@ -611,6 +611,312 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
     }
 
     @TensorOp()
+    override fun <T : DType, V> conv1d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>?,
+        stride: Int,
+        padding: Int,
+        dilation: Int,
+        groups: Int
+    ): Tensor<T, V> {
+        // Validate shapes
+        require(input.rank == 3) { "conv1d: input must be 3D (N, C_in, L), got ${input.shape.dimensions.contentToString()}" }
+        require(weight.rank == 3) { "conv1d: weight must be 3D (C_out, C_in/groups, K), got ${weight.shape.dimensions.contentToString()}" }
+        require(groups >= 1) { "conv1d: groups must be >= 1" }
+        require(input.dtype == weight.dtype) { "conv1d: dtype mismatch between input and weight: ${input.dtype} vs ${weight.dtype}" }
+        bias?.let { require(it.dtype == input.dtype) { "conv1d: dtype mismatch for bias" } }
+
+        val n = input.shape[0]
+        val cIn = input.shape[1]
+        val inL = input.shape[2]
+
+        val cOut = weight.shape[0]
+        val cInPerGroup = weight.shape[1]
+        val kL = weight.shape[2]
+
+        require(cIn % groups == 0) { "conv1d: input channels ${cIn} not divisible by groups ${groups}" }
+        require(cOut % groups == 0) { "conv1d: output channels ${cOut} not divisible by groups ${groups}" }
+        require(cInPerGroup == cIn / groups) { "conv1d: weight input channels ${cInPerGroup} must equal C_in/groups ${cIn / groups}" }
+
+        fun outDim(inDim: Int, k: Int, s: Int, p: Int, d: Int): Int {
+            return ((inDim + 2 * p - d * (k - 1) - 1) / s) + 1
+        }
+        val outL = outDim(inL, kL, stride, padding, dilation)
+        require(outL >= 0) { "conv1d: computed negative output length (L=${outL})" }
+
+        // Validate bias shape if provided
+        if (bias != null) {
+            when (bias.rank) {
+                1 -> require(bias.shape[0] == cOut) { "conv1d: bias shape must be [C_out], got ${bias.shape.dimensions.contentToString()}" }
+                3 -> {
+                    require(bias.shape[0] == 1 && bias.shape[1] == cOut && bias.shape[2] == 1) {
+                        "conv1d: bias shape must be [1,C_out,1] when 3D, got ${bias.shape.dimensions.contentToString()}"
+                    }
+                }
+                else -> error("conv1d: unsupported bias rank ${bias.rank}")
+            }
+        }
+
+        val outShape = Shape(n, cOut, outL)
+        val outData = dataFactory.init<T, V>(outShape, input.dtype) { outIdx ->
+            val bIdx = outIdx[0]
+            val oc = outIdx[1]
+            val ol = outIdx[2]
+
+            when (input.dtype) {
+                sk.ainet.lang.types.FP32::class, sk.ainet.lang.types.FP16::class -> {
+                    var acc = 0.0f
+                    val groupIdx = (oc * groups) / cOut
+                    val inCStart = groupIdx * cInPerGroup
+                    val inCEnd = inCStart + cInPerGroup
+                    val lBase = ol * stride - padding
+
+                    var ic = inCStart
+                    while (ic < inCEnd) {
+                        val kc = ic - inCStart
+                        var kl = 0
+                        while (kl < kL) {
+                            val il = lBase + kl * dilation
+                            if (il >= 0 && il < inL) {
+                                val vIn = input.data.get(bIdx, ic, il) as Float
+                                val vW = weight.data.get(oc, kc, kl) as Float
+                                acc += vIn * vW
+                            }
+                            kl++
+                        }
+                        ic++
+                    }
+                    if (bias != null) {
+                        val b = when (bias.rank) {
+                            1 -> bias.data.get(oc) as Float
+                            3 -> bias.data.get(0, oc, 0) as Float
+                            else -> 0.0f
+                        }
+                        acc += b
+                    }
+                    @Suppress("UNCHECKED_CAST")
+                    acc as V
+                }
+                sk.ainet.lang.types.Int32::class -> {
+                    var acc = 0
+                    val groupIdx = (oc * groups) / cOut
+                    val inCStart = groupIdx * cInPerGroup
+                    val inCEnd = inCStart + cInPerGroup
+                    val lBase = ol * stride - padding
+
+                    var ic = inCStart
+                    while (ic < inCEnd) {
+                        val kc = ic - inCStart
+                        var kl = 0
+                        while (kl < kL) {
+                            val il = lBase + kl * dilation
+                            if (il >= 0 && il < inL) {
+                                val vIn = input.data.get(bIdx, ic, il) as Int
+                                val vW = weight.data.get(oc, kc, kl) as Int
+                                acc += vIn * vW
+                            }
+                            kl++
+                        }
+                        ic++
+                    }
+                    if (bias != null) {
+                        val b = when (bias.rank) {
+                            1 -> bias.data.get(oc) as Int
+                            3 -> bias.data.get(0, oc, 0) as Int
+                            else -> 0
+                        }
+                        acc += b
+                    }
+                    @Suppress("UNCHECKED_CAST")
+                    acc as V
+                }
+                else -> throw IllegalArgumentException("Unsupported dtype for conv1d: ${input.dtype}")
+            }
+        }
+        return if (bias != null) {
+            newTensor(outData, input.dtype, input, weight, bias)
+        } else {
+            newTensor(outData, input.dtype, input, weight)
+        }
+    }
+
+    @TensorOp()
+    override fun <T : DType, V> conv3d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>?,
+        stride: Triple<Int, Int, Int>,
+        padding: Triple<Int, Int, Int>,
+        dilation: Triple<Int, Int, Int>,
+        groups: Int
+    ): Tensor<T, V> {
+        // Validate shapes
+        require(input.rank == 5) { "conv3d: input must be 5D (N, C_in, D, H, W), got ${input.shape.dimensions.contentToString()}" }
+        require(weight.rank == 5) { "conv3d: weight must be 5D (C_out, C_in/groups, kD, kH, kW), got ${weight.shape.dimensions.contentToString()}" }
+        require(groups >= 1) { "conv3d: groups must be >= 1" }
+        require(input.dtype == weight.dtype) { "conv3d: dtype mismatch between input and weight: ${input.dtype} vs ${weight.dtype}" }
+        bias?.let { require(it.dtype == input.dtype) { "conv3d: dtype mismatch for bias" } }
+
+        val n = input.shape[0]
+        val cIn = input.shape[1]
+        val inD = input.shape[2]
+        val inH = input.shape[3]
+        val inW = input.shape[4]
+
+        val cOut = weight.shape[0]
+        val cInPerGroup = weight.shape[1]
+        val kD = weight.shape[2]
+        val kH = weight.shape[3]
+        val kW = weight.shape[4]
+
+        require(cIn % groups == 0) { "conv3d: input channels ${cIn} not divisible by groups ${groups}" }
+        require(cOut % groups == 0) { "conv3d: output channels ${cOut} not divisible by groups ${groups}" }
+        require(cInPerGroup == cIn / groups) { "conv3d: weight input channels ${cInPerGroup} must equal C_in/groups ${cIn / groups}" }
+
+        val (sD, sH, sW) = stride
+        val (pD, pH, pW) = padding
+        val (dD, dH, dW) = dilation
+
+        fun outDim(inDim: Int, k: Int, s: Int, p: Int, d: Int): Int {
+            return ((inDim + 2 * p - d * (k - 1) - 1) / s) + 1
+        }
+        val outD = outDim(inD, kD, sD, pD, dD)
+        val outH = outDim(inH, kH, sH, pH, dH)
+        val outW = outDim(inW, kW, sW, pW, dW)
+        require(outD >= 0 && outH >= 0 && outW >= 0) { "conv3d: computed negative output shape (D=${outD}, H=${outH}, W=${outW})" }
+
+        // Validate bias shape if provided
+        if (bias != null) {
+            when (bias.rank) {
+                1 -> require(bias.shape[0] == cOut) { "conv3d: bias shape must be [C_out], got ${bias.shape.dimensions.contentToString()}" }
+                5 -> {
+                    require(bias.shape[0] == 1 && bias.shape[1] == cOut && bias.shape[2] == 1 && bias.shape[3] == 1 && bias.shape[4] == 1) {
+                        "conv3d: bias shape must be [1,C_out,1,1,1] when 5D, got ${bias.shape.dimensions.contentToString()}"
+                    }
+                }
+                else -> error("conv3d: unsupported bias rank ${bias.rank}")
+            }
+        }
+
+        val outShape = Shape(n, cOut, outD, outH, outW)
+        val outData = dataFactory.init<T, V>(outShape, input.dtype) { outIdx ->
+            val bIdx = outIdx[0]
+            val oc = outIdx[1]
+            val od = outIdx[2]
+            val oh = outIdx[3]
+            val ow = outIdx[4]
+
+            when (input.dtype) {
+                sk.ainet.lang.types.FP32::class, sk.ainet.lang.types.FP16::class -> {
+                    var acc = 0.0f
+                    val groupIdx = (oc * groups) / cOut
+                    val inCStart = groupIdx * cInPerGroup
+                    val inCEnd = inCStart + cInPerGroup
+                    val dBase = od * sD - pD
+                    val hBase = oh * sH - pH
+                    val wBase = ow * sW - pW
+
+                    var ic = inCStart
+                    while (ic < inCEnd) {
+                        val kc = ic - inCStart
+                        var kd = 0
+                        while (kd < kD) {
+                            val id = dBase + kd * dD
+                            if (id >= 0 && id < inD) {
+                                var kh = 0
+                                while (kh < kH) {
+                                    val ih = hBase + kh * dH
+                                    if (ih >= 0 && ih < inH) {
+                                        var kw = 0
+                                        while (kw < kW) {
+                                            val iw = wBase + kw * dW
+                                            if (iw >= 0 && iw < inW) {
+                                                val vIn = input.data.get(bIdx, ic, id, ih, iw) as Float
+                                                val vW = weight.data.get(oc, kc, kd, kh, kw) as Float
+                                                acc += vIn * vW
+                                            }
+                                            kw++
+                                        }
+                                    }
+                                    kh++
+                                }
+                            }
+                            kd++
+                        }
+                        ic++
+                    }
+                    if (bias != null) {
+                        val b = when (bias.rank) {
+                            1 -> bias.data.get(oc) as Float
+                            5 -> bias.data.get(0, oc, 0, 0, 0) as Float
+                            else -> 0.0f
+                        }
+                        acc += b
+                    }
+                    @Suppress("UNCHECKED_CAST")
+                    acc as V
+                }
+                sk.ainet.lang.types.Int32::class -> {
+                    var acc = 0
+                    val groupIdx = (oc * groups) / cOut
+                    val inCStart = groupIdx * cInPerGroup
+                    val inCEnd = inCStart + cInPerGroup
+                    val dBase = od * sD - pD
+                    val hBase = oh * sH - pH
+                    val wBase = ow * sW - pW
+
+                    var ic = inCStart
+                    while (ic < inCEnd) {
+                        val kc = ic - inCStart
+                        var kd = 0
+                        while (kd < kD) {
+                            val id = dBase + kd * dD
+                            if (id >= 0 && id < inD) {
+                                var kh = 0
+                                while (kh < kH) {
+                                    val ih = hBase + kh * dH
+                                    if (ih >= 0 && ih < inH) {
+                                        var kw = 0
+                                        while (kw < kW) {
+                                            val iw = wBase + kw * dW
+                                            if (iw >= 0 && iw < inW) {
+                                                val vIn = input.data.get(bIdx, ic, id, ih, iw) as Int
+                                                val vW = weight.data.get(oc, kc, kd, kh, kw) as Int
+                                                acc += vIn * vW
+                                            }
+                                            kw++
+                                        }
+                                    }
+                                    kh++
+                                }
+                            }
+                            kd++
+                        }
+                        ic++
+                    }
+                    if (bias != null) {
+                        val b = when (bias.rank) {
+                            1 -> bias.data.get(oc) as Int
+                            5 -> bias.data.get(0, oc, 0, 0, 0) as Int
+                            else -> 0
+                        }
+                        acc += b
+                    }
+                    @Suppress("UNCHECKED_CAST")
+                    acc as V
+                }
+                else -> throw IllegalArgumentException("Unsupported dtype for conv3d: ${input.dtype}")
+            }
+        }
+        return if (bias != null) {
+            newTensor(outData, input.dtype, input, weight, bias)
+        } else {
+            newTensor(outData, input.dtype, input, weight)
+        }
+    }
+
+    @TensorOp()
     @InProgress("cpu", owner = "team:cpu", issue = "task-ops.md#op-upsample2d")
     override fun <T : DType, V> upsample2d(
         input: Tensor<T, V>,

--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/ops/ConvOpsTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/ops/ConvOpsTest.kt
@@ -1,0 +1,247 @@
+package sk.ainet.exec.ops
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.Phase
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.FP32
+
+class ConvOpsTest {
+
+    private val ctx = DirectCpuExecutionContext(phase = Phase.EVAL)
+
+    private fun tensor(shape: Shape, data: FloatArray): Tensor<FP32, Float> =
+        ctx.fromFloatArray(shape, FP32::class, data)
+
+    // ========== Conv1d Tests ==========
+
+    @Test
+    fun conv1d_basic_no_padding_stride1() {
+        // Input: (batch=1, channels=1, length=5) with values [1, 2, 3, 4, 5]
+        val input = tensor(Shape(1, 1, 5), floatArrayOf(1f, 2f, 3f, 4f, 5f))
+        // Weight: (out_channels=1, in_channels=1, kernel_size=3) with values [1, 1, 1]
+        val weight = tensor(Shape(1, 1, 3), floatArrayOf(1f, 1f, 1f))
+
+        val output = input.ops.conv1d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = 1,
+            padding = 0,
+            dilation = 1,
+            groups = 1
+        )
+
+        // Output should be (1, 1, 3) with values [1+2+3, 2+3+4, 3+4+5] = [6, 9, 12]
+        assertEquals(listOf(1, 1, 3), output.shape.dimensions.toList())
+        assertEquals(6f, output.data[0, 0, 0], 1e-5f)
+        assertEquals(9f, output.data[0, 0, 1], 1e-5f)
+        assertEquals(12f, output.data[0, 0, 2], 1e-5f)
+    }
+
+    @Test
+    fun conv1d_with_padding() {
+        val input = tensor(Shape(1, 1, 5), floatArrayOf(1f, 2f, 3f, 4f, 5f))
+        val weight = tensor(Shape(1, 1, 3), floatArrayOf(1f, 1f, 1f))
+
+        val output = input.ops.conv1d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = 1,
+            padding = 1,  // Add padding to preserve length
+            dilation = 1,
+            groups = 1
+        )
+
+        // With padding=1, output length = 5
+        assertEquals(listOf(1, 1, 5), output.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv1d_with_stride2() {
+        val input = tensor(Shape(1, 1, 7), floatArrayOf(1f, 2f, 3f, 4f, 5f, 6f, 7f))
+        val weight = tensor(Shape(1, 1, 3), floatArrayOf(1f, 1f, 1f))
+
+        val output = input.ops.conv1d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = 2,
+            padding = 0,
+            dilation = 1,
+            groups = 1
+        )
+
+        // Output length = (7 - 3) / 2 + 1 = 3
+        assertEquals(listOf(1, 1, 3), output.shape.dimensions.toList())
+        assertEquals(6f, output.data[0, 0, 0], 1e-5f)  // 1+2+3
+        assertEquals(12f, output.data[0, 0, 1], 1e-5f) // 3+4+5
+        assertEquals(18f, output.data[0, 0, 2], 1e-5f) // 5+6+7
+    }
+
+    @Test
+    fun conv1d_with_bias() {
+        val input = tensor(Shape(1, 1, 5), floatArrayOf(1f, 2f, 3f, 4f, 5f))
+        val weight = tensor(Shape(1, 1, 3), floatArrayOf(1f, 1f, 1f))
+        val bias = tensor(Shape(1), floatArrayOf(10f))
+
+        val output = input.ops.conv1d(
+            input = input,
+            weight = weight,
+            bias = bias,
+            stride = 1,
+            padding = 0,
+            dilation = 1,
+            groups = 1
+        )
+
+        // Output should have bias added: [6+10, 9+10, 12+10] = [16, 19, 22]
+        assertEquals(16f, output.data[0, 0, 0], 1e-5f)
+        assertEquals(19f, output.data[0, 0, 1], 1e-5f)
+        assertEquals(22f, output.data[0, 0, 2], 1e-5f)
+    }
+
+    @Test
+    fun conv1d_multiple_channels() {
+        // Input: (batch=1, channels=2, length=4)
+        val input = tensor(Shape(1, 2, 4), floatArrayOf(
+            1f, 2f, 3f, 4f,   // Channel 0
+            5f, 6f, 7f, 8f    // Channel 1
+        ))
+        // Weight: (out_channels=1, in_channels=2, kernel_size=2)
+        val weight = tensor(Shape(1, 2, 2), floatArrayOf(
+            1f, 1f,   // Filter for channel 0
+            1f, 1f    // Filter for channel 1
+        ))
+
+        val output = input.ops.conv1d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = 1,
+            padding = 0,
+            dilation = 1,
+            groups = 1
+        )
+
+        // Output: (1, 1, 3)
+        // Position 0: (1+2) + (5+6) = 14
+        // Position 1: (2+3) + (6+7) = 18
+        // Position 2: (3+4) + (7+8) = 22
+        assertEquals(listOf(1, 1, 3), output.shape.dimensions.toList())
+        assertEquals(14f, output.data[0, 0, 0], 1e-5f)
+        assertEquals(18f, output.data[0, 0, 1], 1e-5f)
+        assertEquals(22f, output.data[0, 0, 2], 1e-5f)
+    }
+
+    // ========== Conv3d Tests ==========
+
+    @Test
+    fun conv3d_basic_shape() {
+        // Input: (batch=1, channels=1, depth=4, height=4, width=4)
+        val input = tensor(Shape(1, 1, 4, 4, 4), FloatArray(64) { 1f })
+        // Weight: (out_channels=1, in_channels=1, kd=2, kh=2, kw=2)
+        val weight = tensor(Shape(1, 1, 2, 2, 2), FloatArray(8) { 1f })
+
+        val output = input.ops.conv3d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Output shape: (1, 1, 3, 3, 3)
+        assertEquals(listOf(1, 1, 3, 3, 3), output.shape.dimensions.toList())
+        // Each output value should be 8 (sum of 2x2x2 block of 1s)
+        assertEquals(8f, output.data[0, 0, 0, 0, 0], 1e-5f)
+    }
+
+    @Test
+    fun conv3d_with_padding() {
+        val input = tensor(Shape(1, 1, 4, 4, 4), FloatArray(64) { 1f })
+        val weight = tensor(Shape(1, 1, 3, 3, 3), FloatArray(27) { 1f })
+
+        val output = input.ops.conv3d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(1, 1, 1),  // Same padding
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // With padding=1, output dimensions should be preserved
+        assertEquals(listOf(1, 1, 4, 4, 4), output.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv3d_with_stride() {
+        val input = tensor(Shape(1, 1, 6, 6, 6), FloatArray(216) { 1f })
+        val weight = tensor(Shape(1, 1, 2, 2, 2), FloatArray(8) { 1f })
+
+        val output = input.ops.conv3d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = Triple(2, 2, 2),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Output shape: (6-2)/2+1 = 3 for each dimension
+        assertEquals(listOf(1, 1, 3, 3, 3), output.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv3d_with_bias() {
+        val input = tensor(Shape(1, 1, 3, 3, 3), FloatArray(27) { 1f })
+        val weight = tensor(Shape(2, 1, 2, 2, 2), FloatArray(16) { 1f })
+        val bias = tensor(Shape(2), floatArrayOf(5f, 10f))
+
+        val output = input.ops.conv3d(
+            input = input,
+            weight = weight,
+            bias = bias,
+            stride = Triple(1, 1, 1),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Output shape: (1, 2, 2, 2, 2)
+        assertEquals(listOf(1, 2, 2, 2, 2), output.shape.dimensions.toList())
+        // Each position = 8 (sum of 2x2x2 block) + bias
+        assertEquals(13f, output.data[0, 0, 0, 0, 0], 1e-5f)  // 8 + 5
+        assertEquals(18f, output.data[0, 1, 0, 0, 0], 1e-5f)  // 8 + 10
+    }
+
+    @Test
+    fun conv3d_multiple_in_out_channels() {
+        // Input: (batch=1, channels=2, depth=3, height=3, width=3)
+        val input = tensor(Shape(1, 2, 3, 3, 3), FloatArray(54) { it.toFloat() })
+        // Weight: (out_channels=3, in_channels=2, kd=2, kh=2, kw=2)
+        val weight = tensor(Shape(3, 2, 2, 2, 2), FloatArray(48) { 1f })
+
+        val output = input.ops.conv3d(
+            input = input,
+            weight = weight,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Output shape: (1, 3, 2, 2, 2)
+        assertEquals(listOf(1, 3, 2, 2, 2), output.shape.dimensions.toList())
+    }
+}

--- a/skainet-compile/skainet-compile-core/src/commonMain/kotlin/sk/ainet/tape/RecordingExecution.kt
+++ b/skainet-compile/skainet-compile-core/src/commonMain/kotlin/sk/ainet/tape/RecordingExecution.kt
@@ -235,6 +235,16 @@ internal class RecordingTensorOpsDecorator(private val base: TensorOps) : Tensor
     }
 
     // --- Conv/Pool ---
+    override fun <T : DType, V> conv1d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>?,
+        stride: Int,
+        padding: Int,
+        dilation: Int,
+        groups: Int
+    ): Tensor<T, V> = base.conv1d(input, weight, bias, stride, padding, dilation, groups)
+
     override fun <T : DType, V> conv2d(
         input: Tensor<T, V>,
         weight: Tensor<T, V>,
@@ -259,6 +269,16 @@ internal class RecordingTensorOpsDecorator(private val base: TensorOps) : Tensor
         )
         return out
     }
+
+    override fun <T : DType, V> conv3d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>?,
+        stride: Triple<Int, Int, Int>,
+        padding: Triple<Int, Int, Int>,
+        dilation: Triple<Int, Int, Int>,
+        groups: Int
+    ): Tensor<T, V> = base.conv3d(input, weight, bias, stride, padding, dilation, groups)
 
     override fun <T : DType, V> maxPool2d(
         input: Tensor<T, V>,

--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultExecutionTape.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultExecutionTape.kt
@@ -600,10 +600,20 @@ public class DefaultGradientTape(
         return listOf(logSoftmaxGrad(upstream, output, dim))
     }
 
+    override fun conv1dBackward(upstream: Tensor<DType, Any>, output: Tensor<DType, Any>, inputs: List<Tensor<DType, Any>>, attributes: Map<String, Any?>): List<Tensor<DType, Any>?> {
+        // Conv1d backward is complex, return null for now
+        return listOf(null, null, null)
+    }
+
     override fun conv2dBackward(upstream: Tensor<DType, Any>, output: Tensor<DType, Any>, inputs: List<Tensor<DType, Any>>, attributes: Map<String, Any?>): List<Tensor<DType, Any>?> {
         // d(conv2d(x, w, b))/dx, d(conv2d(x, w, b))/dw, d(conv2d(x, w, b))/db
         // This is complex and usually implemented in the backend.
         // For now we return null to signal it's not implemented yet, or throw if we want to be strict.
+        return listOf(null, null, null)
+    }
+
+    override fun conv3dBackward(upstream: Tensor<DType, Any>, output: Tensor<DType, Any>, inputs: List<Tensor<DType, Any>>, attributes: Map<String, Any?>): List<Tensor<DType, Any>?> {
+        // Conv3d backward is complex, return null for now
         return listOf(null, null, null)
     }
 
@@ -780,7 +790,9 @@ public class DefaultGradientTape(
             "gelu" -> BackwardOp(inputs, output) { upstream -> geluBackward(upstream, output, inputs, trace.attributes) }
             "variance" -> BackwardOp(inputs, output) { upstream -> varianceBackward(upstream, output, inputs, trace.attributes) }
             "sqrt" -> BackwardOp(inputs, output) { upstream -> sqrtBackward(upstream, output, inputs, trace.attributes) }
+            "conv1d" -> BackwardOp(inputs, output) { upstream -> conv1dBackward(upstream, output, inputs, trace.attributes) }
             "conv2d" -> BackwardOp(inputs, output) { upstream -> conv2dBackward(upstream, output, inputs, trace.attributes) }
+            "conv3d" -> BackwardOp(inputs, output) { upstream -> conv3dBackward(upstream, output, inputs, trace.attributes) }
             "maxPool2d" -> BackwardOp(inputs, output) { upstream -> maxPool2dBackward(upstream, output, inputs, trace.attributes) }
             "upsample2d" -> BackwardOp(inputs, output) { upstream -> upsample2dBackward(upstream, output, inputs, trace.attributes) }
             "concat" -> BackwardOp(inputs, output) { upstream -> concatBackward(upstream, output, inputs, trace.attributes) }

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/Conv1d.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/Conv1d.kt
@@ -1,0 +1,87 @@
+package sk.ainet.lang.nn
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.nn.topology.ModuleParameter
+import sk.ainet.lang.nn.topology.ModuleParameters
+import sk.ainet.lang.nn.topology.bias
+import sk.ainet.lang.nn.topology.weights
+
+/**
+ * 1D Convolutional layer that applies a convolution operation over 1D input.
+ *
+ * This layer is commonly used for sequence data like time series or text.
+ *
+ * @param inChannels Number of input channels
+ * @param outChannels Number of output channels/filters
+ * @param kernelSize Size of the convolving kernel
+ * @param stride Stride of the convolution (default: 1)
+ * @param padding Padding added to both sides of the input (default: 0)
+ * @param dilation Spacing between kernel elements (default: 1)
+ * @param groups Number of blocked connections from input channels to output channels (default: 1)
+ * @param bias Whether to add a learnable bias to the output (default: true)
+ * @param name Name of the module
+ * @param initWeights Initial weights tensor
+ * @param initBias Initial bias tensor (if bias is true)
+ */
+public class Conv1d<T : DType, V>(
+    public val inChannels: Int,
+    public val outChannels: Int,
+    public val kernelSize: Int,
+    public val stride: Int = 1,
+    public val padding: Int = 0,
+    public val dilation: Int = 1,
+    public val groups: Int = 1,
+    public val bias: Boolean = true,
+    override val name: String = "Conv1d",
+    initWeights: Tensor<T, V>,
+    initBias: Tensor<T, V>? = null,
+    public val trainable: Boolean = true
+) : Module<T, V>(), ModuleParameters<T, V> {
+
+    init {
+        require(inChannels > 0) { "inChannels must be positive" }
+        require(outChannels > 0) { "outChannels must be positive" }
+        require(kernelSize > 0) { "kernelSize must be positive" }
+        require(stride > 0) { "stride must be positive" }
+        require(padding >= 0) { "padding must be non-negative" }
+        require(dilation > 0) { "dilation must be positive" }
+        require(groups > 0) { "groups must be positive" }
+        require(inChannels % groups == 0) { "inChannels must be divisible by groups" }
+        require(outChannels % groups == 0) { "outChannels must be divisible by groups" }
+    }
+
+    override val params: List<ModuleParameter<T, V>> = buildList {
+        add(ModuleParameter.WeightParameter("$name.weight", initWeights, trainable))
+        if (bias && initBias != null) {
+            add(ModuleParameter.BiasParameter("$name.bias", initBias, trainable))
+        }
+    }
+
+    override val modules: List<Module<T, V>>
+        get() = emptyList()
+
+    override fun forward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> =
+        sk.ainet.lang.nn.hooks.withForwardHooks(ctx, this, input) {
+            val weight = params.weights().value
+            val biasValue = if (bias) params.bias().value else null
+
+            input.ops.conv1d(
+                input = input,
+                weight = weight,
+                bias = biasValue,
+                stride = stride,
+                padding = padding,
+                dilation = dilation,
+                groups = groups
+            )
+        }
+
+    /**
+     * Calculates the output size for a given input size and convolution parameters.
+     */
+    public fun outputSize(inputSize: Int): Int {
+        return ((inputSize + 2 * padding - dilation * (kernelSize - 1) - 1) / stride) + 1
+    }
+}

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/Conv3d.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/Conv3d.kt
@@ -1,0 +1,97 @@
+package sk.ainet.lang.nn
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.nn.topology.ModuleParameter
+import sk.ainet.lang.nn.topology.ModuleParameters
+import sk.ainet.lang.nn.topology.bias
+import sk.ainet.lang.nn.topology.weights
+
+/**
+ * 3D Convolutional layer that applies a convolution operation over 3D input.
+ *
+ * This layer is commonly used for volumetric data like video or medical imaging.
+ *
+ * @param inChannels Number of input channels
+ * @param outChannels Number of output channels/filters
+ * @param kernelSize Size of the convolving kernel (depth, height, width)
+ * @param stride Stride of the convolution (default: 1, 1, 1)
+ * @param padding Padding added to all sides of the input (default: 0, 0, 0)
+ * @param dilation Spacing between kernel elements (default: 1, 1, 1)
+ * @param groups Number of blocked connections from input channels to output channels (default: 1)
+ * @param bias Whether to add a learnable bias to the output (default: true)
+ * @param name Name of the module
+ * @param initWeights Initial weights tensor
+ * @param initBias Initial bias tensor (if bias is true)
+ */
+public class Conv3d<T : DType, V>(
+    public val inChannels: Int,
+    public val outChannels: Int,
+    public val kernelSize: Triple<Int, Int, Int>,
+    public val stride: Triple<Int, Int, Int> = Triple(1, 1, 1),
+    public val padding: Triple<Int, Int, Int> = Triple(0, 0, 0),
+    public val dilation: Triple<Int, Int, Int> = Triple(1, 1, 1),
+    public val groups: Int = 1,
+    public val bias: Boolean = true,
+    override val name: String = "Conv3d",
+    initWeights: Tensor<T, V>,
+    initBias: Tensor<T, V>? = null,
+    public val trainable: Boolean = true
+) : Module<T, V>(), ModuleParameters<T, V> {
+
+    init {
+        require(inChannels > 0) { "inChannels must be positive" }
+        require(outChannels > 0) { "outChannels must be positive" }
+        require(kernelSize.first > 0 && kernelSize.second > 0 && kernelSize.third > 0) { "kernelSize must be positive" }
+        require(stride.first > 0 && stride.second > 0 && stride.third > 0) { "stride must be positive" }
+        require(padding.first >= 0 && padding.second >= 0 && padding.third >= 0) { "padding must be non-negative" }
+        require(dilation.first > 0 && dilation.second > 0 && dilation.third > 0) { "dilation must be positive" }
+        require(groups > 0) { "groups must be positive" }
+        require(inChannels % groups == 0) { "inChannels must be divisible by groups" }
+        require(outChannels % groups == 0) { "outChannels must be divisible by groups" }
+    }
+
+    override val params: List<ModuleParameter<T, V>> = buildList {
+        add(ModuleParameter.WeightParameter("$name.weight", initWeights, trainable))
+        if (bias && initBias != null) {
+            add(ModuleParameter.BiasParameter("$name.bias", initBias, trainable))
+        }
+    }
+
+    override val modules: List<Module<T, V>>
+        get() = emptyList()
+
+    override fun forward(input: Tensor<T, V>, ctx: ExecutionContext): Tensor<T, V> =
+        sk.ainet.lang.nn.hooks.withForwardHooks(ctx, this, input) {
+            val weight = params.weights().value
+            val biasValue = if (bias) params.bias().value else null
+
+            input.ops.conv3d(
+                input = input,
+                weight = weight,
+                bias = biasValue,
+                stride = stride,
+                padding = padding,
+                dilation = dilation,
+                groups = groups
+            )
+        }
+
+    /**
+     * Calculates the output size for a given input size and convolution parameters.
+     */
+    public fun outputSize(inputSize: Triple<Int, Int, Int>): Triple<Int, Int, Int> {
+        val (inputDepth, inputHeight, inputWidth) = inputSize
+        val (kernelDepth, kernelHeight, kernelWidth) = kernelSize
+        val (strideDepth, strideHeight, strideWidth) = stride
+        val (padDepth, padHeight, padWidth) = padding
+        val (dilationDepth, dilationHeight, dilationWidth) = dilation
+
+        val outputDepth = ((inputDepth + 2 * padDepth - dilationDepth * (kernelDepth - 1) - 1) / strideDepth) + 1
+        val outputHeight = ((inputHeight + 2 * padHeight - dilationHeight * (kernelHeight - 1) - 1) / strideHeight) + 1
+        val outputWidth = ((inputWidth + 2 * padWidth - dilationWidth * (kernelWidth - 1) - 1) / strideWidth) + 1
+
+        return Triple(outputDepth, outputHeight, outputWidth)
+    }
+}

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/TensorOps.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/TensorOps.kt
@@ -42,6 +42,17 @@ public interface TensorOps {
 
     // Convolutional operations
     @Diff
+    public fun <T : DType, V> conv1d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>? = null,
+        stride: Int = 1,
+        padding: Int = 0,
+        dilation: Int = 1,
+        groups: Int = 1
+    ): Tensor<T, V>
+
+    @Diff
     public fun <T : DType, V> conv2d(
         input: Tensor<T, V>,
         weight: Tensor<T, V>,
@@ -49,6 +60,17 @@ public interface TensorOps {
         stride: Pair<Int, Int> = 1 to 1,
         padding: Pair<Int, Int> = 0 to 0,
         dilation: Pair<Int, Int> = 1 to 1,
+        groups: Int = 1
+    ): Tensor<T, V>
+
+    @Diff
+    public fun <T : DType, V> conv3d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>? = null,
+        stride: Triple<Int, Int, Int> = Triple(1, 1, 1),
+        padding: Triple<Int, Int, Int> = Triple(0, 0, 0),
+        dilation: Triple<Int, Int, Int> = Triple(1, 1, 1),
         groups: Int = 1
     ): Tensor<T, V>
 

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/VoidTensorOps.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/VoidTensorOps.kt
@@ -150,6 +150,20 @@ public class VoidTensorOps : TensorOps {
         return VoidOpsTensor(resultData, tensor.dtype)
     }
 
+    override fun <T : DType, V> conv1d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>?,
+        stride: Int,
+        padding: Int,
+        dilation: Int,
+        groups: Int
+    ): Tensor<T, V> {
+        val resultShape = calculateConv1dShape(input.shape, weight.shape, stride, padding, dilation)
+        val resultData = dataFactory.zeros<T, V>(resultShape, input.dtype)
+        return VoidOpsTensor(resultData, input.dtype)
+    }
+
     override fun <T : DType, V> conv2d(
         input: Tensor<T, V>,
         weight: Tensor<T, V>,
@@ -160,6 +174,20 @@ public class VoidTensorOps : TensorOps {
         groups: Int
     ): Tensor<T, V> {
         val resultShape = calculateConv2dShape(input.shape, weight.shape, stride, padding, dilation)
+        val resultData = dataFactory.zeros<T, V>(resultShape, input.dtype)
+        return VoidOpsTensor(resultData, input.dtype)
+    }
+
+    override fun <T : DType, V> conv3d(
+        input: Tensor<T, V>,
+        weight: Tensor<T, V>,
+        bias: Tensor<T, V>?,
+        stride: Triple<Int, Int, Int>,
+        padding: Triple<Int, Int, Int>,
+        dilation: Triple<Int, Int, Int>,
+        groups: Int
+    ): Tensor<T, V> {
+        val resultShape = calculateConv3dShape(input.shape, weight.shape, stride, padding, dilation)
         val resultData = dataFactory.zeros<T, V>(resultShape, input.dtype)
         return VoidOpsTensor(resultData, input.dtype)
     }
@@ -578,6 +606,76 @@ public class VoidTensorOps : TensorOps {
                 Shape(resultDims)
             }
         }
+    }
+
+    /**
+     * Calculates the result shape for conv1d operation.
+     * Input shape: (batch, in_channels, length)
+     * Weight shape: (out_channels, in_channels_per_group, kernel_length)
+     * Output shape: (batch, out_channels, out_length)
+     */
+    private fun calculateConv1dShape(
+        inputShape: Shape,
+        weightShape: Shape,
+        stride: Int,
+        padding: Int,
+        dilation: Int
+    ): Shape {
+        if (inputShape.rank != 3) {
+            throw IllegalArgumentException("Conv1d input must be 3D tensor (batch, channels, length)")
+        }
+        if (weightShape.rank != 3) {
+            throw IllegalArgumentException("Conv1d weight must be 3D tensor (out_channels, in_channels, kernel_length)")
+        }
+
+        val batch = inputShape.dimensions[0]
+        val outChannels = weightShape.dimensions[0]
+        val inputLength = inputShape.dimensions[2]
+        val kernelLength = weightShape.dimensions[2]
+
+        val outputLength = ((inputLength + 2 * padding - dilation * (kernelLength - 1) - 1) / stride) + 1
+
+        return Shape(batch, outChannels, outputLength)
+    }
+
+    /**
+     * Calculates the result shape for conv3d operation.
+     * Input shape: (batch, in_channels, depth, height, width)
+     * Weight shape: (out_channels, in_channels_per_group, kernel_depth, kernel_height, kernel_width)
+     * Output shape: (batch, out_channels, out_depth, out_height, out_width)
+     */
+    private fun calculateConv3dShape(
+        inputShape: Shape,
+        weightShape: Shape,
+        stride: Triple<Int, Int, Int>,
+        padding: Triple<Int, Int, Int>,
+        dilation: Triple<Int, Int, Int>
+    ): Shape {
+        if (inputShape.rank != 5) {
+            throw IllegalArgumentException("Conv3d input must be 5D tensor (batch, channels, depth, height, width)")
+        }
+        if (weightShape.rank != 5) {
+            throw IllegalArgumentException("Conv3d weight must be 5D tensor (out_channels, in_channels, kernel_d, kernel_h, kernel_w)")
+        }
+
+        val batch = inputShape.dimensions[0]
+        val outChannels = weightShape.dimensions[0]
+        val inputDepth = inputShape.dimensions[2]
+        val inputHeight = inputShape.dimensions[3]
+        val inputWidth = inputShape.dimensions[4]
+        val kernelDepth = weightShape.dimensions[2]
+        val kernelHeight = weightShape.dimensions[3]
+        val kernelWidth = weightShape.dimensions[4]
+
+        val (strideD, strideH, strideW) = stride
+        val (padD, padH, padW) = padding
+        val (dilationD, dilationH, dilationW) = dilation
+
+        val outputDepth = ((inputDepth + 2 * padD - dilationD * (kernelDepth - 1) - 1) / strideD) + 1
+        val outputHeight = ((inputHeight + 2 * padH - dilationH * (kernelHeight - 1) - 1) / strideH) + 1
+        val outputWidth = ((inputWidth + 2 * padW - dilationW * (kernelWidth - 1) - 1) / strideW) + 1
+
+        return Shape(batch, outChannels, outputDepth, outputHeight, outputWidth)
     }
 
     /**

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/ops/ConvVoidOpsShapeTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/ops/ConvVoidOpsShapeTest.kt
@@ -1,0 +1,199 @@
+package sk.ainet.lang.tensor.ops
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.DenseTensorDataFactory
+import sk.ainet.lang.types.FP32
+
+class ConvVoidOpsShapeTest {
+
+    private val dataFactory = DenseTensorDataFactory()
+    private val ops = VoidTensorOps()
+
+    private fun tensor(shape: Shape): VoidOpsTensor<FP32, Float> =
+        VoidOpsTensor(dataFactory.zeros(shape, FP32::class), FP32::class)
+
+    // ========== Conv1d Shape Tests ==========
+
+    @Test
+    fun conv1d_no_padding_stride1_kernel3_returns_expected_shape() {
+        // Input: NCL = (1, 3, 28)
+        val x = tensor(Shape(1, 3, 28))
+        // Weight: (out_channels=16, in_channels=3, kernel_length=3)
+        val w = tensor(Shape(16, 3, 3))
+
+        val y = ops.conv1d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = 1,
+            padding = 0,
+            dilation = 1,
+            groups = 1
+        )
+
+        // Expected: (1, 16, 28 - 3 + 1 = 26)
+        assertEquals(listOf(1, 16, 26), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv1d_same_padding_preserves_length() {
+        val x = tensor(Shape(1, 3, 28))
+        val w = tensor(Shape(16, 3, 5))
+
+        val y = ops.conv1d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = 1,
+            padding = 2,  // SAME-like padding for kernel=5
+            dilation = 1,
+            groups = 1
+        )
+
+        // Expected: (1, 16, 28)
+        assertEquals(listOf(1, 16, 28), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv1d_stride2_halves_length() {
+        val x = tensor(Shape(1, 3, 28))
+        val w = tensor(Shape(16, 3, 3))
+
+        val y = ops.conv1d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = 2,
+            padding = 0,
+            dilation = 1,
+            groups = 1
+        )
+
+        // Expected: (1, 16, (28 - 3) / 2 + 1 = 13)
+        assertEquals(listOf(1, 16, 13), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv1d_dilation2_effective_kernel() {
+        val x = tensor(Shape(1, 3, 32))
+        // 3-element kernel with dilation 2 → effective kernel = 1 + (3-1)*2 = 5
+        val w = tensor(Shape(16, 3, 3))
+
+        val y = ops.conv1d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = 1,
+            padding = 0,
+            dilation = 2,
+            groups = 1
+        )
+
+        // Expected: (1, 16, 32 - 2*(3-1) - 1 + 1 = 28)
+        assertEquals(listOf(1, 16, 28), y.shape.dimensions.toList())
+    }
+
+    // ========== Conv3d Shape Tests ==========
+
+    @Test
+    fun conv3d_no_padding_stride1_kernel3_returns_expected_shape() {
+        // Input: NCDHW = (1, 3, 16, 16, 16)
+        val x = tensor(Shape(1, 3, 16, 16, 16))
+        // Weight: (out_channels=8, in_channels=3, kd=3, kh=3, kw=3)
+        val w = tensor(Shape(8, 3, 3, 3, 3))
+
+        val y = ops.conv3d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Expected: (1, 8, 14, 14, 14)
+        assertEquals(listOf(1, 8, 14, 14, 14), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv3d_same_padding_preserves_dims() {
+        val x = tensor(Shape(1, 3, 16, 16, 16))
+        val w = tensor(Shape(8, 3, 3, 3, 3))
+
+        val y = ops.conv3d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(1, 1, 1),  // Same padding for 3x3x3
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Expected: (1, 8, 16, 16, 16)
+        assertEquals(listOf(1, 8, 16, 16, 16), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv3d_stride2_halves_dims() {
+        val x = tensor(Shape(1, 3, 16, 16, 16))
+        val w = tensor(Shape(8, 3, 2, 2, 2))
+
+        val y = ops.conv3d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = Triple(2, 2, 2),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Expected: (1, 8, (16-2)/2+1=8, 8, 8)
+        assertEquals(listOf(1, 8, 8, 8, 8), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv3d_asymmetric_kernel() {
+        val x = tensor(Shape(1, 3, 16, 24, 32))
+        val w = tensor(Shape(8, 3, 3, 5, 7))
+
+        val y = ops.conv3d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(1, 1, 1),
+            groups = 1
+        )
+
+        // Expected: (1, 8, 16-3+1=14, 24-5+1=20, 32-7+1=26)
+        assertEquals(listOf(1, 8, 14, 20, 26), y.shape.dimensions.toList())
+    }
+
+    @Test
+    fun conv3d_dilation_affects_receptive_field() {
+        val x = tensor(Shape(1, 3, 32, 32, 32))
+        // 3x3x3 kernel with dilation 2 → effective kernel = 5x5x5
+        val w = tensor(Shape(8, 3, 3, 3, 3))
+
+        val y = ops.conv3d(
+            input = x,
+            weight = w,
+            bias = null,
+            stride = Triple(1, 1, 1),
+            padding = Triple(0, 0, 0),
+            dilation = Triple(2, 2, 2),
+            groups = 1
+        )
+
+        // Effective kernel = 1 + (3-1)*2 = 5 for each dim
+        // Expected: (1, 8, 32-4=28, 28, 28)
+        assertEquals(listOf(1, 8, 28, 28, 28), y.shape.dimensions.toList())
+    }
+}

--- a/skainet-lang/skainet-lang-ksp-processor/src/main/kotlin/sk/ainet/lang/ksp/GraphDslGenerator.kt
+++ b/skainet-lang/skainet-lang-ksp-processor/src/main/kotlin/sk/ainet/lang/ksp/GraphDslGenerator.kt
@@ -78,7 +78,8 @@ class GraphDslGenerator(
                    if (param.type.startsWith("kotlin.collections.List<") || param.type.startsWith("List<")) "List<GraphValue<*>>" else "GraphValue<*>"
                 } else {
                     // Replace generic type parameters with DType/Any if they appear in non-tensor params
-                    param.type.replace("T", "DType").replace("V", "Any")
+                    // Use regex to only replace standalone type parameters, not substrings like "Triple"
+                    param.type.replace(Regex("\\bT\\b"), "DType").replace(Regex("\\bV\\b"), "Any")
                 }
                 
                 // If the parameter is optional but we don't have a default value yet,
@@ -116,7 +117,7 @@ class GraphDslGenerator(
             append(dslParams.joinToString(", "))
             append("): ")
             
-            val returnType = if (method.returnType.isTensor) "GraphValue<*>" else if (method.returnType.isTensorList) "List<GraphValue<*>>" else method.returnType.type.replace("T", "DType").replace("V", "Any")
+            val returnType = if (method.returnType.isTensor) "GraphValue<*>" else if (method.returnType.isTensorList) "List<GraphValue<*>>" else method.returnType.type.replace(Regex("\\bT\\b"), "DType").replace(Regex("\\bV\\b"), "Any")
             appendLine("$returnType {")
             
             // Map parameters to attributes

--- a/skainet-lang/skainet-lang-ksp-processor/src/main/kotlin/sk/ainet/lang/ksp/TracingWrapperProcessor.kt
+++ b/skainet-lang/skainet-lang-ksp-processor/src/main/kotlin/sk/ainet/lang/ksp/TracingWrapperProcessor.kt
@@ -294,10 +294,10 @@ class TracingWrapperGenerator(
                 // Fix the type for nullable parameters that should have ? suffix
                 val correctedType = when {
                     param.name == "dim" && method.name in listOf("squeeze", "sum", "mean", "variance") && !param.type.endsWith("?") -> "${param.type}?"
-                    param.name == "bias" && method.name == "conv2d" && !param.type.endsWith("?") -> "${param.type}?"
+                    param.name == "bias" && method.name in listOf("conv1d", "conv2d", "conv3d") && !param.type.endsWith("?") -> "${param.type}?"
                     else -> param.type
                 }
-                
+
                 // Override methods cannot specify default values - they inherit them from the interface
                 "${param.name}: $correctedType"
             })


### PR DESCRIPTION
Add 1D and 3D convolutional operations to support sequence/temporal data (Conv1d) and volumetric data like video/medical imaging (Conv3d).

Changes:
- Add conv1d and conv3d to TensorOps interface with @Diff annotation
- Implement both operations in DefaultCpuOps with full support for groups, stride, padding, dilation, and optional bias
- Add shape calculation and implementations to VoidTensorOps
- Add delegation in RecordingTensorOpsDecorator
- Add backward method stubs in DefaultGradientTape
- Create Conv1d and Conv3d module wrapper classes
- Add comprehensive unit tests for both operations
- Fix KSP processor to handle nullable bias parameter for conv1d/conv3d
- Fix GraphDslGenerator to use word boundaries for type parameter replacement (prevents Triple->DTyperiple bug)

Implements: #300
Related-To: #290