### PR TITLE
Add CIFAR-10 dataset support (#292)

### DIFF
--- a/skainet-data/skainet-data-simple/src/androidMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderAndroid.kt
+++ b/skainet-data/skainet-data-simple/src/androidMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderAndroid.kt
@@ -1,0 +1,163 @@
+package sk.ainet.data.cifar10
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.call.body
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.GZIPInputStream
+
+/**
+ * Android implementation of the CIFAR-10 loader.
+ *
+ * Downloads the CIFAR-10 binary archive, extracts batch files, and caches them locally.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderAndroid(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    /**
+     * Downloads the CIFAR-10 archive and extracts the specified batch file.
+     *
+     * @param batchFilename The name of the batch file to extract.
+     * @return The bytes of the extracted batch file.
+     */
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray = withContext(Dispatchers.IO) {
+        val cacheDir = File(config.cacheDir)
+        if (!cacheDir.exists()) {
+            cacheDir.mkdirs()
+        }
+
+        val extractedDir = File(cacheDir, "cifar-10-batches-bin")
+        val batchFile = File(extractedDir, batchFilename)
+
+        // Check if the batch file already exists in cache
+        if (config.useCache && batchFile.exists()) {
+            println("Using cached file: ${batchFile.path}")
+            return@withContext batchFile.readBytes()
+        }
+
+        // Check if we need to download and extract the archive
+        if (!extractedDir.exists() || !config.useCache) {
+            val archiveFile = File(cacheDir, CIFAR10Constants.ARCHIVE_FILENAME)
+
+            // Download if not cached
+            if (!archiveFile.exists() || !config.useCache) {
+                println("Downloading CIFAR-10 archive: ${CIFAR10Constants.DOWNLOAD_URL}")
+                downloadFile(CIFAR10Constants.DOWNLOAD_URL, archiveFile.path)
+            } else {
+                println("Using cached archive: ${archiveFile.path}")
+            }
+
+            // Extract the archive
+            println("Extracting CIFAR-10 archive...")
+            extractTarGz(archiveFile.path, cacheDir.path)
+        }
+
+        if (!batchFile.exists()) {
+            throw IllegalStateException("Batch file not found after extraction: ${batchFile.path}")
+        }
+
+        return@withContext batchFile.readBytes()
+    }
+
+    private suspend fun downloadFile(url: String, outputPath: String) {
+        val client = HttpClient(Android) {
+            // No plugins needed for basic functionality
+        }
+
+        try {
+            val file = File(outputPath)
+
+            val httpResponse: HttpResponse = client.get(url)
+            val responseBody: ByteArray = httpResponse.body()
+            file.writeBytes(responseBody)
+
+            println("File saved to ${file.path} (${responseBody.size} bytes)")
+        } finally {
+            client.close()
+        }
+    }
+
+    private fun extractTarGz(archivePath: String, outputDir: String) {
+        val outputDirFile = File(outputDir)
+
+        val tarBytes = GZIPInputStream(FileInputStream(archivePath)).use { gzipIn ->
+            gzipIn.readBytes()
+        }
+
+        extractTar(tarBytes, outputDirFile)
+    }
+
+    private fun extractTar(tarBytes: ByteArray, outputDir: File) {
+        var offset = 0
+        val headerSize = 512
+
+        while (offset + headerSize <= tarBytes.size) {
+            if (isZeroBlock(tarBytes, offset, headerSize)) {
+                break
+            }
+
+            val filename = parseString(tarBytes, offset, 100).trimEnd('\u0000', '/')
+            val fileSizeOctal = parseString(tarBytes, offset + 124, 12).trim('\u0000', ' ')
+            val typeFlag = tarBytes[offset + 156].toInt().toChar()
+
+            val fileSize = if (fileSizeOctal.isNotEmpty()) {
+                fileSizeOctal.toLongOrNull(8) ?: 0L
+            } else {
+                0L
+            }
+
+            offset += headerSize
+
+            if (typeFlag == '5' || typeFlag == 'x' || typeFlag == 'g' || filename.isEmpty()) {
+                offset += ((fileSize + 511) / 512 * 512).toInt()
+                continue
+            }
+
+            if (typeFlag == '0' || typeFlag == '\u0000') {
+                val outputFile = File(outputDir, filename)
+                outputFile.parentFile?.mkdirs()
+
+                if (fileSize > 0 && offset + fileSize <= tarBytes.size) {
+                    FileOutputStream(outputFile).use { fos ->
+                        fos.write(tarBytes, offset, fileSize.toInt())
+                    }
+                    println("Extracted: ${outputFile.path}")
+                }
+            }
+
+            offset += ((fileSize + 511) / 512 * 512).toInt()
+        }
+    }
+
+    private fun isZeroBlock(bytes: ByteArray, offset: Int, size: Int): Boolean {
+        for (i in 0 until size) {
+            if (offset + i >= bytes.size) return true
+            if (bytes[offset + i] != 0.toByte()) return false
+        }
+        return true
+    }
+
+    private fun parseString(bytes: ByteArray, offset: Int, length: Int): String {
+        val sb = StringBuilder()
+        for (i in 0 until length) {
+            if (offset + i >= bytes.size) break
+            val b = bytes[offset + i]
+            if (b == 0.toByte()) break
+            sb.append(b.toInt().toChar())
+        }
+        return sb.toString()
+    }
+
+    public companion object {
+        public fun create(): CIFAR10LoaderAndroid = CIFAR10LoaderAndroid(CIFAR10LoaderConfig())
+        public fun create(cacheDir: String): CIFAR10LoaderAndroid = CIFAR10LoaderAndroid(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderAndroid = CIFAR10LoaderAndroid(config)
+    }
+}

--- a/skainet-data/skainet-data-simple/src/androidMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/androidMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * Android implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderAndroid(config)
+}

--- a/skainet-data/skainet-data-simple/src/commonMain/kotlin/sk/ainet/data/cifar10/CIFAR10.kt
+++ b/skainet-data/skainet-data-simple/src/commonMain/kotlin/sk/ainet/data/cifar10/CIFAR10.kt
@@ -1,0 +1,63 @@
+package sk.ainet.data.cifar10
+
+/**
+ * Common entry points for obtaining CIFAR-10 datasets across platforms.
+ *
+ * CIFAR-10 is a dataset of 60,000 32x32 color images in 10 classes:
+ * airplane, automobile, bird, cat, deer, dog, frog, horse, ship, and truck.
+ * There are 50,000 training images and 10,000 test images.
+ *
+ * The images are stored in channel-first format (3x32x32 = 3072 bytes per image).
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * // Load training data
+ * val trainDataset = CIFAR10.loadTrain()
+ *
+ * // Load test data
+ * val testDataset = CIFAR10.loadTest()
+ *
+ * // Iterate over batches
+ * val batchIterator = trainDataset.batchIterator<Int8, Byte>(32)
+ * for (batch in batchIterator) {
+ *     val images = batch.x[0]  // Shape: [32, 3, 32, 32]
+ *     val labels = batch.y     // Shape: [32]
+ * }
+ *
+ * // Get class name for a sample
+ * val sample = trainDataset.getX(0)
+ * println("Class: ${sample.className()}")  // e.g., "airplane"
+ * ```
+ */
+public object CIFAR10 {
+    /**
+     * Create a platform-specific CIFAR10Loader using the provided config.
+     */
+    public fun loader(config: CIFAR10LoaderConfig = CIFAR10LoaderConfig()): CIFAR10Loader =
+        createCIFAR10Loader(config)
+
+    /**
+     * Download (with caching if supported) and return the CIFAR-10 training dataset.
+     *
+     * @param config Configuration for caching and download behavior.
+     * @return The CIFAR-10 training dataset (50,000 images).
+     */
+    public suspend fun loadTrain(config: CIFAR10LoaderConfig = CIFAR10LoaderConfig()): CIFAR10Dataset =
+        loader(config).loadTrainingData()
+
+    /**
+     * Download (with caching if supported) and return the CIFAR-10 test dataset.
+     *
+     * @param config Configuration for caching and download behavior.
+     * @return The CIFAR-10 test dataset (10,000 images).
+     */
+    public suspend fun loadTest(config: CIFAR10LoaderConfig = CIFAR10LoaderConfig()): CIFAR10Dataset =
+        loader(config).loadTestData()
+}
+
+/**
+ * Expect/actual factory function implemented per platform that returns the concrete
+ * CIFAR10Loader implementation.
+ */
+public expect fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader

--- a/skainet-data/skainet-data-simple/src/commonMain/kotlin/sk/ainet/data/cifar10/CIFAR10Data.kt
+++ b/skainet-data/skainet-data-simple/src/commonMain/kotlin/sk/ainet/data/cifar10/CIFAR10Data.kt
@@ -1,0 +1,222 @@
+package sk.ainet.data.cifar10
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import sk.ainet.context.DefaultDataExecutionContext
+import sk.ainet.context.ExecutionContext
+import sk.ainet.data.DataBatch
+import sk.ainet.data.Dataset
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.types.Int8
+import kotlin.math.min
+import kotlin.random.Random
+
+/**
+ * Represents a single CIFAR-10 image with its label.
+ *
+ * CIFAR-10 consists of 60,000 32x32 color images in 10 classes:
+ * - 50,000 training images
+ * - 10,000 test images
+ *
+ * Classes:
+ * - 0: airplane
+ * - 1: automobile
+ * - 2: bird
+ * - 3: cat
+ * - 4: deer
+ * - 5: dog
+ * - 6: frog
+ * - 7: horse
+ * - 8: ship
+ * - 9: truck
+ *
+ * @property image The pixel data of the image as a ByteArray (3x32x32 = 3072 bytes, channel-first RGB).
+ * @property label The label of the image (0-9).
+ */
+@Serializable
+public data class CIFAR10Image(
+    val image: ByteArray,
+    val label: Byte
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as CIFAR10Image
+
+        if (!image.contentEquals(other.image)) return false
+        if (label != other.label) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = image.contentHashCode()
+        result = 31 * result + label.toInt()
+        return result
+    }
+
+    /**
+     * Returns the class name for this image's label.
+     */
+    public fun className(): String = CIFAR10Constants.CLASS_NAMES[label.toInt()]
+}
+
+/**
+ * CIFAR-10 dataset implementation using Dataset/DataBatch API.
+ * - Provides batching as tensors [Int8] with shapes:
+ *   x: [batch, 3, 32, 32] (channel-first RGB)
+ *   y: [batch] (labels as bytes)
+ */
+@Serializable
+public data class CIFAR10Dataset(
+    val images: List<CIFAR10Image>,
+    @Transient private val executionContext: ExecutionContext = DefaultDataExecutionContext()
+) : Dataset<CIFAR10Image, Float>() {
+
+    override val xSize: Int get() = images.size
+
+    override fun getX(idx: Int): CIFAR10Image = images[idx]
+
+    override fun getY(idx: Int): Float = images[idx].label.toInt().toFloat()
+
+    override fun shuffle(): Dataset<CIFAR10Image, Float> {
+        val shuffled = images.toMutableList()
+        shuffled.shuffle(Random.Default)
+        return CIFAR10Dataset(shuffled, executionContext)
+    }
+
+    override fun split(splitRatio: Double): Pair<Dataset<CIFAR10Image, Float>, Dataset<CIFAR10Image, Float>> {
+        require(splitRatio > 0.0 && splitRatio < 1.0) { "splitRatio must be in (0,1)" }
+        val splitIndex = (images.size * splitRatio).toInt()
+        val first = images.subList(0, splitIndex)
+        val second = images.subList(splitIndex, images.size)
+        return CIFAR10Dataset(first, executionContext) to CIFAR10Dataset(second, executionContext)
+    }
+
+    /**
+     * Creates a DataBatch with memory-efficient Int8 tensors from raw byte arrays.
+     */
+    override fun <T : DType, V> createDataBatch(batchStart: Int, batchLength: Int): DataBatch<T, V> {
+        val actualLen = min(batchLength, xSize - batchStart)
+        val batchImages = images.subList(batchStart, batchStart + actualLen)
+
+        // Concatenate raw image bytes (no normalization) for memory efficiency
+        val xData = ByteArray(actualLen * CIFAR10Constants.IMAGE_BYTES)
+        var offset = 0
+        for (sample in batchImages) {
+            val bytes = sample.image
+            bytes.copyInto(xData, destinationOffset = offset, startIndex = 0, endIndex = CIFAR10Constants.IMAGE_BYTES)
+            offset += CIFAR10Constants.IMAGE_BYTES
+        }
+
+        // Shape as [batch, 3, 32, 32] (channel-first)
+        val xShape = Shape(actualLen, CIFAR10Constants.NUM_CHANNELS, CIFAR10Constants.IMAGE_SIZE, CIFAR10Constants.IMAGE_SIZE)
+        val xTensor: Tensor<Int8, Byte> = executionContext.fromByteArray(xShape, Int8::class, xData)
+
+        // Labels as bytes (memory-efficient)
+        val yData = ByteArray(actualLen) { idx -> batchImages[idx].label }
+        val yShape = Shape(actualLen)
+        val yTensor: Tensor<Int8, Byte> = executionContext.fromByteArray(yShape, Int8::class, yData)
+
+        // DataBatch expects array of input tensors; we provide single input
+        val xArray: Array<Tensor<Int8, Byte>> = arrayOf(xTensor)
+
+        @Suppress("UNCHECKED_CAST")
+        return DataBatch(xArray as Array<Tensor<T, V>>, yTensor as Tensor<T, V>)
+    }
+
+    /**
+     * Returns a subset of the dataset.
+     */
+    public fun subset(fromIndex: Int, toIndex: Int): CIFAR10Dataset {
+        return CIFAR10Dataset(images.subList(fromIndex, toIndex), executionContext)
+    }
+}
+
+/**
+ * Configuration for the CIFAR-10 loader.
+ *
+ * @property cacheDir The directory where downloaded files will be cached.
+ * @property useCache Whether to use cached files if available.
+ */
+public data class CIFAR10LoaderConfig(
+    val cacheDir: String = "cifar10-data",
+    val useCache: Boolean = true
+)
+
+/**
+ * Constants for the CIFAR-10 dataset.
+ */
+public object CIFAR10Constants {
+    public const val IMAGE_SIZE: Int = 32
+    public const val NUM_CHANNELS: Int = 3
+    public const val IMAGE_BYTES: Int = NUM_CHANNELS * IMAGE_SIZE * IMAGE_SIZE  // 3072
+
+    public const val NUM_TRAINING_IMAGES: Int = 50000
+    public const val NUM_TEST_IMAGES: Int = 10000
+    public const val IMAGES_PER_BATCH: Int = 10000
+
+    // CIFAR-10 binary format filenames
+    public const val DATA_BATCH_1_FILENAME: String = "data_batch_1.bin"
+    public const val DATA_BATCH_2_FILENAME: String = "data_batch_2.bin"
+    public const val DATA_BATCH_3_FILENAME: String = "data_batch_3.bin"
+    public const val DATA_BATCH_4_FILENAME: String = "data_batch_4.bin"
+    public const val DATA_BATCH_5_FILENAME: String = "data_batch_5.bin"
+    public const val TEST_BATCH_FILENAME: String = "test_batch.bin"
+
+    // Archive filename
+    public const val ARCHIVE_FILENAME: String = "cifar-10-binary.tar.gz"
+
+    // CIFAR-10 download URL (University of Toronto)
+    public const val DOWNLOAD_URL: String =
+        "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz"
+
+    /**
+     * Class names for CIFAR-10 labels.
+     */
+    public val CLASS_NAMES: List<String> = listOf(
+        "airplane",
+        "automobile",
+        "bird",
+        "cat",
+        "deer",
+        "dog",
+        "frog",
+        "horse",
+        "ship",
+        "truck"
+    )
+
+    /**
+     * Training batch filenames in order.
+     */
+    public val TRAINING_BATCH_FILENAMES: List<String> = listOf(
+        DATA_BATCH_1_FILENAME,
+        DATA_BATCH_2_FILENAME,
+        DATA_BATCH_3_FILENAME,
+        DATA_BATCH_4_FILENAME,
+        DATA_BATCH_5_FILENAME
+    )
+}
+
+/**
+ * Interface for the CIFAR-10 loader.
+ */
+public interface CIFAR10Loader {
+    /**
+     * Loads the CIFAR-10 training dataset.
+     *
+     * @return The CIFAR-10 training dataset (50,000 images).
+     */
+    public suspend fun loadTrainingData(): CIFAR10Dataset
+
+    /**
+     * Loads the CIFAR-10 test dataset.
+     *
+     * @return The CIFAR-10 test dataset (10,000 images).
+     */
+    public suspend fun loadTestData(): CIFAR10Dataset
+}

--- a/skainet-data/skainet-data-simple/src/commonMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderCommon.kt
+++ b/skainet-data/skainet-data-simple/src/commonMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderCommon.kt
@@ -1,0 +1,91 @@
+package sk.ainet.data.cifar10
+
+/**
+ * Abstract base class for CIFAR-10 loaders that implements common functionality.
+ *
+ * CIFAR-10 binary format:
+ * - Each image is stored as: 1 byte label + 3072 bytes pixel data
+ * - Pixel data is in channel-first format: 1024 red + 1024 green + 1024 blue
+ * - Training data is split across 5 batch files (10,000 images each)
+ * - Test data is in a single batch file (10,000 images)
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public abstract class CIFAR10LoaderCommon(public val config: CIFAR10LoaderConfig) : CIFAR10Loader {
+
+    /**
+     * Loads the CIFAR-10 training dataset by combining all 5 training batches.
+     *
+     * @return The CIFAR-10 training dataset (50,000 images).
+     */
+    override suspend fun loadTrainingData(): CIFAR10Dataset {
+        val allImages = mutableListOf<CIFAR10Image>()
+
+        for (batchFilename in CIFAR10Constants.TRAINING_BATCH_FILENAMES) {
+            val batchBytes = downloadAndExtractBatch(batchFilename)
+            val batchImages = parseBatch(batchBytes)
+            allImages.addAll(batchImages)
+        }
+
+        return CIFAR10Dataset(allImages)
+    }
+
+    /**
+     * Loads the CIFAR-10 test dataset.
+     *
+     * @return The CIFAR-10 test dataset (10,000 images).
+     */
+    override suspend fun loadTestData(): CIFAR10Dataset {
+        val batchBytes = downloadAndExtractBatch(CIFAR10Constants.TEST_BATCH_FILENAME)
+        val images = parseBatch(batchBytes)
+        return CIFAR10Dataset(images)
+    }
+
+    /**
+     * Downloads the CIFAR-10 archive and extracts the specified batch file.
+     *
+     * @param batchFilename The name of the batch file to extract.
+     * @return The bytes of the extracted batch file.
+     */
+    protected abstract suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray
+
+    /**
+     * Parses a CIFAR-10 batch file into a list of images.
+     *
+     * Binary format per image: 1 byte label + 3072 bytes pixel data
+     * Pixel data is channel-first: 1024 R + 1024 G + 1024 B
+     *
+     * @param batchBytes The bytes of the batch file.
+     * @return The list of parsed CIFAR-10 images.
+     */
+    protected fun parseBatch(batchBytes: ByteArray): List<CIFAR10Image> {
+        val bytesPerImage = 1 + CIFAR10Constants.IMAGE_BYTES  // 1 label + 3072 pixels
+        val numImages = batchBytes.size / bytesPerImage
+
+        if (batchBytes.size % bytesPerImage != 0) {
+            throw IllegalArgumentException(
+                "Invalid batch file size: ${batchBytes.size} bytes. " +
+                "Expected multiple of $bytesPerImage bytes."
+            )
+        }
+
+        val images = mutableListOf<CIFAR10Image>()
+
+        for (i in 0 until numImages) {
+            val offset = i * bytesPerImage
+
+            // First byte is the label
+            val label = batchBytes[offset]
+
+            // Next 3072 bytes are pixel data (channel-first: R, G, B)
+            val imageData = ByteArray(CIFAR10Constants.IMAGE_BYTES)
+            for (j in 0 until CIFAR10Constants.IMAGE_BYTES) {
+                imageData[j] = batchBytes[offset + 1 + j]
+            }
+
+            images.add(CIFAR10Image(imageData, label))
+        }
+
+        return images
+    }
+}

--- a/skainet-data/skainet-data-simple/src/iosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/iosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * iOS implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderIos(config)
+}

--- a/skainet-data/skainet-data-simple/src/iosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderIos.kt
+++ b/skainet-data/skainet-data-simple/src/iosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderIos.kt
@@ -1,0 +1,24 @@
+package sk.ainet.data.cifar10
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * iOS implementation of the CIFAR-10 loader.
+ * Placeholder implementation - tar.gz extraction not yet implemented for iOS.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderIos(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray =
+        withContext(Dispatchers.Default) {
+            error("CIFAR10LoaderIos is not fully implemented yet. Tar.gz extraction requires native implementation.")
+        }
+
+    public companion object {
+        public fun create(): CIFAR10LoaderIos = CIFAR10LoaderIos(CIFAR10LoaderConfig())
+        public fun create(cacheDir: String): CIFAR10LoaderIos = CIFAR10LoaderIos(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderIos = CIFAR10LoaderIos(config)
+    }
+}

--- a/skainet-data/skainet-data-simple/src/jsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/jsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * JS implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderJs(config)
+}

--- a/skainet-data/skainet-data-simple/src/jsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderJs.kt
+++ b/skainet-data/skainet-data-simple/src/jsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderJs.kt
@@ -1,0 +1,24 @@
+package sk.ainet.data.cifar10
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * JS (browser) implementation of the CIFAR-10 loader.
+ * Placeholder implementation - tar.gz extraction not yet implemented for JS.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderJs(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray =
+        withContext(Dispatchers.Default) {
+            error("CIFAR10LoaderJs is not fully implemented yet. Tar.gz extraction requires JS library support.")
+        }
+
+    public companion object {
+        public fun create(): CIFAR10LoaderJs = CIFAR10LoaderJs(CIFAR10LoaderConfig())
+        public fun create(cacheDir: String): CIFAR10LoaderJs = CIFAR10LoaderJs(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderJs = CIFAR10LoaderJs(config)
+    }
+}

--- a/skainet-data/skainet-data-simple/src/jvmMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/jvmMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * JVM implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderJvm(config)
+}

--- a/skainet-data/skainet-data-simple/src/jvmMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderJvm.kt
+++ b/skainet-data/skainet-data-simple/src/jvmMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderJvm.kt
@@ -1,0 +1,230 @@
+package sk.ainet.data.cifar10
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.call.body
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+
+/**
+ * JVM implementation of the CIFAR-10 loader.
+ *
+ * Downloads the CIFAR-10 binary archive, extracts batch files, and caches them locally.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderJvm(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    /**
+     * Downloads the CIFAR-10 archive and extracts the specified batch file.
+     *
+     * @param batchFilename The name of the batch file to extract.
+     * @return The bytes of the extracted batch file.
+     */
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray = withContext(Dispatchers.IO) {
+        val cacheDir = File(config.cacheDir)
+        if (!cacheDir.exists()) {
+            cacheDir.mkdirs()
+        }
+
+        val extractedDir = File(cacheDir, "cifar-10-batches-bin")
+        val batchFile = File(extractedDir, batchFilename)
+
+        // Check if the batch file already exists in cache
+        if (config.useCache && batchFile.exists()) {
+            println("Using cached file: ${batchFile.path}")
+            return@withContext batchFile.readBytes()
+        }
+
+        // Check if we need to download and extract the archive
+        if (!extractedDir.exists() || !config.useCache) {
+            val archiveFile = File(cacheDir, CIFAR10Constants.ARCHIVE_FILENAME)
+
+            // Download if not cached
+            if (!archiveFile.exists() || !config.useCache) {
+                println("Downloading CIFAR-10 archive: ${CIFAR10Constants.DOWNLOAD_URL}")
+                downloadFile(CIFAR10Constants.DOWNLOAD_URL, archiveFile.path)
+            } else {
+                println("Using cached archive: ${archiveFile.path}")
+            }
+
+            // Extract the archive
+            println("Extracting CIFAR-10 archive...")
+            extractTarGz(archiveFile.path, cacheDir.path)
+        }
+
+        if (!batchFile.exists()) {
+            throw IllegalStateException("Batch file not found after extraction: ${batchFile.path}")
+        }
+
+        return@withContext batchFile.readBytes()
+    }
+
+    /**
+     * Downloads a file from a URL.
+     *
+     * @param url The URL to download from.
+     * @param outputPath The path to save the file to.
+     */
+    private suspend fun downloadFile(url: String, outputPath: String) {
+        val client = HttpClient(CIO) {
+            install(Logging)
+
+            // Configure timeout for large files (CIFAR-10 is ~170MB)
+            install(HttpTimeout) {
+                requestTimeoutMillis = 300000 // 5 minutes
+                connectTimeoutMillis = 60000 // 60 seconds
+                socketTimeoutMillis = 300000 // 5 minutes
+            }
+        }
+
+        try {
+            val file = File(outputPath)
+
+            val httpResponse: HttpResponse = client.get(url)
+            val responseBody: ByteArray = httpResponse.body()
+            file.writeBytes(responseBody)
+
+            println("File saved to ${file.path} (${responseBody.size} bytes)")
+        } finally {
+            client.close()
+        }
+    }
+
+    /**
+     * Extracts a .tar.gz archive using a simple TAR parser.
+     *
+     * @param archivePath The path to the .tar.gz file.
+     * @param outputDir The directory to extract files to.
+     */
+    private fun extractTarGz(archivePath: String, outputDir: String) {
+        val outputDirFile = File(outputDir)
+
+        // First, decompress gzip to get the tar content
+        val tarBytes = GZIPInputStream(FileInputStream(archivePath)).use { gzipIn ->
+            gzipIn.readBytes()
+        }
+
+        // Parse the TAR archive
+        extractTar(tarBytes, outputDirFile)
+    }
+
+    /**
+     * Extracts files from a TAR archive.
+     *
+     * TAR format:
+     * - 512-byte header blocks
+     * - File content (rounded up to 512-byte blocks)
+     * - Two empty 512-byte blocks at the end
+     */
+    private fun extractTar(tarBytes: ByteArray, outputDir: File) {
+        var offset = 0
+        val headerSize = 512
+
+        while (offset + headerSize <= tarBytes.size) {
+            // Check for end of archive (two zero blocks)
+            if (isZeroBlock(tarBytes, offset, headerSize)) {
+                break
+            }
+
+            // Parse header
+            val filename = parseString(tarBytes, offset, 100).trimEnd('\u0000', '/')
+            val fileSizeOctal = parseString(tarBytes, offset + 124, 12).trim('\u0000', ' ')
+            val typeFlag = tarBytes[offset + 156].toInt().toChar()
+
+            val fileSize = if (fileSizeOctal.isNotEmpty()) {
+                fileSizeOctal.toLongOrNull(8) ?: 0L
+            } else {
+                0L
+            }
+
+            // Move past header
+            offset += headerSize
+
+            // Skip if it's a directory or special file
+            if (typeFlag == '5' || typeFlag == 'x' || typeFlag == 'g' || filename.isEmpty()) {
+                // Round up to next 512-byte boundary
+                offset += ((fileSize + 511) / 512 * 512).toInt()
+                continue
+            }
+
+            // Only extract regular files (type '0' or '\0')
+            if (typeFlag == '0' || typeFlag == '\u0000') {
+                val outputFile = File(outputDir, filename)
+
+                // Ensure parent directory exists
+                outputFile.parentFile?.mkdirs()
+
+                // Extract file content
+                if (fileSize > 0 && offset + fileSize <= tarBytes.size) {
+                    FileOutputStream(outputFile).use { fos ->
+                        fos.write(tarBytes, offset, fileSize.toInt())
+                    }
+                    println("Extracted: ${outputFile.path}")
+                }
+            }
+
+            // Move to next header (content is padded to 512-byte boundary)
+            offset += ((fileSize + 511) / 512 * 512).toInt()
+        }
+    }
+
+    private fun isZeroBlock(bytes: ByteArray, offset: Int, size: Int): Boolean {
+        for (i in 0 until size) {
+            if (offset + i >= bytes.size) return true
+            if (bytes[offset + i] != 0.toByte()) return false
+        }
+        return true
+    }
+
+    private fun parseString(bytes: ByteArray, offset: Int, length: Int): String {
+        val sb = StringBuilder()
+        for (i in 0 until length) {
+            if (offset + i >= bytes.size) break
+            val b = bytes[offset + i]
+            if (b == 0.toByte()) break
+            sb.append(b.toInt().toChar())
+        }
+        return sb.toString()
+    }
+
+    public companion object {
+        /**
+         * Creates a new instance of CIFAR10LoaderJvm with the default configuration.
+         *
+         * @return A new instance of CIFAR10LoaderJvm.
+         */
+        public fun create(): CIFAR10LoaderJvm {
+            return CIFAR10LoaderJvm(CIFAR10LoaderConfig())
+        }
+
+        /**
+         * Creates a new instance of CIFAR10LoaderJvm with a custom cache directory.
+         *
+         * @param cacheDir The directory to use for caching.
+         * @return A new instance of CIFAR10LoaderJvm.
+         */
+        public fun create(cacheDir: String): CIFAR10LoaderJvm {
+            return CIFAR10LoaderJvm(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        }
+
+        /**
+         * Creates a new instance of CIFAR10LoaderJvm with a custom configuration.
+         *
+         * @param config The configuration to use.
+         * @return A new instance of CIFAR10LoaderJvm.
+         */
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderJvm {
+            return CIFAR10LoaderJvm(config)
+        }
+    }
+}

--- a/skainet-data/skainet-data-simple/src/jvmTest/kotlin/sk/ainet/io/data/cifar10/CIFAR10IntegrationTest.kt
+++ b/skainet-data/skainet-data-simple/src/jvmTest/kotlin/sk/ainet/io/data/cifar10/CIFAR10IntegrationTest.kt
@@ -1,0 +1,105 @@
+package sk.ainet.io.data.cifar10
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DefaultDataExecutionContext
+import sk.ainet.data.cifar10.CIFAR10Constants
+import sk.ainet.data.cifar10.CIFAR10LoaderConfig
+import sk.ainet.data.cifar10.createCIFAR10Loader
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.Int8
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration test that:
+ * 1) Downloads CIFAR-10 dataset (ignores cache)
+ * 2) Creates a train/test split from the training data
+ * 3) Selects one random image and converts it to a tensor
+ *
+ * Note: This test downloads ~170MB of data and may take several minutes.
+ */
+class CIFAR10IntegrationTest {
+
+    @Test
+    fun downloadSplitAndTensorize() = runBlocking {
+        // always ignore cache to force download as requested
+        val config = CIFAR10LoaderConfig(
+            cacheDir = createTempDir(prefix = "cifar10-it-").absolutePath,
+            useCache = false
+        )
+
+        val loader = createCIFAR10Loader(config)
+
+        // 1) Download training dataset
+        val trainDataset = loader.loadTrainingData()
+        assertTrue(trainDataset.images.isNotEmpty(), "Training dataset should not be empty")
+        assertEquals(CIFAR10Constants.NUM_TRAINING_IMAGES, trainDataset.images.size,
+            "Training dataset should have ${CIFAR10Constants.NUM_TRAINING_IMAGES} images")
+
+        // 2) Create a train/test split (80/20)
+        val (trainSplit, testSplit) = trainDataset.shuffle().split(0.8)
+        assertTrue(trainSplit.xSize > 0, "Train split should not be empty")
+        assertTrue(testSplit.xSize > 0, "Test split should not be empty")
+
+        // 3) Pick a random image from the train split and convert to a tensor
+        val idx = Random(1234).nextInt(trainSplit.xSize)
+        val sample = trainSplit.getX(idx)
+
+        // Expect raw bytes of size 3*32*32 = 3072
+        assertEquals(CIFAR10Constants.IMAGE_BYTES, sample.image.size)
+
+        // Verify label is in valid range and has a class name
+        assertTrue(sample.label in 0..9, "Label should be between 0 and 9")
+        assertTrue(sample.className() in CIFAR10Constants.CLASS_NAMES, "Class name should be valid")
+
+        // Convert to an Int8 tensor with shape [1, 3, 32, 32]
+        val ctx = DefaultDataExecutionContext()
+        val shape = Shape(1, CIFAR10Constants.NUM_CHANNELS, CIFAR10Constants.IMAGE_SIZE, CIFAR10Constants.IMAGE_SIZE)
+        val tensor = ctx.fromByteArray<Int8, Byte>(shape, Int8::class, sample.image)
+
+        assertEquals(shape, tensor.shape)
+
+        // Basic sanity checks on values range and size
+        assertEquals(CIFAR10Constants.IMAGE_BYTES, tensor.volume)
+
+        // Verify tensor isn't all zeros
+        var nonZeroCount = 0
+        val c = CIFAR10Constants.NUM_CHANNELS
+        val h = CIFAR10Constants.IMAGE_SIZE
+        val w = CIFAR10Constants.IMAGE_SIZE
+        for (ch in 0 until c) {
+            for (yy in 0 until h) {
+                for (xx in 0 until w) {
+                    val tVal: Byte = tensor.data[0, ch, yy, xx]
+                    if (tVal.toInt() != 0) nonZeroCount++
+                }
+            }
+        }
+
+        // CIFAR-10 images are real photos, should have many non-zero pixels
+        assertTrue(nonZeroCount > 0, "Constructed tensor appears to be all zeros — expected some non-zero pixels")
+    }
+
+    @Test
+    fun downloadTestDataset() = runBlocking {
+        val config = CIFAR10LoaderConfig(
+            cacheDir = createTempDir(prefix = "cifar10-it-test-").absolutePath,
+            useCache = false
+        )
+
+        val loader = createCIFAR10Loader(config)
+
+        // Download test dataset
+        val testDataset = loader.loadTestData()
+        assertTrue(testDataset.images.isNotEmpty(), "Test dataset should not be empty")
+        assertEquals(CIFAR10Constants.NUM_TEST_IMAGES, testDataset.images.size,
+            "Test dataset should have ${CIFAR10Constants.NUM_TEST_IMAGES} images")
+
+        // Verify first image
+        val firstImage = testDataset.getX(0)
+        assertEquals(CIFAR10Constants.IMAGE_BYTES, firstImage.image.size)
+        assertTrue(firstImage.label in 0..9)
+    }
+}

--- a/skainet-data/skainet-data-simple/src/jvmTest/kotlin/sk/ainet/io/data/cifar10/CIFAR10LoaderTest.kt
+++ b/skainet-data/skainet-data-simple/src/jvmTest/kotlin/sk/ainet/io/data/cifar10/CIFAR10LoaderTest.kt
@@ -1,0 +1,179 @@
+package sk.ainet.io.data.cifar10
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.data.cifar10.CIFAR10Constants
+import sk.ainet.data.cifar10.CIFAR10Image
+import sk.ainet.data.cifar10.CIFAR10LoaderConfig
+import sk.ainet.data.cifar10.CIFAR10LoaderCommon
+import sk.ainet.data.cifar10.createCIFAR10Loader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CIFAR10LoaderTest {
+
+    @Test
+    fun testLoadTrainingData() = runBlocking {
+        val loader = createFakeLoader()
+
+        val dataset = loader.loadTrainingData()
+
+        // 5 batches * 3 images per batch = 15 images in our fake data
+        assertEquals(15, dataset.images.size)
+        val firstImage = dataset.images.first()
+        assertEquals(CIFAR10Constants.IMAGE_BYTES, firstImage.image.size)
+        assertTrue(firstImage.label in 0..9)
+
+        val cachedDataset = loader.loadTrainingData()
+        assertEquals(dataset.images, cachedDataset.images)
+    }
+
+    @Test
+    fun testLoadTestData() = runBlocking {
+        val loader = createFakeLoader()
+
+        val dataset = loader.loadTestData()
+
+        assertEquals(EXPECTED_TEST_DATA.size, dataset.images.size)
+        assertEquals(EXPECTED_TEST_DATA, dataset.images)
+        val firstImage = dataset.images.first()
+        assertEquals(CIFAR10Constants.IMAGE_BYTES, firstImage.image.size)
+
+        val cachedDataset = loader.loadTestData()
+        assertEquals(dataset.images, cachedDataset.images)
+    }
+
+    @Test
+    fun testDatasetSubset() = runBlocking {
+        val loader = createFakeLoader()
+        val dataset = loader.loadTestData()
+
+        val subset = dataset.subset(0, 2)
+
+        assertEquals(2, subset.images.size)
+        assertEquals(dataset.images[0], subset.images[0])
+        assertEquals(dataset.images[1], subset.images[1])
+    }
+
+    @Test
+    fun testLoaderConfiguration() {
+        val config = CIFAR10LoaderConfig(
+            cacheDir = "custom-cache-dir",
+            useCache = false
+        )
+        val loader = createCIFAR10Loader(config)
+
+        assertNotNull(loader)
+    }
+
+    @Test
+    fun testClassNames() {
+        assertEquals("airplane", CIFAR10Constants.CLASS_NAMES[0])
+        assertEquals("automobile", CIFAR10Constants.CLASS_NAMES[1])
+        assertEquals("bird", CIFAR10Constants.CLASS_NAMES[2])
+        assertEquals("cat", CIFAR10Constants.CLASS_NAMES[3])
+        assertEquals("deer", CIFAR10Constants.CLASS_NAMES[4])
+        assertEquals("dog", CIFAR10Constants.CLASS_NAMES[5])
+        assertEquals("frog", CIFAR10Constants.CLASS_NAMES[6])
+        assertEquals("horse", CIFAR10Constants.CLASS_NAMES[7])
+        assertEquals("ship", CIFAR10Constants.CLASS_NAMES[8])
+        assertEquals("truck", CIFAR10Constants.CLASS_NAMES[9])
+    }
+
+    @Test
+    fun testImageClassName() {
+        val image = CIFAR10Image(ByteArray(CIFAR10Constants.IMAGE_BYTES), 3)
+        assertEquals("cat", image.className())
+    }
+
+    @Test
+    fun testImageDimensions() {
+        assertEquals(32, CIFAR10Constants.IMAGE_SIZE)
+        assertEquals(3, CIFAR10Constants.NUM_CHANNELS)
+        assertEquals(3072, CIFAR10Constants.IMAGE_BYTES)  // 3 * 32 * 32
+    }
+}
+
+private fun createFakeLoader(config: CIFAR10LoaderConfig = CIFAR10LoaderConfig()): FakeCIFAR10Loader {
+    return FakeCIFAR10Loader(config)
+}
+
+private class FakeCIFAR10Loader(
+    config: CIFAR10LoaderConfig
+) : CIFAR10LoaderCommon(config) {
+
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray {
+        // Generate fake batch data based on filename
+        val images = when (batchFilename) {
+            CIFAR10Constants.DATA_BATCH_1_FILENAME -> EXPECTED_BATCH_1_DATA
+            CIFAR10Constants.DATA_BATCH_2_FILENAME -> EXPECTED_BATCH_2_DATA
+            CIFAR10Constants.DATA_BATCH_3_FILENAME -> EXPECTED_BATCH_3_DATA
+            CIFAR10Constants.DATA_BATCH_4_FILENAME -> EXPECTED_BATCH_4_DATA
+            CIFAR10Constants.DATA_BATCH_5_FILENAME -> EXPECTED_BATCH_5_DATA
+            CIFAR10Constants.TEST_BATCH_FILENAME -> EXPECTED_TEST_DATA
+            else -> error("Unexpected filename $batchFilename")
+        }
+        return buildBatchFile(images)
+    }
+}
+
+// Each training batch has 3 fake images
+private val EXPECTED_BATCH_1_DATA = listOf(
+    sampleCifar10Image(seed = 0, label = 0),   // airplane
+    sampleCifar10Image(seed = 1, label = 1),   // automobile
+    sampleCifar10Image(seed = 2, label = 2)    // bird
+)
+
+private val EXPECTED_BATCH_2_DATA = listOf(
+    sampleCifar10Image(seed = 10, label = 3),  // cat
+    sampleCifar10Image(seed = 11, label = 4),  // deer
+    sampleCifar10Image(seed = 12, label = 5)   // dog
+)
+
+private val EXPECTED_BATCH_3_DATA = listOf(
+    sampleCifar10Image(seed = 20, label = 6),  // frog
+    sampleCifar10Image(seed = 21, label = 7),  // horse
+    sampleCifar10Image(seed = 22, label = 8)   // ship
+)
+
+private val EXPECTED_BATCH_4_DATA = listOf(
+    sampleCifar10Image(seed = 30, label = 9),  // truck
+    sampleCifar10Image(seed = 31, label = 0),  // airplane
+    sampleCifar10Image(seed = 32, label = 1)   // automobile
+)
+
+private val EXPECTED_BATCH_5_DATA = listOf(
+    sampleCifar10Image(seed = 40, label = 2),  // bird
+    sampleCifar10Image(seed = 41, label = 3),  // cat
+    sampleCifar10Image(seed = 42, label = 4)   // deer
+)
+
+private val EXPECTED_TEST_DATA = listOf(
+    sampleCifar10Image(seed = 100, label = 5), // dog
+    sampleCifar10Image(seed = 101, label = 6)  // frog
+)
+
+private fun sampleCifar10Image(seed: Int, label: Int): CIFAR10Image {
+    val pixels = ByteArray(CIFAR10Constants.IMAGE_BYTES) { idx ->
+        ((seed + idx) % 256).toByte()
+    }
+    return CIFAR10Image(pixels, label.toByte())
+}
+
+/**
+ * Build a CIFAR-10 batch file format:
+ * Each image: 1 byte label + 3072 bytes pixel data
+ */
+private fun buildBatchFile(images: List<CIFAR10Image>): ByteArray {
+    val bytesPerImage = 1 + CIFAR10Constants.IMAGE_BYTES
+    val buffer = ByteArray(images.size * bytesPerImage)
+
+    var offset = 0
+    for (image in images) {
+        buffer[offset] = image.label
+        image.image.copyInto(buffer, destinationOffset = offset + 1)
+        offset += bytesPerImage
+    }
+    return buffer
+}

--- a/skainet-data/skainet-data-simple/src/linuxMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/linuxMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * Linux implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderLinux(config)
+}

--- a/skainet-data/skainet-data-simple/src/linuxMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderLinux.kt
+++ b/skainet-data/skainet-data-simple/src/linuxMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderLinux.kt
@@ -1,0 +1,24 @@
+package sk.ainet.data.cifar10
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Linux implementation of the CIFAR-10 loader.
+ * Placeholder implementation.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderLinux(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray =
+        withContext(Dispatchers.Default) {
+            error("CIFAR10LoaderLinux is not implemented yet.")
+        }
+
+    public companion object {
+        public fun create(): CIFAR10LoaderLinux = CIFAR10LoaderLinux(CIFAR10LoaderConfig())
+        public fun create(cacheDir: String): CIFAR10LoaderLinux = CIFAR10LoaderLinux(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderLinux = CIFAR10LoaderLinux(config)
+    }
+}

--- a/skainet-data/skainet-data-simple/src/macosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/macosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * macOS implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderMacos(config)
+}

--- a/skainet-data/skainet-data-simple/src/macosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderMacos.kt
+++ b/skainet-data/skainet-data-simple/src/macosMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderMacos.kt
@@ -1,0 +1,24 @@
+package sk.ainet.data.cifar10
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * macOS implementation of the CIFAR-10 loader.
+ * Placeholder implementation.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderMacos(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray =
+        withContext(Dispatchers.Default) {
+            error("CIFAR10LoaderMacos is not implemented yet.")
+        }
+
+    public companion object {
+        public fun create(): CIFAR10LoaderMacos = CIFAR10LoaderMacos(CIFAR10LoaderConfig())
+        public fun create(cacheDir: String): CIFAR10LoaderMacos = CIFAR10LoaderMacos(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderMacos = CIFAR10LoaderMacos(config)
+    }
+}

--- a/skainet-data/skainet-data-simple/src/wasmJsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
+++ b/skainet-data/skainet-data-simple/src/wasmJsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderFactory.kt
@@ -1,0 +1,8 @@
+package sk.ainet.data.cifar10
+
+/**
+ * WASM JS implementation of the CIFAR-10 loader factory.
+ */
+public actual fun createCIFAR10Loader(config: CIFAR10LoaderConfig): CIFAR10Loader {
+    return CIFAR10LoaderWasmJs(config)
+}

--- a/skainet-data/skainet-data-simple/src/wasmJsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderWasmJs.kt
+++ b/skainet-data/skainet-data-simple/src/wasmJsMain/kotlin/sk/ainet/data/cifar10/CIFAR10LoaderWasmJs.kt
@@ -1,0 +1,24 @@
+package sk.ainet.data.cifar10
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * WASM JS implementation of the CIFAR-10 loader.
+ * Placeholder implementation.
+ *
+ * @property config The configuration for the CIFAR-10 loader.
+ */
+public class CIFAR10LoaderWasmJs(config: CIFAR10LoaderConfig) : CIFAR10LoaderCommon(config) {
+
+    override suspend fun downloadAndExtractBatch(batchFilename: String): ByteArray =
+        withContext(Dispatchers.Default) {
+            error("CIFAR10LoaderWasmJs is not implemented yet.")
+        }
+
+    public companion object {
+        public fun create(): CIFAR10LoaderWasmJs = CIFAR10LoaderWasmJs(CIFAR10LoaderConfig())
+        public fun create(cacheDir: String): CIFAR10LoaderWasmJs = CIFAR10LoaderWasmJs(CIFAR10LoaderConfig(cacheDir = cacheDir))
+        public fun create(config: CIFAR10LoaderConfig): CIFAR10LoaderWasmJs = CIFAR10LoaderWasmJs(config)
+    }
+}


### PR DESCRIPTION
Implement CIFAR-10 dataset loader for 32x32 RGB images with 10 classes: airplane, automobile, bird, cat, deer, dog, frog, horse, ship, truck.

Features:
- CIFAR10Image, CIFAR10Dataset, CIFAR10LoaderConfig data classes
- CIFAR10Constants with download URL and class names
- CIFAR10 entry point with loadTrain() and loadTest() suspend functions
- Platform-specific loaders for JVM and Android (full tar.gz extraction)
- Stub implementations for iOS, JS, WasmJS, macOS, Linux
- Built-in TAR parser (no external dependencies)
- Unit tests with fake loader and integration test

Dataset specs:
- 50,000 training images, 10,000 test images
- 32x32 pixels, 3 channels (RGB), channel-first format
- Binary format: 1 byte label + 3072 bytes pixel data per image

Related to #290