### PR TITLE
Add SafeTensors model loading support to KLlama CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # models
 *.gguf
 *.onnx
+model-371/
 
 local.properties
 .gradle

--- a/skainet-apps/skainet-kgemma/api/android/skainet-kgemma.api
+++ b/skainet-apps/skainet-kgemma/api/android/skainet-kgemma.api
@@ -1,3 +1,8 @@
+public abstract interface class sk/ainet/apps/kgemma/AttentionBackend {
+	public abstract fun attention (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun reset ()V
+}
+
 public final class sk/ainet/apps/kgemma/Gemma3nAttentionBackend : sk/ainet/apps/kgemma/AttentionBackend {
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;Lsk/ainet/apps/kgemma/Gemma3nKvCache;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;Lsk/ainet/apps/kgemma/Gemma3nKvCache;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -6,6 +11,7 @@ public final class sk/ainet/apps/kgemma/Gemma3nAttentionBackend : sk/ainet/apps/
 }
 
 public final class sk/ainet/apps/kgemma/Gemma3nConfig {
+	public static final field Companion Lsk/ainet/apps/kgemma/Gemma3nConfig$Companion;
 	public fun <init> ()V
 	public fun <init> (IIIIIILjava/util/List;ILjava/util/List;FFI)V
 	public synthetic fun <init> (IIIIIILjava/util/List;ILjava/util/List;FFIILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -24,32 +30,62 @@ public final class sk/ainet/apps/kgemma/Gemma3nConfig {
 	public final fun copy (IIIIIILjava/util/List;ILjava/util/List;FFI)Lsk/ainet/apps/kgemma/Gemma3nConfig;
 	public static synthetic fun copy$default (Lsk/ainet/apps/kgemma/Gemma3nConfig;IIIIIILjava/util/List;ILjava/util/List;FFIILjava/lang/Object;)Lsk/ainet/apps/kgemma/Gemma3nConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCacheLayerIndex (I)I
+	public final fun getEffectiveCacheLayers ()I
 	public final fun getHeadDim ()I
 	public final fun getHiddenSize ()I
+	public final fun getIntermediateSize (I)I
 	public final fun getIntermediateSizes ()Ljava/util/List;
+	public final fun getKvDim ()I
 	public final fun getKvSharedLayers ()I
 	public final fun getLayerPattern ()Ljava/util/List;
+	public final fun getLayerType (I)Lsk/ainet/io/gguf/gemma/LayerType;
 	public final fun getNumAttentionHeads ()I
+	public final fun getNumHeadsPerKv ()I
 	public final fun getNumKvHeads ()I
 	public final fun getNumLayers ()I
 	public final fun getPerLayerHiddenSize ()I
+	public final fun getQueryDim ()I
+	public final fun getRopeBase (I)F
 	public final fun getRopeBaseGlobal ()F
 	public final fun getRopeBaseLocal ()F
 	public final fun getSlidingWindow ()I
 	public fun hashCode ()I
+	public final fun isGlobalLayer (I)Z
+	public final fun isKvShared (I)Z
+	public final fun isLocalLayer (I)Z
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class sk/ainet/apps/kgemma/AttentionBackend {
-	public abstract fun attention (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
-	public abstract fun reset ()V
+public final class sk/ainet/apps/kgemma/Gemma3nConfig$Companion {
+	public final fun fromMetadata (Lsk/ainet/io/gguf/gemma/Gemma3nModelMetadata;)Lsk/ainet/apps/kgemma/Gemma3nConfig;
+	public final fun getDEFAULT_LAYER_PATTERN ()Ljava/util/List;
+	public final fun getE2B_DEFAULT ()Lsk/ainet/apps/kgemma/Gemma3nConfig;
 }
 
 public final class sk/ainet/apps/kgemma/Gemma3nIngestion {
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nLoadConfig;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nLoadConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun load (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadFromSafeTensors (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadRuntime (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadRuntimeFromSafeTensors (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadRuntimeStreaming (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun loadStreaming (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class sk/ainet/apps/kgemma/Gemma3nKvCache {
+	public abstract fun getKey (IIII)F
+	public abstract fun getKvDim ()I
+	public abstract fun getNLayers ()I
+	public abstract fun getSeqLen ()I
+	public abstract fun getValue (IIII)F
+	public abstract fun reset ()V
+	public abstract fun store (II[FI[FI)V
+}
+
+public final class sk/ainet/apps/kgemma/Gemma3nKvCacheKt {
+	public static final fun createOptimalGemma3nKvCache (Lsk/ainet/apps/kgemma/Gemma3nConfig;I)Lsk/ainet/apps/kgemma/Gemma3nKvCache;
 }
 
 public final class sk/ainet/apps/kgemma/Gemma3nLoadConfig {
@@ -67,17 +103,8 @@ public final class sk/ainet/apps/kgemma/Gemma3nLoadConfig {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class sk/ainet/apps/kgemma/Gemma3nKvCache {
-	public abstract fun getKey (IIII)F
-	public abstract fun getKvDim ()I
-	public abstract fun getNLayers ()I
-	public abstract fun getSeqLen ()I
-	public abstract fun getValue (IIII)F
-	public abstract fun reset ()V
-	public abstract fun store (II[FI[FI)V
-}
-
 public final class sk/ainet/apps/kgemma/Gemma3nRuntime {
+	public static final field BOS_TOKEN I
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lsk/ainet/apps/kgemma/AttentionBackend;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;FLkotlin/random/Random;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lsk/ainet/apps/kgemma/AttentionBackend;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;FLkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun forward (I)Lsk/ainet/lang/tensor/Tensor;
@@ -88,13 +115,50 @@ public final class sk/ainet/apps/kgemma/Gemma3nRuntime {
 }
 
 public final class sk/ainet/apps/kgemma/HeapGemma3nKvCache : sk/ainet/apps/kgemma/Gemma3nKvCache {
+	public static final field Companion Lsk/ainet/apps/kgemma/HeapGemma3nKvCache$Companion;
 	public fun <init> (IIILjava/util/List;I)V
 	public fun getKey (IIII)F
+	public final fun getKeyArray ()[F
 	public fun getKvDim ()I
 	public fun getNLayers ()I
 	public fun getSeqLen ()I
 	public fun getValue (IIII)F
+	public final fun getValueArray ()[F
 	public fun reset ()V
 	public fun store (II[FI[FI)V
+}
+
+public final class sk/ainet/apps/kgemma/HeapGemma3nKvCache$Companion {
+	public final fun fromConfig (Lsk/ainet/apps/kgemma/Gemma3nConfig;I)Lsk/ainet/apps/kgemma/HeapGemma3nKvCache;
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/AudioEncoder {
+	public static final field Companion Lsk/ainet/apps/kgemma/multimodal/AudioEncoder$Companion;
+	public static final field DEFAULT_FRAME_SIZE I
+	public static final field DEFAULT_HOP_SIZE I
+	public static final field DEFAULT_SAMPLE_RATE I
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;III)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun encode ([FI)Lsk/ainet/lang/tensor/Tensor;
+	public static synthetic fun encode$default (Lsk/ainet/apps/kgemma/multimodal/AudioEncoder;[FIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public final fun encodeFromWav ([B)Lsk/ainet/lang/tensor/Tensor;
+	public final fun estimateTokenCount (FI)I
+	public static synthetic fun estimateTokenCount$default (Lsk/ainet/apps/kgemma/multimodal/AudioEncoder;FIILjava/lang/Object;)I
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/AudioEncoder$Companion {
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/VisionEncoder {
+	public static final field Companion Lsk/ainet/apps/kgemma/multimodal/VisionEncoder$Companion;
+	public static final field DEFAULT_IMAGE_SIZE I
+	public static final field DEFAULT_NUM_TOKENS I
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;II)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun encode ([FII)Lsk/ainet/lang/tensor/Tensor;
+	public final fun encodeFromBytes ([B)Lsk/ainet/lang/tensor/Tensor;
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/VisionEncoder$Companion {
 }
 

--- a/skainet-apps/skainet-kgemma/api/jvm/skainet-kgemma.api
+++ b/skainet-apps/skainet-kgemma/api/jvm/skainet-kgemma.api
@@ -1,3 +1,8 @@
+public abstract interface class sk/ainet/apps/kgemma/AttentionBackend {
+	public abstract fun attention (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun reset ()V
+}
+
 public final class sk/ainet/apps/kgemma/Gemma3nAttentionBackend : sk/ainet/apps/kgemma/AttentionBackend {
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;Lsk/ainet/apps/kgemma/Gemma3nKvCache;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;Lsk/ainet/apps/kgemma/Gemma3nKvCache;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -6,6 +11,7 @@ public final class sk/ainet/apps/kgemma/Gemma3nAttentionBackend : sk/ainet/apps/
 }
 
 public final class sk/ainet/apps/kgemma/Gemma3nConfig {
+	public static final field Companion Lsk/ainet/apps/kgemma/Gemma3nConfig$Companion;
 	public fun <init> ()V
 	public fun <init> (IIIIIILjava/util/List;ILjava/util/List;FFI)V
 	public synthetic fun <init> (IIIIIILjava/util/List;ILjava/util/List;FFIILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -24,32 +30,62 @@ public final class sk/ainet/apps/kgemma/Gemma3nConfig {
 	public final fun copy (IIIIIILjava/util/List;ILjava/util/List;FFI)Lsk/ainet/apps/kgemma/Gemma3nConfig;
 	public static synthetic fun copy$default (Lsk/ainet/apps/kgemma/Gemma3nConfig;IIIIIILjava/util/List;ILjava/util/List;FFIILjava/lang/Object;)Lsk/ainet/apps/kgemma/Gemma3nConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCacheLayerIndex (I)I
+	public final fun getEffectiveCacheLayers ()I
 	public final fun getHeadDim ()I
 	public final fun getHiddenSize ()I
+	public final fun getIntermediateSize (I)I
 	public final fun getIntermediateSizes ()Ljava/util/List;
+	public final fun getKvDim ()I
 	public final fun getKvSharedLayers ()I
 	public final fun getLayerPattern ()Ljava/util/List;
+	public final fun getLayerType (I)Lsk/ainet/io/gguf/gemma/LayerType;
 	public final fun getNumAttentionHeads ()I
+	public final fun getNumHeadsPerKv ()I
 	public final fun getNumKvHeads ()I
 	public final fun getNumLayers ()I
 	public final fun getPerLayerHiddenSize ()I
+	public final fun getQueryDim ()I
+	public final fun getRopeBase (I)F
 	public final fun getRopeBaseGlobal ()F
 	public final fun getRopeBaseLocal ()F
 	public final fun getSlidingWindow ()I
 	public fun hashCode ()I
+	public final fun isGlobalLayer (I)Z
+	public final fun isKvShared (I)Z
+	public final fun isLocalLayer (I)Z
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class sk/ainet/apps/kgemma/AttentionBackend {
-	public abstract fun attention (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
-	public abstract fun reset ()V
+public final class sk/ainet/apps/kgemma/Gemma3nConfig$Companion {
+	public final fun fromMetadata (Lsk/ainet/io/gguf/gemma/Gemma3nModelMetadata;)Lsk/ainet/apps/kgemma/Gemma3nConfig;
+	public final fun getDEFAULT_LAYER_PATTERN ()Ljava/util/List;
+	public final fun getE2B_DEFAULT ()Lsk/ainet/apps/kgemma/Gemma3nConfig;
 }
 
 public final class sk/ainet/apps/kgemma/Gemma3nIngestion {
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nLoadConfig;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nLoadConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun load (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadFromSafeTensors (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadRuntime (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadRuntimeFromSafeTensors (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadRuntimeStreaming (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun loadStreaming (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class sk/ainet/apps/kgemma/Gemma3nKvCache {
+	public abstract fun getKey (IIII)F
+	public abstract fun getKvDim ()I
+	public abstract fun getNLayers ()I
+	public abstract fun getSeqLen ()I
+	public abstract fun getValue (IIII)F
+	public abstract fun reset ()V
+	public abstract fun store (II[FI[FI)V
+}
+
+public final class sk/ainet/apps/kgemma/Gemma3nKvCacheKt {
+	public static final fun createOptimalGemma3nKvCache (Lsk/ainet/apps/kgemma/Gemma3nConfig;I)Lsk/ainet/apps/kgemma/Gemma3nKvCache;
 }
 
 public final class sk/ainet/apps/kgemma/Gemma3nLoadConfig {
@@ -67,17 +103,8 @@ public final class sk/ainet/apps/kgemma/Gemma3nLoadConfig {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class sk/ainet/apps/kgemma/Gemma3nKvCache {
-	public abstract fun getKey (IIII)F
-	public abstract fun getKvDim ()I
-	public abstract fun getNLayers ()I
-	public abstract fun getSeqLen ()I
-	public abstract fun getValue (IIII)F
-	public abstract fun reset ()V
-	public abstract fun store (II[FI[FI)V
-}
-
 public final class sk/ainet/apps/kgemma/Gemma3nRuntime {
+	public static final field BOS_TOKEN I
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lsk/ainet/apps/kgemma/AttentionBackend;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;FLkotlin/random/Random;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lsk/ainet/io/gguf/gemma/Gemma3nRuntimeWeights;Lsk/ainet/apps/kgemma/AttentionBackend;Lkotlin/reflect/KClass;Lsk/ainet/apps/kgemma/Gemma3nConfig;FLkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun forward (I)Lsk/ainet/lang/tensor/Tensor;
@@ -88,13 +115,54 @@ public final class sk/ainet/apps/kgemma/Gemma3nRuntime {
 }
 
 public final class sk/ainet/apps/kgemma/HeapGemma3nKvCache : sk/ainet/apps/kgemma/Gemma3nKvCache {
+	public static final field Companion Lsk/ainet/apps/kgemma/HeapGemma3nKvCache$Companion;
 	public fun <init> (IIILjava/util/List;I)V
 	public fun getKey (IIII)F
+	public final fun getKeyArray ()[F
 	public fun getKvDim ()I
 	public fun getNLayers ()I
 	public fun getSeqLen ()I
 	public fun getValue (IIII)F
+	public final fun getValueArray ()[F
 	public fun reset ()V
 	public fun store (II[FI[FI)V
+}
+
+public final class sk/ainet/apps/kgemma/HeapGemma3nKvCache$Companion {
+	public final fun fromConfig (Lsk/ainet/apps/kgemma/Gemma3nConfig;I)Lsk/ainet/apps/kgemma/HeapGemma3nKvCache;
+}
+
+public final class sk/ainet/apps/kgemma/cli/MainKt {
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/AudioEncoder {
+	public static final field Companion Lsk/ainet/apps/kgemma/multimodal/AudioEncoder$Companion;
+	public static final field DEFAULT_FRAME_SIZE I
+	public static final field DEFAULT_HOP_SIZE I
+	public static final field DEFAULT_SAMPLE_RATE I
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;III)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun encode ([FI)Lsk/ainet/lang/tensor/Tensor;
+	public static synthetic fun encode$default (Lsk/ainet/apps/kgemma/multimodal/AudioEncoder;[FIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public final fun encodeFromWav ([B)Lsk/ainet/lang/tensor/Tensor;
+	public final fun estimateTokenCount (FI)I
+	public static synthetic fun estimateTokenCount$default (Lsk/ainet/apps/kgemma/multimodal/AudioEncoder;FIILjava/lang/Object;)I
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/AudioEncoder$Companion {
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/VisionEncoder {
+	public static final field Companion Lsk/ainet/apps/kgemma/multimodal/VisionEncoder$Companion;
+	public static final field DEFAULT_IMAGE_SIZE I
+	public static final field DEFAULT_NUM_TOKENS I
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;II)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun encode ([FII)Lsk/ainet/lang/tensor/Tensor;
+	public final fun encodeFromBytes ([B)Lsk/ainet/lang/tensor/Tensor;
+}
+
+public final class sk/ainet/apps/kgemma/multimodal/VisionEncoder$Companion {
 }
 

--- a/skainet-apps/skainet-kllama/api/android/skainet-kllama.api
+++ b/skainet-apps/skainet-kllama/api/android/skainet-kllama.api
@@ -29,6 +29,8 @@ public final class sk/ainet/apps/kllama/GGUFTokenizer$Companion {
 	public static synthetic fun fromRandomAccessSource$default (Lsk/ainet/apps/kllama/GGUFTokenizer$Companion;Lsk/ainet/io/RandomAccessSource;ZILjava/lang/Object;)Lsk/ainet/apps/kllama/GGUFTokenizer;
 	public final fun fromSource (Lkotlinx/io/Source;Z)Lsk/ainet/apps/kllama/GGUFTokenizer;
 	public static synthetic fun fromSource$default (Lsk/ainet/apps/kllama/GGUFTokenizer$Companion;Lkotlinx/io/Source;ZILjava/lang/Object;)Lsk/ainet/apps/kllama/GGUFTokenizer;
+	public final fun fromTokenizerJson (Ljava/lang/String;Z)Lsk/ainet/apps/kllama/GGUFTokenizer;
+	public static synthetic fun fromTokenizerJson$default (Lsk/ainet/apps/kllama/GGUFTokenizer$Companion;Ljava/lang/String;ZILjava/lang/Object;)Lsk/ainet/apps/kllama/GGUFTokenizer;
 }
 
 public final class sk/ainet/apps/kllama/GpuAttentionBackend : sk/ainet/apps/kllama/AttentionBackend {
@@ -78,6 +80,11 @@ public final class sk/ainet/apps/kllama/HeapKvCache : sk/ainet/apps/kllama/KvCac
 	public fun store (II[FI[FI)V
 }
 
+public final class sk/ainet/apps/kllama/HfTensorNameMapper {
+	public static final field INSTANCE Lsk/ainet/apps/kllama/HfTensorNameMapper;
+	public final fun toCanonical (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public abstract interface class sk/ainet/apps/kllama/KvCache {
 	public abstract fun getKey (IIII)F
 	public abstract fun getKvDim ()I
@@ -97,10 +104,18 @@ public final class sk/ainet/apps/kllama/Llama2DotCWeightLoader {
 	public final fun load (Lsk/ainet/context/ExecutionContext;Lkotlinx/io/Source;)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
 }
 
+public final class sk/ainet/apps/kllama/LlamaConfigParser {
+	public static final field INSTANCE Lsk/ainet/apps/kllama/LlamaConfigParser;
+	public final fun isTiedEmbeddings (Ljava/lang/String;)Z
+	public final fun parse (Ljava/lang/String;)Lsk/ainet/io/gguf/llama/LlamaModelMetadata;
+}
+
 public final class sk/ainet/apps/kllama/LlamaIngestion {
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kllama/LlamaLoadConfig;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kllama/LlamaLoadConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun load (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadSafeTensors (Lkotlin/jvm/functions/Function0;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;Z)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
+	public static synthetic fun loadSafeTensors$default (Lsk/ainet/apps/kllama/LlamaIngestion;Lkotlin/jvm/functions/Function0;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;ZILjava/lang/Object;)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
 	public final fun loadStreaming (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -138,6 +153,12 @@ public abstract interface class sk/ainet/apps/kllama/LlamaRuntimeInterface : sk/
 
 public final class sk/ainet/apps/kllama/LlamaRuntimeInterface$DefaultImpls {
 	public static synthetic fun generate$default (Lsk/ainet/apps/kllama/LlamaRuntimeInterface;[IIFLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class sk/ainet/apps/kllama/LlamaSafeTensorsLoader {
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;Z)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun load (Lkotlin/jvm/functions/Function0;)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
 }
 
 public final class sk/ainet/apps/kllama/TokenizerImpl : sk/ainet/apps/llm/Tokenizer {

--- a/skainet-apps/skainet-kllama/api/jvm/skainet-kllama.api
+++ b/skainet-apps/skainet-kllama/api/jvm/skainet-kllama.api
@@ -29,6 +29,8 @@ public final class sk/ainet/apps/kllama/GGUFTokenizer$Companion {
 	public static synthetic fun fromRandomAccessSource$default (Lsk/ainet/apps/kllama/GGUFTokenizer$Companion;Lsk/ainet/io/RandomAccessSource;ZILjava/lang/Object;)Lsk/ainet/apps/kllama/GGUFTokenizer;
 	public final fun fromSource (Lkotlinx/io/Source;Z)Lsk/ainet/apps/kllama/GGUFTokenizer;
 	public static synthetic fun fromSource$default (Lsk/ainet/apps/kllama/GGUFTokenizer$Companion;Lkotlinx/io/Source;ZILjava/lang/Object;)Lsk/ainet/apps/kllama/GGUFTokenizer;
+	public final fun fromTokenizerJson (Ljava/lang/String;Z)Lsk/ainet/apps/kllama/GGUFTokenizer;
+	public static synthetic fun fromTokenizerJson$default (Lsk/ainet/apps/kllama/GGUFTokenizer$Companion;Ljava/lang/String;ZILjava/lang/Object;)Lsk/ainet/apps/kllama/GGUFTokenizer;
 }
 
 public final class sk/ainet/apps/kllama/GpuAttentionBackend : sk/ainet/apps/kllama/AttentionBackend {
@@ -78,6 +80,11 @@ public final class sk/ainet/apps/kllama/HeapKvCache : sk/ainet/apps/kllama/KvCac
 	public fun store (II[FI[FI)V
 }
 
+public final class sk/ainet/apps/kllama/HfTensorNameMapper {
+	public static final field INSTANCE Lsk/ainet/apps/kllama/HfTensorNameMapper;
+	public final fun toCanonical (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public abstract interface class sk/ainet/apps/kllama/KvCache {
 	public abstract fun getKey (IIII)F
 	public abstract fun getKvDim ()I
@@ -97,10 +104,18 @@ public final class sk/ainet/apps/kllama/Llama2DotCWeightLoader {
 	public final fun load (Lsk/ainet/context/ExecutionContext;Lkotlinx/io/Source;)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
 }
 
+public final class sk/ainet/apps/kllama/LlamaConfigParser {
+	public static final field INSTANCE Lsk/ainet/apps/kllama/LlamaConfigParser;
+	public final fun isTiedEmbeddings (Ljava/lang/String;)Z
+	public final fun parse (Ljava/lang/String;)Lsk/ainet/io/gguf/llama/LlamaModelMetadata;
+}
+
 public final class sk/ainet/apps/kllama/LlamaIngestion {
 	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kllama/LlamaLoadConfig;)V
 	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/apps/kllama/LlamaLoadConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun load (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun loadSafeTensors (Lkotlin/jvm/functions/Function0;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;Z)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
+	public static synthetic fun loadSafeTensors$default (Lsk/ainet/apps/kllama/LlamaIngestion;Lkotlin/jvm/functions/Function0;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;ZILjava/lang/Object;)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
 	public final fun loadStreaming (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -138,6 +153,12 @@ public abstract interface class sk/ainet/apps/kllama/LlamaRuntimeInterface : sk/
 
 public final class sk/ainet/apps/kllama/LlamaRuntimeInterface$DefaultImpls {
 	public static synthetic fun generate$default (Lsk/ainet/apps/kllama/LlamaRuntimeInterface;[IIFLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class sk/ainet/apps/kllama/LlamaSafeTensorsLoader {
+	public fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;Z)V
+	public synthetic fun <init> (Lsk/ainet/context/ExecutionContext;Lkotlin/reflect/KClass;Lsk/ainet/io/gguf/llama/LlamaModelMetadata;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun load (Lkotlin/jvm/functions/Function0;)Lsk/ainet/io/gguf/llama/LlamaRuntimeWeights;
 }
 
 public final class sk/ainet/apps/kllama/OffheapKvCache : java/lang/AutoCloseable, sk/ainet/apps/kllama/KvCache {

--- a/skainet-apps/skainet-kllama/build.gradle.kts
+++ b/skainet-apps/skainet-kllama/build.gradle.kts
@@ -71,6 +71,7 @@ kotlin {
             implementation(project(":skainet-lang:skainet-lang-ksp-annotations"))
             implementation(project(":skainet-io:skainet-io-core"))
             implementation(project(":skainet-io:skainet-io-gguf"))
+            implementation(project(":skainet-io:skainet-io-safetensors"))
             implementation(libs.kotlinx.io.core)
             implementation(libs.kotlinx.coroutines)
             implementation(libs.kotlinx.serialization.json)

--- a/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/GGUFTokenizer.kt
+++ b/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/GGUFTokenizer.kt
@@ -36,6 +36,169 @@ class GGUFTokenizer private constructor(
         private const val DEFAULT_UNK_TOKEN_ID = 0
 
         /**
+         * Create a tokenizer from a HuggingFace tokenizer.json string.
+         *
+         * Parses the "model.vocab" and "model.merges" sections to build
+         * a BPE tokenizer compatible with LLaMA 3 models.
+         * Also reads "added_tokens" for BOS/EOS token IDs.
+         */
+        fun fromTokenizerJson(json: String, debug: Boolean = false): GGUFTokenizer {
+            // --- Parse vocab: {"token": id, ...} → List<String> indexed by id ---
+            val vocabStart = json.indexOf("\"vocab\"")
+            if (vocabStart < 0) error("tokenizer.json: no \"vocab\" section found")
+            val vocabBraceStart = json.indexOf('{', vocabStart + 7)
+            if (vocabBraceStart < 0) error("tokenizer.json: malformed vocab section")
+            val vocabBraceEnd = findMatchingBrace(json, vocabBraceStart)
+
+            val vocabMap = mutableMapOf<String, Int>()
+            val vocabContent = json.substring(vocabBraceStart + 1, vocabBraceEnd)
+            val vocabPattern = Regex("\"((?:[^\"\\\\]|\\\\.)*)\"\\s*:\\s*(\\d+)")
+            for (match in vocabPattern.findAll(vocabContent)) {
+                val token = unescapeJsonString(match.groupValues[1])
+                val id = match.groupValues[2].toInt()
+                vocabMap[token] = id
+            }
+
+            if (debug) println("DEBUG: Parsed ${vocabMap.size} vocab entries")
+
+            // Build vocab list indexed by id
+            val maxId = vocabMap.values.maxOrNull() ?: 0
+
+            // --- Parse added_tokens for special tokens and to extend vocab ---
+            var bosTokenId = DEFAULT_BOS_TOKEN_ID
+            var eosTokenId = DEFAULT_EOS_TOKEN_ID
+            var unkTokenId = DEFAULT_UNK_TOKEN_ID
+
+            val addedTokensStart = json.indexOf("\"added_tokens\"")
+            if (addedTokensStart >= 0) {
+                val arrStart = json.indexOf('[', addedTokensStart)
+                if (arrStart >= 0) {
+                    val arrEnd = findMatchingBracket(json, arrStart)
+                    val addedContent = json.substring(arrStart, arrEnd + 1)
+                    val idPattern = Regex("\"id\"\\s*:\\s*(\\d+)")
+                    val contentPattern = Regex("\"content\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"")
+                    // Parse each added token object
+                    val objPattern = Regex("\\{[^}]+\\}")
+                    for (objMatch in objPattern.findAll(addedContent)) {
+                        val obj = objMatch.value
+                        val idMatch = idPattern.find(obj)
+                        val contentMatch = contentPattern.find(obj)
+                        if (idMatch != null && contentMatch != null) {
+                            val id = idMatch.groupValues[1].toInt()
+                            val content = unescapeJsonString(contentMatch.groupValues[1])
+                            vocabMap[content] = id
+                            when {
+                                content.contains("begin_of_text") || content == "<s>" -> bosTokenId = id
+                                content.contains("end_of_text") || content == "</s>" -> eosTokenId = id
+                                content == "<unk>" -> unkTokenId = id
+                            }
+                        }
+                    }
+                }
+            }
+
+            val totalVocabSize = maxOf(maxId + 1, (vocabMap.values.maxOrNull() ?: 0) + 1)
+            val vocab = MutableList(totalVocabSize) { "<unk>" }
+            for ((token, id) in vocabMap) {
+                if (id < vocab.size) vocab[id] = token
+            }
+
+            if (debug) println("DEBUG: Total vocab size = ${vocab.size}, BOS=$bosTokenId, EOS=$eosTokenId")
+
+            // --- Parse merges: ["tok1 tok2", ...] → scores (earlier merge = higher score) ---
+            val scores = FloatArray(vocab.size) { 0f }
+            val mergesStart = json.indexOf("\"merges\"")
+            if (mergesStart >= 0) {
+                val mergesArrStart = json.indexOf('[', mergesStart)
+                if (mergesArrStart >= 0) {
+                    val mergesArrEnd = findMatchingBracket(json, mergesArrStart)
+                    val mergesContent = json.substring(mergesArrStart + 1, mergesArrEnd)
+                    val mergePattern = Regex("\"((?:[^\"\\\\]|\\\\.)*)\"")
+                    var mergeRank = 0
+                    for (match in mergePattern.findAll(mergesContent)) {
+                        val merge = unescapeJsonString(match.groupValues[1])
+                        val parts = merge.split(' ', limit = 2)
+                        if (parts.size == 2) {
+                            val merged = parts[0] + parts[1]
+                            val mergedId = vocabMap[merged]
+                            if (mergedId != null && mergedId < scores.size) {
+                                // Higher score = higher merge priority (earlier in list)
+                                scores[mergedId] = (1_000_000 - mergeRank).toFloat()
+                            }
+                            mergeRank++
+                        }
+                    }
+                    if (debug) println("DEBUG: Parsed $mergeRank merges")
+                }
+            }
+
+            val strategy = BPEStrategy
+            println("Tokenizer: BPE (from tokenizer.json, vocab=${vocab.size})")
+
+            return GGUFTokenizer(vocab, scores, bosTokenId, eosTokenId, unkTokenId, strategy)
+        }
+
+        private fun findMatchingBrace(s: String, start: Int): Int {
+            var depth = 0
+            var inStr = false
+            var i = start
+            while (i < s.length) {
+                val c = s[i]
+                when {
+                    inStr -> { if (c == '"') inStr = false; if (c == '\\') i++ }
+                    c == '"' -> inStr = true
+                    c == '{' -> depth++
+                    c == '}' -> { depth--; if (depth == 0) return i }
+                }
+                i++
+            }
+            return s.length - 1
+        }
+
+        private fun findMatchingBracket(s: String, start: Int): Int {
+            var depth = 0
+            var inStr = false
+            var i = start
+            while (i < s.length) {
+                val c = s[i]
+                when {
+                    inStr -> { if (c == '"') inStr = false; if (c == '\\') i++ }
+                    c == '"' -> inStr = true
+                    c == '[' -> depth++
+                    c == ']' -> { depth--; if (depth == 0) return i }
+                }
+                i++
+            }
+            return s.length - 1
+        }
+
+        private fun unescapeJsonString(s: String): String {
+            val sb = StringBuilder()
+            var i = 0
+            while (i < s.length) {
+                if (s[i] == '\\' && i + 1 < s.length) {
+                    when (s[i + 1]) {
+                        '"' -> { sb.append('"'); i += 2 }
+                        '\\' -> { sb.append('\\'); i += 2 }
+                        '/' -> { sb.append('/'); i += 2 }
+                        'n' -> { sb.append('\n'); i += 2 }
+                        'r' -> { sb.append('\r'); i += 2 }
+                        't' -> { sb.append('\t'); i += 2 }
+                        'u' -> {
+                            if (i + 5 < s.length) {
+                                val cp = s.substring(i + 2, i + 6).toInt(16)
+                                sb.append(cp.toChar())
+                                i += 6
+                            } else { sb.append(s[i]); i++ }
+                        }
+                        else -> { sb.append(s[i]); i++ }
+                    }
+                } else { sb.append(s[i]); i++ }
+            }
+            return sb.toString()
+        }
+
+        /**
          * Create a tokenizer by reading GGUF metadata from a source.
          * Only reads metadata (not tensor data) for efficiency.
          */

--- a/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaConfigParser.kt
+++ b/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaConfigParser.kt
@@ -1,0 +1,148 @@
+package sk.ainet.apps.kllama
+
+import sk.ainet.io.gguf.llama.LlamaModelMetadata
+
+/**
+ * Parses HuggingFace `config.json` into [LlamaModelMetadata].
+ *
+ * Uses lightweight manual JSON parsing to avoid external dependencies.
+ */
+public object LlamaConfigParser {
+
+    /**
+     * Parse a HuggingFace config.json string into LlamaModelMetadata.
+     *
+     * Required fields: hidden_size, num_hidden_layers, num_attention_heads,
+     * num_key_value_heads, intermediate_size, vocab_size.
+     * Optional: max_position_embeddings, head_dim, model_type.
+     */
+    public fun parse(json: String): LlamaModelMetadata {
+        val map = parseJsonObject(json.trim())
+
+        val hiddenSize = map.requireInt("hidden_size")
+        val numLayers = map.requireInt("num_hidden_layers")
+        val numHeads = map.requireInt("num_attention_heads")
+        val numKvHeads = map.intOrNull("num_key_value_heads") ?: numHeads
+        val intermediateSize = map.requireInt("intermediate_size")
+        val vocabSize = map.requireInt("vocab_size")
+        val contextLength = map.intOrNull("max_position_embeddings") ?: 2048
+        val headDim = map.intOrNull("head_dim") ?: (hiddenSize / numHeads)
+        val architecture = map.stringOrNull("model_type") ?: "llama"
+
+        return LlamaModelMetadata(
+            architecture = architecture,
+            embeddingLength = hiddenSize,
+            contextLength = contextLength,
+            blockCount = numLayers,
+            headCount = numHeads,
+            kvHeadCount = numKvHeads,
+            feedForwardLength = intermediateSize,
+            ropeDimensionCount = headDim,
+            vocabSize = vocabSize
+        )
+    }
+
+    /**
+     * Check if config.json indicates tied word embeddings.
+     */
+    public fun isTiedEmbeddings(json: String): Boolean {
+        val map = parseJsonObject(json.trim())
+        return map["tie_word_embeddings"] == "true"
+    }
+
+    // ========== Lightweight JSON parsing ==========
+
+    private fun parseJsonObject(json: String): Map<String, String> {
+        if (!json.startsWith("{") || !json.endsWith("}")) {
+            error("config.json: expected JSON object")
+        }
+        val content = json.substring(1, json.length - 1)
+        val result = mutableMapOf<String, String>()
+
+        var i = 0
+        while (i < content.length) {
+            // Skip whitespace
+            while (i < content.length && content[i].isWhitespace()) i++
+            if (i >= content.length) break
+
+            // Parse key
+            if (content[i] != '"') { i++; continue }
+            val keyEnd = findStringEnd(content, i)
+            val key = content.substring(i + 1, keyEnd)
+            i = keyEnd + 1
+
+            // Skip colon
+            while (i < content.length && (content[i].isWhitespace() || content[i] == ':')) i++
+
+            // Parse value
+            val valueStart = i
+            i = skipValue(content, i)
+            var value = content.substring(valueStart, i).trim()
+            // Strip quotes from string values
+            if (value.startsWith("\"") && value.endsWith("\"")) {
+                value = value.substring(1, value.length - 1)
+            }
+            result[key] = value
+
+            // Skip comma
+            while (i < content.length && (content[i].isWhitespace() || content[i] == ',')) i++
+        }
+
+        return result
+    }
+
+    private fun findStringEnd(s: String, start: Int): Int {
+        var i = start + 1
+        while (i < s.length) {
+            when (s[i]) {
+                '"' -> return i
+                '\\' -> i += 2
+                else -> i++
+            }
+        }
+        return s.length
+    }
+
+    private fun skipValue(s: String, start: Int): Int {
+        if (start >= s.length) return start
+        return when (s[start]) {
+            '"' -> findStringEnd(s, start) + 1
+            '{' -> findMatching(s, start, '{', '}')
+            '[' -> findMatching(s, start, '[', ']')
+            else -> {
+                var i = start
+                while (i < s.length && s[i] != ',' && s[i] != '}' && s[i] != ']') i++
+                i
+            }
+        }
+    }
+
+    private fun findMatching(s: String, start: Int, open: Char, close: Char): Int {
+        var depth = 0
+        var i = start
+        var inString = false
+        while (i < s.length) {
+            val c = s[i]
+            when {
+                inString -> {
+                    if (c == '"') inString = false
+                    else if (c == '\\') i++
+                }
+                c == '"' -> inString = true
+                c == open -> depth++
+                c == close -> { depth--; if (depth == 0) return i + 1 }
+            }
+            i++
+        }
+        return s.length
+    }
+
+    private fun Map<String, String>.requireInt(key: String): Int =
+        this[key]?.toIntOrNull() ?: error("config.json: missing or invalid '$key'")
+
+    private fun Map<String, String>.intOrNull(key: String): Int? =
+        this[key]?.toIntOrNull()
+
+    private fun Map<String, String>.stringOrNull(key: String): String? =
+        this[key]?.takeIf { it.isNotBlank() }
+}

--- a/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaIngestion.kt
+++ b/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaIngestion.kt
@@ -3,6 +3,7 @@ package sk.ainet.apps.kllama
 import kotlinx.io.Source
 import sk.ainet.context.ExecutionContext
 import sk.ainet.io.RandomAccessSource
+import sk.ainet.io.gguf.llama.LlamaModelMetadata
 import sk.ainet.io.gguf.llama.LlamaRuntimeWeights
 import sk.ainet.io.gguf.llama.LlamaWeightLoader
 import sk.ainet.io.gguf.llama.loadLlamaRuntimeWeights
@@ -60,5 +61,27 @@ public class LlamaIngestion<T : DType>(
             quantPolicy = config.quantPolicy,
             allowQuantized = config.allowQuantized
         )
+    }
+
+    /**
+     * Load LLaMA runtime weights from a HuggingFace SafeTensors file.
+     * Handles Q4+qb dequantization, BF16→FP32, name mapping, and tied embeddings.
+     *
+     * @param randomAccessProvider Factory that provides RandomAccessSource to the .safetensors file
+     * @param metadata Model metadata parsed from config.json via [LlamaConfigParser]
+     * @param tiedEmbeddings Whether output weight is tied to token embeddings
+     */
+    public fun loadSafeTensors(
+        randomAccessProvider: () -> RandomAccessSource,
+        metadata: LlamaModelMetadata,
+        tiedEmbeddings: Boolean = false
+    ): LlamaRuntimeWeights<T> {
+        val loader = LlamaSafeTensorsLoader(
+            ctx = ctx,
+            dtype = dtype,
+            metadata = metadata,
+            tiedEmbeddings = tiedEmbeddings
+        )
+        return loader.load(randomAccessProvider)
     }
 }

--- a/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaSafeTensorsLoader.kt
+++ b/skainet-apps/skainet-kllama/src/commonMain/kotlin/sk/ainet/apps/kllama/LlamaSafeTensorsLoader.kt
@@ -1,0 +1,292 @@
+package sk.ainet.apps.kllama
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.io.RandomAccessSource
+import sk.ainet.io.gguf.llama.LlamaModelMetadata
+import sk.ainet.io.gguf.llama.LlamaRuntimeWeights
+import sk.ainet.io.gguf.llama.LlamaWeightMapper
+import sk.ainet.io.gguf.llama.LlamaWeights
+import sk.ainet.io.gguf.llama.LlamaTensorNames
+import sk.ainet.io.model.DataType
+import sk.ainet.io.safetensors.StreamingSafeTensorsReader
+import sk.ainet.io.safetensors.StreamingSafeTensorInfo
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.types.DType
+import sk.ainet.lang.types.FP32
+import kotlin.math.pow
+import kotlin.reflect.KClass
+
+/**
+ * Loads LLaMA weights from HuggingFace SafeTensors format and maps them to
+ * the canonical GGUF tensor naming used by [LlamaWeightMapper].
+ *
+ * Handles:
+ * - HuggingFace → GGUF tensor name mapping
+ * - Q4 + .qb companion tensor dequantization to FP32
+ * - BF16/F16 dequantization to FP32
+ * - Shape normalization ([1, dim] norms → [dim])
+ * - Tied word embeddings (output.weight = token_embd.weight)
+ */
+public class LlamaSafeTensorsLoader<T : DType>(
+    private val ctx: ExecutionContext,
+    private val dtype: KClass<T>,
+    private val metadata: LlamaModelMetadata,
+    private val tiedEmbeddings: Boolean = false
+) {
+
+    /**
+     * Load weights from SafeTensors file and return [LlamaRuntimeWeights].
+     */
+    public fun load(randomAccessProvider: () -> RandomAccessSource): LlamaRuntimeWeights<T> {
+        val tensors = mutableMapOf<String, Tensor<T, Float>>()
+
+        StreamingSafeTensorsReader.open(randomAccessProvider()).use { reader ->
+            // Index all tensors by name for companion lookup
+            val tensorInfoMap = reader.tensors.associateBy { it.name }
+
+            // Process non-qb tensors
+            for (info in reader.tensors) {
+                if (info.name.endsWith(".qb")) continue  // handled as companion
+
+                val canonicalName = HfTensorNameMapper.toCanonical(info.name) ?: continue
+
+                val tensor = when (info.dataType) {
+                    DataType.QUANT4 -> {
+                        // Q4 with companion .qb scales → dequant to FP32
+                        val qbName = info.name + ".qb"
+                        val qbInfo = tensorInfoMap[qbName]
+                        val rawQ4 = reader.loadTensorData(info)
+                        val qbBytes = qbInfo?.let { reader.loadTensorData(it) }
+                        val targetShape = inferShape(canonicalName, info.shape)
+                        val floats = dequantQ4(rawQ4, qbBytes, info.shape, qbInfo?.shape)
+                        @Suppress("UNCHECKED_CAST")
+                        ctx.fromFloatArray<T, Float>(targetShape, dtype, floats) as Tensor<T, Float>
+                    }
+                    DataType.BFLOAT16 -> {
+                        val bytes = reader.loadTensorData(info)
+                        val floats = dequantBF16(bytes)
+                        val targetShape = normalizeNormShape(info.shape)
+                        @Suppress("UNCHECKED_CAST")
+                        ctx.fromFloatArray<T, Float>(targetShape, dtype, floats) as Tensor<T, Float>
+                    }
+                    DataType.FLOAT16 -> {
+                        val bytes = reader.loadTensorData(info)
+                        val floats = dequantF16(bytes)
+                        val targetShape = normalizeNormShape(info.shape)
+                        @Suppress("UNCHECKED_CAST")
+                        ctx.fromFloatArray<T, Float>(targetShape, dtype, floats) as Tensor<T, Float>
+                    }
+                    DataType.FLOAT32 -> {
+                        val bytes = reader.loadTensorData(info)
+                        val floats = bytesToFloatArray(bytes)
+                        val targetShape = normalizeNormShape(info.shape)
+                        @Suppress("UNCHECKED_CAST")
+                        ctx.fromFloatArray<T, Float>(targetShape, dtype, floats) as Tensor<T, Float>
+                    }
+                    else -> {
+                        println("WARNING: Skipping tensor '${info.name}' with unsupported dtype ${info.dtype}")
+                        continue
+                    }
+                }
+
+                tensors[canonicalName] = tensor
+                println("  Loaded: ${info.name} (${info.dtype} ${info.shape}) → $canonicalName ${tensor.shape}")
+            }
+        }
+
+        // Handle tied embeddings: reuse token_embd as output.weight
+        if (tiedEmbeddings && !tensors.containsKey(LlamaTensorNames.OUTPUT_WEIGHT)) {
+            val embedding = tensors[LlamaTensorNames.TOKEN_EMBEDDINGS]
+                ?: error("tie_word_embeddings=true but token embedding not found")
+            tensors[LlamaTensorNames.OUTPUT_WEIGHT] = embedding
+            println("  Tied: ${LlamaTensorNames.OUTPUT_WEIGHT} → ${LlamaTensorNames.TOKEN_EMBEDDINGS}")
+        }
+
+        val weights = LlamaWeights<T, Float>(
+            metadata = metadata,
+            tensors = tensors
+        )
+        return LlamaWeightMapper.map(weights)
+    }
+
+    /**
+     * Infer the target shape for a tensor, normalizing norm shapes.
+     * For Q4 tensors, the target shape is the logical shape (not the packed shape).
+     */
+    private fun inferShape(canonicalName: String, originalShape: List<Long>): Shape {
+        // Q4 tensors already have logical shapes in the header
+        return Shape(*originalShape.map { it.toInt() }.toIntArray())
+    }
+
+    /**
+     * Normalize norm shapes: [1, dim] → [dim] for 1D norm weights.
+     */
+    private fun normalizeNormShape(shape: List<Long>): Shape {
+        return if (shape.size == 2 && shape[0] == 1L) {
+            Shape(shape[1].toInt())
+        } else {
+            Shape(*shape.map { it.toInt() }.toIntArray())
+        }
+    }
+
+    // ========== Q4 Dequantization ==========
+
+    /**
+     * Dequantize Q4 (4-bit quantized) tensor using companion .qb scale tensor.
+     *
+     * Q4 packs two 4-bit values per byte. The .qb tensor provides per-group
+     * scale factors in FP32. Each group of 32 elements shares one scale factor.
+     */
+    private fun dequantQ4(
+        q4Bytes: ByteArray,
+        qbBytes: ByteArray?,
+        q4Shape: List<Long>,
+        qbShape: List<Long>?
+    ): FloatArray {
+        val rows = q4Shape[0].toInt()
+        val cols = q4Shape[1].toInt()
+        val totalElements = rows * cols
+        val out = FloatArray(totalElements)
+
+        if (qbBytes == null) {
+            // No scale tensor; just unpack nibbles to [-8, 7] range
+            for (i in 0 until totalElements) {
+                val byteIdx = i / 2
+                val nibble = if (i % 2 == 0) {
+                    (q4Bytes[byteIdx].toInt() and 0x0F)
+                } else {
+                    (q4Bytes[byteIdx].toInt() shr 4) and 0x0F
+                }
+                // Signed 4-bit: 0..7 → 0..7, 8..15 → -8..-1
+                out[i] = (if (nibble >= 8) nibble - 16 else nibble).toFloat()
+            }
+            return out
+        }
+
+        // Unpack .qb scales from FP32 bytes
+        val scales = bytesToFloatArray(qbBytes)
+
+        // Determine group size from shapes: each scale covers a group of elements
+        // qb shape is [rows, numGroups] where numGroups = cols / groupSize
+        val numGroups = if (qbShape != null && qbShape.size == 2) qbShape[1].toInt() else scales.size / rows
+        val groupSize = if (numGroups > 0) cols / numGroups else 32
+
+        for (row in 0 until rows) {
+            for (col in 0 until cols) {
+                val flatIdx = row * cols + col
+                val byteIdx = flatIdx / 2
+                val nibble = if (flatIdx % 2 == 0) {
+                    (q4Bytes[byteIdx].toInt() and 0x0F)
+                } else {
+                    (q4Bytes[byteIdx].toInt() shr 4) and 0x0F
+                }
+                // Signed 4-bit
+                val q = if (nibble >= 8) nibble - 16 else nibble
+                // Look up group scale
+                val groupIdx = col / groupSize
+                val scaleIdx = row * numGroups + groupIdx
+                val scale = if (scaleIdx < scales.size) scales[scaleIdx] else 1.0f
+                out[flatIdx] = q.toFloat() * scale
+            }
+        }
+
+        return out
+    }
+
+    // ========== BF16/F16 Dequantization ==========
+
+    private fun dequantBF16(bytes: ByteArray): FloatArray {
+        val out = FloatArray(bytes.size / 2)
+        for (i in out.indices) {
+            val offset = i * 2
+            val bf16Low = bytes[offset].toInt() and 0xFF
+            val bf16High = bytes[offset + 1].toInt() and 0xFF
+            val bits = (bf16High shl 24) or (bf16Low shl 16)
+            out[i] = Float.fromBits(bits)
+        }
+        return out
+    }
+
+    private fun dequantF16(bytes: ByteArray): FloatArray {
+        val out = FloatArray(bytes.size / 2)
+        for (i in out.indices) {
+            val offset = i * 2
+            val half = (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8)
+            out[i] = halfToFloat(half)
+        }
+        return out
+    }
+
+    private fun halfToFloat(hbits: Int): Float {
+        val mant = hbits and 0x03FF
+        val exp = hbits and 0x7C00
+        val sign = hbits and 0x8000
+        return when (exp) {
+            0 -> {
+                val v = (mant.toFloat() / 1024.0f) * (2.0f).pow(-14)
+                if (sign != 0) -v else v
+            }
+            0x7C00 -> {
+                val v = if (mant == 0) Float.POSITIVE_INFINITY else Float.NaN
+                if (sign != 0) -v else v
+            }
+            else -> {
+                val v = (1.0f + mant.toFloat() / 1024.0f) * (2.0f).pow((exp shr 10) - 15)
+                if (sign != 0) -v else v
+            }
+        }
+    }
+
+    private fun bytesToFloatArray(bytes: ByteArray): FloatArray {
+        val out = FloatArray(bytes.size / 4)
+        for (i in out.indices) {
+            val offset = i * 4
+            val bits = (bytes[offset].toInt() and 0xFF) or
+                    ((bytes[offset + 1].toInt() and 0xFF) shl 8) or
+                    ((bytes[offset + 2].toInt() and 0xFF) shl 16) or
+                    ((bytes[offset + 3].toInt() and 0xFF) shl 24)
+            out[i] = Float.fromBits(bits)
+        }
+        return out
+    }
+}
+
+/**
+ * Maps HuggingFace tensor names to GGUF canonical names used by [LlamaTensorNames].
+ */
+public object HfTensorNameMapper {
+
+    private val LAYER_PATTERN = Regex("""model\.layers\.(\d+)\.(.+)""")
+
+    /**
+     * Convert a HuggingFace tensor name to its GGUF canonical equivalent.
+     * Returns null if the tensor should be skipped (e.g. .qb companions).
+     */
+    public fun toCanonical(hfName: String): String? {
+        // Global tensors
+        return when (hfName) {
+            "model.embed_tokens.weight" -> LlamaTensorNames.TOKEN_EMBEDDINGS
+            "model.norm.weight" -> LlamaTensorNames.OUTPUT_NORM
+            "lm_head.weight" -> LlamaTensorNames.OUTPUT_WEIGHT
+            else -> {
+                // Layer tensors
+                val match = LAYER_PATTERN.matchEntire(hfName) ?: return null
+                val layer = match.groupValues[1].toInt()
+                when (match.groupValues[2]) {
+                    "input_layernorm.weight" -> LlamaTensorNames.attnNorm(layer)
+                    "self_attn.q_proj.weight" -> LlamaTensorNames.attnQ(layer)
+                    "self_attn.k_proj.weight" -> LlamaTensorNames.attnK(layer)
+                    "self_attn.v_proj.weight" -> LlamaTensorNames.attnV(layer)
+                    "self_attn.o_proj.weight" -> LlamaTensorNames.attnOut(layer)
+                    "post_attention_layernorm.weight" -> LlamaTensorNames.ffnNorm(layer)
+                    "mlp.gate_proj.weight" -> LlamaTensorNames.ffnGate(layer)
+                    "mlp.down_proj.weight" -> LlamaTensorNames.ffnDown(layer)
+                    "mlp.up_proj.weight" -> LlamaTensorNames.ffnUp(layer)
+                    else -> null
+                }
+            }
+        }
+    }
+}

--- a/skainet-apps/skainet-kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
+++ b/skainet-apps/skainet-kllama/src/jvmMain/kotlin/sk/ainet/apps/kllama/cli/Main.kt
@@ -1,6 +1,7 @@
 package sk.ainet.apps.kllama.cli
 
 import sk.ainet.apps.kllama.GGUFTokenizer
+import sk.ainet.apps.kllama.LlamaConfigParser
 import sk.ainet.apps.kllama.LlamaIngestion
 import sk.ainet.apps.kllama.LlamaLoadConfig
 import sk.ainet.apps.llm.Tokenizer
@@ -19,9 +20,13 @@ import java.nio.file.Path
 import java.nio.file.Files
 import kotlin.io.path.exists
 import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
 import kotlin.system.exitProcess
 import kotlin.time.measureTime
 import kotlinx.coroutines.runBlocking
+
+private enum class ModelFormat { GGUF, SAFETENSORS, BIN }
 
 private data class CliArgs(
     val modelPath: Path,
@@ -43,8 +48,8 @@ private fun usage(errorMessage: String? = null): Nothing {
     }
 
     println("Usage: kllama -m <model> [-t <tokenizer>] [-s <steps>] [-k <temperature>] [-p <systemprompt>] [--chat] [--agent] [--demo] [--template=NAME] <prompt>")
-    println("  -m, --model         Path to .gguf or .bin model (required)")
-    println("  -t, --tokenizer     Path to tokenizer.bin (required for .bin models, optional for .gguf)")
+    println("  -m, --model         Path to .gguf, .safetensors, .bin model, or HuggingFace directory (required)")
+    println("  -t, --tokenizer     Path to tokenizer (auto-detected for .gguf and .safetensors)")
     println("  -s, --steps         Generation steps (default: 64)")
     println("  -k, --temperature   Sampling temperature (default: 0.8)")
     println("  -p, --systemprompt  Optional system prompt prepended to user prompt")
@@ -166,6 +171,10 @@ private fun resolveModelPath(candidate: Path): Path {
     if (!candidate.exists()) error("Model not found: $candidate")
     if (!Files.isDirectory(candidate)) return candidate
 
+    // If directory contains model.safetensors, return directory for SafeTensors loading
+    val safetensorsModel = candidate.resolve("model.safetensors")
+    if (safetensorsModel.exists()) return candidate
+
     val modelCandidates = mutableListOf<Path>()
     Files.list(candidate).use { stream ->
         stream.forEach { entry ->
@@ -179,7 +188,7 @@ private fun resolveModelPath(candidate: Path): Path {
 
     when {
         modelCandidates.isEmpty() -> {
-            error("No .gguf or .bin model found in directory: $candidate")
+            error("No .gguf, .safetensors, or .bin model found in directory: $candidate")
         }
         modelCandidates.size > 1 -> {
             val choices = modelCandidates.sortedBy { it.fileName.toString() }.joinToString(", ")
@@ -193,20 +202,49 @@ private fun resolveModelPath(candidate: Path): Path {
     }
 }
 
+/**
+ * Detect model format from the given path.
+ * Supports: .gguf, .safetensors, .bin files, and directories containing model.safetensors.
+ */
+private fun detectFormat(path: Path): ModelFormat {
+    if (path.isDirectory()) {
+        // Check for safetensors model in directory
+        val st = path.resolve("model.safetensors")
+        if (st.exists()) return ModelFormat.SAFETENSORS
+        val gguf = path.toFile().listFiles()?.firstOrNull { it.extension == "gguf" }
+        if (gguf != null) return ModelFormat.GGUF
+        error("Directory $path does not contain model.safetensors or .gguf file")
+    }
+    return when (path.extension.lowercase()) {
+        "gguf" -> ModelFormat.GGUF
+        "safetensors" -> ModelFormat.SAFETENSORS
+        else -> ModelFormat.BIN
+    }
+}
+
+/**
+ * Resolve model directory: if path is a file, return its parent; if directory, return it.
+ */
+private fun resolveModelDir(path: Path): Path =
+    if (path.isDirectory()) path else path.parent ?: path
+
 fun main(args: Array<String>) {
     runBlocking {
         val cliArgs = parseArgs(args)
         val modelPath = resolveModelPath(cliArgs.modelPath)
-        val modelExt = modelPath.extension.lowercase()
-        if (modelExt == "safetensors") {
-            error("SafeTensors (.safetensors) is not supported by KLlama CLI yet. Use GGUF or llama2.c .bin.")
+        val format = detectFormat(modelPath)
+
+        // Resolve tokenizer: use explicit -t if provided, auto-discover for SafeTensors
+        val tokenizerPath: Path? = when {
+            cliArgs.tokenizerPath != null -> cliArgs.tokenizerPath
+            format == ModelFormat.SAFETENSORS -> {
+                val modelDir = resolveModelDir(modelPath)
+                val autoTokenizer = modelDir.resolve("tokenizer.json")
+                if (autoTokenizer.exists()) autoTokenizer else null
+            }
+            else -> null
         }
-        val isGguf = modelExt == "gguf"
-        if (!isGguf && modelExt.isNotEmpty() && modelExt != "bin") {
-            error("Unsupported model format '.$modelExt'. Expected .gguf or .bin (llama2.c).")
-        }
-        val tokenizerPath = cliArgs.tokenizerPath
-        if (!isGguf && tokenizerPath == null) {
+        if (format == ModelFormat.BIN && tokenizerPath == null) {
             error("Tokenizer path required for .bin models. Use -t/--tokenizer.")
         }
 
@@ -214,40 +252,78 @@ fun main(args: Array<String>) {
 
         val ctx = DirectCpuExecutionContext()
 
-        val runtimeWeights = if (isGguf) {
-            val ingestion = LlamaIngestion<FP32>(
-                ctx = ctx,
-                dtype = FP32::class,
-                config = LlamaLoadConfig(
-                    quantPolicy = LlamaWeightLoader.QuantPolicy.DEQUANTIZE_TO_FP32,
-                    allowQuantized = false
+        val runtimeWeights = when (format) {
+            ModelFormat.GGUF -> {
+                val ingestion = LlamaIngestion<FP32>(
+                    ctx = ctx,
+                    dtype = FP32::class,
+                    config = LlamaLoadConfig(
+                        quantPolicy = LlamaWeightLoader.QuantPolicy.DEQUANTIZE_TO_FP32,
+                        allowQuantized = false
+                    )
                 )
-            )
-            println("Loading GGUF model from $modelPath (streaming mode)...")
-            ingestion.loadStreaming {
-                JvmRandomAccessSource.open(modelPath.toString())
+                println("Loading GGUF model from $modelPath (streaming mode)...")
+                ingestion.loadStreaming {
+                    JvmRandomAccessSource.open(modelPath.toString())
+                }
             }
-        } else {
-            println("Loading Karpathy .bin model from $modelPath...")
-            modelPath.inputStream().use { input ->
-                Llama2DotCWeightLoader.load(ctx, input.asSource().buffered())
+            ModelFormat.SAFETENSORS -> {
+                val modelDir = resolveModelDir(modelPath)
+                val safetensorsFile = if (modelPath.isDirectory()) {
+                    modelDir.resolve("model.safetensors")
+                } else {
+                    modelPath
+                }
+                val configFile = modelDir.resolve("config.json")
+                if (!configFile.exists()) error("config.json not found in $modelDir")
+
+                println("Loading SafeTensors model from $safetensorsFile...")
+                val configJson = configFile.readText()
+                val metadata = LlamaConfigParser.parse(configJson)
+                val tiedEmbeddings = LlamaConfigParser.isTiedEmbeddings(configJson)
+                println("  Architecture: ${metadata.architecture}, layers=${metadata.blockCount}, " +
+                    "dim=${metadata.embeddingLength}, heads=${metadata.headCount}, " +
+                    "kvHeads=${metadata.kvHeadCount}, vocab=${metadata.vocabSize}")
+                if (tiedEmbeddings) println("  Tied word embeddings: output.weight = embed_tokens.weight")
+
+                val ingestion = LlamaIngestion<FP32>(ctx = ctx, dtype = FP32::class)
+                ingestion.loadSafeTensors(
+                    randomAccessProvider = { JvmRandomAccessSource.open(safetensorsFile.toString()) },
+                    metadata = metadata,
+                    tiedEmbeddings = tiedEmbeddings
+                )
+            }
+            ModelFormat.BIN -> {
+                println("Loading Karpathy .bin model from $modelPath...")
+                modelPath.inputStream().use { input ->
+                    Llama2DotCWeightLoader.load(ctx, input.asSource().buffered())
+                }
             }
         }
 
         val backend = CpuAttentionBackend<FP32>(ctx, runtimeWeights, FP32::class)
         val runtime = LlamaRuntime<FP32>(ctx, runtimeWeights, backend, FP32::class)
 
-        val tokenizer: Tokenizer = if (isGguf && tokenizerPath == null) {
-            println("Loading embedded GGUF tokenizer...")
-            JvmRandomAccessSource.open(modelPath.toString()).use { source ->
-                GGUFTokenizer.fromRandomAccessSource(source)
+        val tokenizer: Tokenizer = when {
+            format == ModelFormat.SAFETENSORS -> {
+                val tPath = tokenizerPath ?: error("tokenizer.json not found for SafeTensors model")
+                if (!tPath.exists()) error("Tokenizer not found: $tPath")
+                println("Loading tokenizer from $tPath...")
+                GGUFTokenizer.fromTokenizerJson(tPath.readText())
             }
-        } else {
-            val tPath = tokenizerPath ?: error("Tokenizer path required for .bin models")
-            if (!tPath.exists()) error("Tokenizer not found: $tPath")
-            println("Loading tokenizer from $tPath...")
-            tPath.inputStream().use { input ->
-                TokenizerUtils.buildTokenizer(input.asSource().buffered(), runtimeWeights.metadata.vocabSize)
+            format == ModelFormat.GGUF && tokenizerPath == null -> {
+                println("Loading embedded GGUF tokenizer...")
+                JvmRandomAccessSource.open(modelPath.toString()).use { source ->
+                    GGUFTokenizer.fromRandomAccessSource(source)
+                }
+            }
+            else -> {
+                val tPath = tokenizerPath ?: error("Tokenizer path required for .bin models")
+                if (!tPath.exists()) error("Tokenizer not found: $tPath")
+                println("Loading tokenizer from $tPath...")
+                tPath.inputStream().use { input ->
+                    TokenizerUtils.buildTokenizer(input.asSource().buffered(), runtimeWeights.metadata.vocabSize)
+                }
             }
         }
 

--- a/skainet-apps/skainet-llm/api/android/skainet-llm.api
+++ b/skainet-apps/skainet-llm/api/android/skainet-llm.api
@@ -29,6 +29,20 @@ public final class sk/ainet/apps/llm/tokenizer/BPEStrategy : sk/ainet/apps/llm/T
 	public fun preprocess (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class sk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer : sk/ainet/apps/llm/Tokenizer {
+	public static final field Companion Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer$Companion;
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;[FIIIZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decode (I)Ljava/lang/String;
+	public fun decode ([I)Ljava/lang/String;
+	public fun encode (Ljava/lang/String;)[I
+	public final fun getVocabSize ()I
+}
+
+public final class sk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer$Companion {
+	public final fun fromJson (Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer;
+	public static synthetic fun fromJson$default (Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer;
+}
+
 public final class sk/ainet/apps/llm/tokenizer/SentencePieceStrategy : sk/ainet/apps/llm/TokenizerStrategy {
 	public static final field INSTANCE Lsk/ainet/apps/llm/tokenizer/SentencePieceStrategy;
 	public fun getSpaceMarker ()Ljava/lang/String;

--- a/skainet-apps/skainet-llm/api/jvm/skainet-llm.api
+++ b/skainet-apps/skainet-llm/api/jvm/skainet-llm.api
@@ -29,6 +29,20 @@ public final class sk/ainet/apps/llm/tokenizer/BPEStrategy : sk/ainet/apps/llm/T
 	public fun preprocess (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class sk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer : sk/ainet/apps/llm/Tokenizer {
+	public static final field Companion Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer$Companion;
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;[FIIIZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decode (I)Ljava/lang/String;
+	public fun decode ([I)Ljava/lang/String;
+	public fun encode (Ljava/lang/String;)[I
+	public final fun getVocabSize ()I
+}
+
+public final class sk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer$Companion {
+	public final fun fromJson (Ljava/lang/String;Ljava/lang/String;)Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer;
+	public static synthetic fun fromJson$default (Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/apps/llm/tokenizer/HuggingFaceBPETokenizer;
+}
+
 public final class sk/ainet/apps/llm/tokenizer/SentencePieceStrategy : sk/ainet/apps/llm/TokenizerStrategy {
 	public static final field INSTANCE Lsk/ainet/apps/llm/tokenizer/SentencePieceStrategy;
 	public fun getSpaceMarker ()Ljava/lang/String;

--- a/skainet-backends/skainet-backend-cpu/api/android/skainet-backend-cpu.api
+++ b/skainet-backends/skainet-backend-cpu/api/android/skainet-backend-cpu.api
@@ -27,10 +27,12 @@ public final class sk/ainet/exec/tensor/ops/DefaultCpuOps : sk/ainet/exec/tensor
 
 public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/ops/TensorOps {
 	public fun <init> (Lsk/ainet/lang/tensor/data/TensorDataFactory;)V
+	public fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun broadcastShapes (Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Shape;
+	public fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv2d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;I)Lsk/ainet/lang/tensor/Tensor;
@@ -41,24 +43,29 @@ public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/o
 	protected final fun elementwise (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/jvm/functions/Function3;)Lsk/ainet/lang/tensor/Tensor;
 	public fun elu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun getDataFactory ()Lsk/ainet/lang/tensor/data/TensorDataFactory;
 	protected final fun gradStateFrom ([Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/GradState;
 	public fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun mapIndex ([ILsk/ainet/lang/tensor/Shape;)[I
 	public fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun newTensor (Lsk/ainet/lang/tensor/data/TensorData;Lkotlin/reflect/KClass;[Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun requireSameDType (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)V
 	public fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun split (Lsk/ainet/lang/tensor/Tensor;II)Ljava/util/List;
@@ -69,6 +76,7 @@ public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/o
 	public fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-backends/skainet-backend-cpu/api/jvm/skainet-backend-cpu.api
+++ b/skainet-backends/skainet-backend-cpu/api/jvm/skainet-backend-cpu.api
@@ -27,10 +27,12 @@ public final class sk/ainet/exec/tensor/ops/DefaultCpuOps : sk/ainet/exec/tensor
 
 public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/ops/TensorOps {
 	public fun <init> (Lsk/ainet/lang/tensor/data/TensorDataFactory;)V
+	public fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun broadcastShapes (Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Shape;
+	public fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv2d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;I)Lsk/ainet/lang/tensor/Tensor;
@@ -41,24 +43,29 @@ public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/o
 	protected final fun elementwise (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/jvm/functions/Function3;)Lsk/ainet/lang/tensor/Tensor;
 	public fun elu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun getDataFactory ()Lsk/ainet/lang/tensor/data/TensorDataFactory;
 	protected final fun gradStateFrom ([Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/GradState;
 	public fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun mapIndex ([ILsk/ainet/lang/tensor/Shape;)[I
 	public fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun newTensor (Lsk/ainet/lang/tensor/data/TensorData;Lkotlin/reflect/KClass;[Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	protected final fun requireSameDType (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)V
 	public fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun split (Lsk/ainet/lang/tensor/Tensor;II)Ljava/util/List;
@@ -69,6 +76,7 @@ public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/o
 	public fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-compile/skainet-compile-dag/api/android/skainet-compile-dag.api
+++ b/skainet-compile/skainet-compile-dag/api/android/skainet-compile-dag.api
@@ -70,9 +70,11 @@ public final class sk/ainet/lang/graph/DefaultGradientTape : sk/ainet/lang/graph
 	public fun <init> ()V
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun absBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun addBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun addScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun avgPool2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public fun clampBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun clear ()V
 	public fun computeGradients (Ljava/util/List;Ljava/util/List;)Ljava/util/Map;
 	public fun concatBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -93,11 +95,14 @@ public final class sk/ainet/lang/graph/DefaultGradientTape : sk/ainet/lang/graph
 	public fun meanBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun mulScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun multiplyBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public fun narrowBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public fun pad2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun rdivScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun recordOperation (Lsk/ainet/lang/tensor/ops/Operation;Ljava/util/List;Ljava/util/List;)V
 	public fun recordTrace (Lsk/ainet/lang/trace/OpTrace;)V
 	public fun reluBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun reshapeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public final fun resumeRecording ()V
 	public fun rsubScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun sigmoidBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun siluBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -109,6 +114,7 @@ public final class sk/ainet/lang/graph/DefaultGradientTape : sk/ainet/lang/graph
 	public fun subScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun subtractBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun sumBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public final fun suppressRecording ()V
 	public fun transposeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun unsqueezeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun upsample2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -122,6 +128,7 @@ public final class sk/ainet/lang/graph/DefaultGraphExecutionContext : sk/ainet/l
 	public fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/context/Phase;Lsk/ainet/lang/tensor/data/TensorDataFactory;Lsk/ainet/lang/nn/hooks/ForwardHooks;Lsk/ainet/context/MemoryInfo;Lsk/ainet/context/ExecutionStats;Lkotlin/jvm/functions/Function1;Lsk/ainet/lang/graph/ComputeGraph;Lsk/ainet/lang/trace/OpSink;)V
 	public synthetic fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/context/Phase;Lsk/ainet/lang/tensor/data/TensorDataFactory;Lsk/ainet/lang/nn/hooks/ForwardHooks;Lsk/ainet/context/MemoryInfo;Lsk/ainet/context/ExecutionStats;Lkotlin/jvm/functions/Function1;Lsk/ainet/lang/graph/ComputeGraph;Lsk/ainet/lang/trace/OpSink;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun backward (Ljava/util/List;Ljava/util/List;)V
+	public final fun clearSession ()V
 	public fun collectGarbage ()V
 	public fun fromByteArray (Lsk/ainet/lang/tensor/Shape;Lkotlin/reflect/KClass;[B)Lsk/ainet/lang/tensor/Tensor;
 	public fun fromData (Lsk/ainet/lang/tensor/data/TensorData;Lkotlin/reflect/KClass;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-compile/skainet-compile-dag/api/jvm/skainet-compile-dag.api
+++ b/skainet-compile/skainet-compile-dag/api/jvm/skainet-compile-dag.api
@@ -70,9 +70,11 @@ public final class sk/ainet/lang/graph/DefaultGradientTape : sk/ainet/lang/graph
 	public fun <init> ()V
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun absBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun addBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun addScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun avgPool2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public fun clampBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun clear ()V
 	public fun computeGradients (Ljava/util/List;Ljava/util/List;)Ljava/util/Map;
 	public fun concatBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -93,11 +95,14 @@ public final class sk/ainet/lang/graph/DefaultGradientTape : sk/ainet/lang/graph
 	public fun meanBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun mulScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun multiplyBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public fun narrowBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public fun pad2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun rdivScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun recordOperation (Lsk/ainet/lang/tensor/ops/Operation;Ljava/util/List;Ljava/util/List;)V
 	public fun recordTrace (Lsk/ainet/lang/trace/OpTrace;)V
 	public fun reluBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun reshapeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public final fun resumeRecording ()V
 	public fun rsubScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun sigmoidBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun siluBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -109,6 +114,7 @@ public final class sk/ainet/lang/graph/DefaultGradientTape : sk/ainet/lang/graph
 	public fun subScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun subtractBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun sumBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public final fun suppressRecording ()V
 	public fun transposeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun unsqueezeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public fun upsample2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -122,6 +128,7 @@ public final class sk/ainet/lang/graph/DefaultGraphExecutionContext : sk/ainet/l
 	public fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/context/Phase;Lsk/ainet/lang/tensor/data/TensorDataFactory;Lsk/ainet/lang/nn/hooks/ForwardHooks;Lsk/ainet/context/MemoryInfo;Lsk/ainet/context/ExecutionStats;Lkotlin/jvm/functions/Function1;Lsk/ainet/lang/graph/ComputeGraph;Lsk/ainet/lang/trace/OpSink;)V
 	public synthetic fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/context/Phase;Lsk/ainet/lang/tensor/data/TensorDataFactory;Lsk/ainet/lang/nn/hooks/ForwardHooks;Lsk/ainet/context/MemoryInfo;Lsk/ainet/context/ExecutionStats;Lkotlin/jvm/functions/Function1;Lsk/ainet/lang/graph/ComputeGraph;Lsk/ainet/lang/trace/OpSink;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun backward (Ljava/util/List;Ljava/util/List;)V
+	public final fun clearSession ()V
 	public fun collectGarbage ()V
 	public fun fromByteArray (Lsk/ainet/lang/tensor/Shape;Lkotlin/reflect/KClass;[B)Lsk/ainet/lang/tensor/Tensor;
 	public fun fromData (Lsk/ainet/lang/tensor/data/TensorData;Lkotlin/reflect/KClass;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/model/DTypeMapping.kt
+++ b/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/model/DTypeMapping.kt
@@ -45,6 +45,9 @@ public object DTypeMapping {
         DataType.UINT32 -> UInt32
         DataType.UINT16 -> UInt16
         DataType.UINT8 -> UInt8
+        // Quantized types
+        DataType.QUANT4 -> Int4  // Best approximation
+        DataType.QUANT8 -> Int8  // Best approximation
         // Types without direct SKaiNET mapping
         DataType.BOOL -> null  // Could map to Int8 but semantically different
         DataType.STRING -> null
@@ -134,6 +137,8 @@ public object DTypeMapping {
         DataType.UINT32 -> UInt32 to false
         DataType.UINT16 -> UInt16 to false
         DataType.UINT8 -> UInt8 to false
+        DataType.QUANT4 -> Int4 to true  // Lossy: needs dequantization
+        DataType.QUANT8 -> Int8 to true  // Lossy: needs dequantization
         DataType.BOOL -> Int8 to true  // Lossy: bool -> int8
         DataType.STRING -> null
         DataType.UNKNOWN -> null

--- a/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/model/DataType.kt
+++ b/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/model/DataType.kt
@@ -25,6 +25,10 @@ public enum class DataType(public val displayName: String, public val sizeInByte
     UINT16("uint16", 2),
     UINT8("uint8", 1),
 
+    // Quantized types (non-standard, used by frameworks like TinyFoA)
+    QUANT4("quant4", null),   // 4-bit quantized, variable block size
+    QUANT8("quant8", null),   // 8-bit quantized, variable block size
+
     // Other types
     BOOL("bool", 1),
     STRING("string", null),  // Variable size

--- a/skainet-io/skainet-io-core/src/commonTest/kotlin/sk/ainet/io/model/DTypeMappingTest.kt
+++ b/skainet-io/skainet-io-core/src/commonTest/kotlin/sk/ainet/io/model/DTypeMappingTest.kt
@@ -147,7 +147,7 @@ class DTypeMappingTest {
     @Test
     fun testNativelySupportedTypesCount() {
         val supported = DTypeMapping.nativelySupportedTypes()
-        assertEquals(12, supported.size, "Should have 12 natively supported types")
+        assertEquals(14, supported.size, "Should have 14 natively supported types")
     }
 
     @Test

--- a/skainet-io/skainet-io-safetensors/src/commonMain/kotlin/sk/ainet/io/safetensors/Constants.kt
+++ b/skainet-io/skainet-io-safetensors/src/commonMain/kotlin/sk/ainet/io/safetensors/Constants.kt
@@ -38,7 +38,11 @@ object SafeTensorsDataTypes {
     const val F32 = "F32"
     const val F64 = "F64"
 
-    /** Size in bytes for each data type */
+    // Non-standard quantized types used by some frameworks (e.g. TinyFoA)
+    const val Q4 = "Q4"
+    const val Q8 = "Q8"
+
+    /** Size in bytes for each data type. Quantized types use half-byte packing. */
     val SIZES: Map<String, Int> = mapOf(
         BOOL to 1,
         U8 to 1,
@@ -53,6 +57,7 @@ object SafeTensorsDataTypes {
         BF16 to 2,
         F32 to 4,
         F64 to 8
+        // Q4/Q8 sizes are not fixed per-element; computed from data_offsets
     )
 
     /** Get size in bytes for a dtype, returns null for unknown types */

--- a/skainet-io/skainet-io-safetensors/src/commonMain/kotlin/sk/ainet/io/safetensors/SafeTensorsDataTypeMapper.kt
+++ b/skainet-io/skainet-io-safetensors/src/commonMain/kotlin/sk/ainet/io/safetensors/SafeTensorsDataTypeMapper.kt
@@ -30,6 +30,8 @@ object SafeTensorsDataTypeMapper {
             "BF16" -> DataType.BFLOAT16
             "F32" -> DataType.FLOAT32
             "F64" -> DataType.FLOAT64
+            "Q4" -> DataType.QUANT4
+            "Q8" -> DataType.QUANT8
             else -> {
                 println("WARNING: Unknown SafeTensors dtype: $safeTensorsType")
                 DataType.UNKNOWN
@@ -58,6 +60,8 @@ object SafeTensorsDataTypeMapper {
             DataType.BFLOAT16 -> "BF16"
             DataType.FLOAT32 -> "F32"
             DataType.FLOAT64 -> "F64"
+            DataType.QUANT4 -> "Q4"
+            DataType.QUANT8 -> "Q8"
             DataType.STRING -> null  // SafeTensors doesn't support strings
             DataType.UNKNOWN -> null
         }

--- a/skainet-lang/skainet-lang-core/api/android/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/android/skainet-lang-core.api
@@ -1800,6 +1800,15 @@ public final class sk/ainet/lang/nn/normalization/LayerNormalization : sk/ainet/
 	public fun getParams ()Ljava/util/List;
 }
 
+public final class sk/ainet/lang/nn/normalization/RMSNormalization : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
+	public fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;)V
+	public synthetic fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun forward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/context/ExecutionContext;)Lsk/ainet/lang/tensor/Tensor;
+	public fun getModules ()Ljava/util/List;
+	public fun getName ()Ljava/lang/String;
+	public fun getParams ()Ljava/util/List;
+}
+
 public final class sk/ainet/lang/nn/optim/AdamKt {
 	public static final fun adam (DDDDDZZ)Lsk/ainet/lang/nn/optim/Optimizer;
 	public static synthetic fun adam$default (DDDDDZZILjava/lang/Object;)Lsk/ainet/lang/nn/optim/Optimizer;
@@ -2271,8 +2280,10 @@ public final class sk/ainet/lang/tensor/Tensor$DefaultImpls {
 }
 
 public final class sk/ainet/lang/tensor/TensorExtensionsKt {
+	public static final fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun avgPool2d$default (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun cosineDistance (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;ID)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun cosineDistance$default (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IDILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun div (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
@@ -2282,27 +2293,34 @@ public final class sk/ainet/lang/tensor/TensorExtensionsKt {
 	public static synthetic fun elu$default (Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun flatten$default (Lsk/ainet/lang/tensor/Tensor;IIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun leakyRelu$default (Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun mean$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun plus (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun plus (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun plus (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun softmax$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun sqrt (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun squeeze (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
+	public static synthetic fun squeeze$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun sum$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun t (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
@@ -2311,6 +2329,8 @@ public final class sk/ainet/lang/tensor/TensorExtensionsKt {
 	public static final fun times (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun tril$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun upsample2d$default (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
@@ -2418,6 +2438,7 @@ public final class sk/ainet/lang/tensor/benchmark/SlicingBenchmarksKt {
 
 public final class sk/ainet/lang/tensor/data/DenseFloatArrayTensorData : sk/ainet/lang/tensor/data/FloatArrayTensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[F)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Float;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBuffer ()[F
@@ -2428,6 +2449,7 @@ public final class sk/ainet/lang/tensor/data/DenseFloatArrayTensorData : sk/aine
 
 public final class sk/ainet/lang/tensor/data/DenseIntArrayTensorData : sk/ainet/lang/tensor/data/IntArrayTensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[I)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Integer;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBuffer ()[I
@@ -2462,11 +2484,20 @@ public final class sk/ainet/lang/tensor/data/DenseTensorDataFactory : sk/ainet/l
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/FloatArrayTensorData : sk/ainet/lang/tensor/data/TensorData {
+	public fun copyToFloatArray ()[F
 	public abstract fun getBuffer ()[F
+}
+
+public final class sk/ainet/lang/tensor/data/FloatArrayTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/FloatArrayTensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/IntArrayTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public abstract fun getBuffer ()[I
+}
+
+public final class sk/ainet/lang/tensor/data/IntArrayTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/IntArrayTensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/ItemsAccessor {
@@ -2481,6 +2512,7 @@ public final class sk/ainet/lang/tensor/data/PprintKt {
 public final class sk/ainet/lang/tensor/data/Q4_KBlockTensorData : sk/ainet/lang/tensor/data/Q4_KTensorData {
 	public static final field Companion Lsk/ainet/lang/tensor/data/Q4_KBlockTensorData$Companion;
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[B)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Byte;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBlockCount ()I
@@ -2521,6 +2553,10 @@ public final class sk/ainet/lang/tensor/data/Q4_KTensorData$Companion {
 	public static final field SUB_BLOCK_SIZE I
 }
 
+public final class sk/ainet/lang/tensor/data/Q4_KTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/Q4_KTensorData;)[F
+}
+
 public final class sk/ainet/lang/tensor/data/Q4_KTensorDataKt {
 	public static final fun toFloatArray (Lsk/ainet/lang/tensor/data/Q4_KTensorData;)[F
 }
@@ -2528,6 +2564,7 @@ public final class sk/ainet/lang/tensor/data/Q4_KTensorDataKt {
 public final class sk/ainet/lang/tensor/data/Q8_0BlockTensorData : sk/ainet/lang/tensor/data/Q8_0TensorData {
 	public static final field Companion Lsk/ainet/lang/tensor/data/Q8_0BlockTensorData$Companion;
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[B)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Byte;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBlockCount ()I
@@ -2558,12 +2595,21 @@ public final class sk/ainet/lang/tensor/data/Q8_0TensorData$Companion {
 	public static final field BYTES_PER_BLOCK I
 }
 
+public final class sk/ainet/lang/tensor/data/Q8_0TensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/Q8_0TensorData;)[F
+}
+
 public final class sk/ainet/lang/tensor/data/Q8_0TensorDataKt {
 	public static final fun toFloatArray (Lsk/ainet/lang/tensor/data/Q8_0TensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/TensorData : sk/ainet/lang/tensor/data/ItemsAccessor {
+	public fun copyToFloatArray ()[F
 	public abstract fun getShape ()Lsk/ainet/lang/tensor/Shape;
+}
+
+public final class sk/ainet/lang/tensor/data/TensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/TensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/TensorDataFactory {
@@ -2590,6 +2636,7 @@ public final class sk/ainet/lang/tensor/data/Ternary2BitTensorData : sk/ainet/la
 	public static final field Companion Lsk/ainet/lang/tensor/data/Ternary2BitTensorData$Companion;
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[BF)V
 	public synthetic fun <init> (Lsk/ainet/lang/tensor/Shape;[BFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Byte;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getPackedData ()[B
@@ -2609,6 +2656,10 @@ public final class sk/ainet/lang/tensor/data/Ternary2BitTensorData$Companion {
 public abstract interface class sk/ainet/lang/tensor/data/TernaryTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public abstract fun getPackedData ()[B
 	public abstract fun getScale ()F
+}
+
+public final class sk/ainet/lang/tensor/data/TernaryTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/TernaryTensorData;)[F
 }
 
 public final class sk/ainet/lang/tensor/data/TernaryTensorDataKt {
@@ -2666,6 +2717,7 @@ public final class sk/ainet/lang/tensor/data/dense/DenseTernaryTensorArray$Compa
 
 public final class sk/ainet/lang/tensor/data/views/UnsqueezedTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/data/TensorData;I)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Object;
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
 	public fun set ([ILjava/lang/Object;)V
@@ -3030,9 +3082,11 @@ public final class sk/ainet/lang/tensor/ops/Conv2dOperation : sk/ainet/lang/tens
 }
 
 public abstract interface class sk/ainet/lang/tensor/ops/DifferentiableTensorOps {
+	public abstract fun absBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun addBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun addScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun avgPool2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public abstract fun clampBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun concatBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun conv1dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun conv2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -3049,6 +3103,8 @@ public abstract interface class sk/ainet/lang/tensor/ops/DifferentiableTensorOps
 	public abstract fun meanBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun mulScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun multiplyBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public abstract fun narrowBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public abstract fun pad2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun rdivScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun reluBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun reshapeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -3113,9 +3169,11 @@ public final class sk/ainet/lang/tensor/ops/InputOperation : sk/ainet/lang/tenso
 public final class sk/ainet/lang/tensor/ops/KspTensorOps : sk/ainet/lang/tensor/ops/TensorOps {
 	public fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/trace/OpSink;Lsk/ainet/lang/trace/TraceSession;)V
 	public synthetic fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/trace/OpSink;Lsk/ainet/lang/trace/TraceSession;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
+	public fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv2d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;I)Lsk/ainet/lang/tensor/Tensor;
@@ -3125,19 +3183,24 @@ public final class sk/ainet/lang/tensor/ops/KspTensorOps : sk/ainet/lang/tensor/
 	public fun divide (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun elu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun split (Lsk/ainet/lang/tensor/Tensor;II)Ljava/util/List;
@@ -3148,6 +3211,7 @@ public final class sk/ainet/lang/tensor/ops/KspTensorOps : sk/ainet/lang/tensor/
 	public fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
@@ -3282,10 +3346,12 @@ public final class sk/ainet/lang/tensor/ops/SubtractOperation : sk/ainet/lang/te
 }
 
 public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
+	public abstract fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun avgPool2d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun conv1d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIIIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3300,11 +3366,13 @@ public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
 	public static synthetic fun elu$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun flatten$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun leakyRelu$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun maxPool2d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3312,11 +3380,14 @@ public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
 	public static synthetic fun mean$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun softmax$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3331,6 +3402,7 @@ public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
 	public abstract fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun tril$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun upsample2d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3446,9 +3518,11 @@ public final class sk/ainet/lang/tensor/ops/ValidationResult$Valid : sk/ainet/la
 
 public final class sk/ainet/lang/tensor/ops/VoidTensorOps : sk/ainet/lang/tensor/ops/TensorOps {
 	public fun <init> ()V
+	public fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
+	public fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv2d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;I)Lsk/ainet/lang/tensor/Tensor;
@@ -3458,19 +3532,24 @@ public final class sk/ainet/lang/tensor/ops/VoidTensorOps : sk/ainet/lang/tensor
 	public fun divide (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun elu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun split (Lsk/ainet/lang/tensor/Tensor;II)Ljava/util/List;
@@ -3481,6 +3560,7 @@ public final class sk/ainet/lang/tensor/ops/VoidTensorOps : sk/ainet/lang/tensor
 	public fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
@@ -3544,6 +3624,7 @@ public final class sk/ainet/lang/trace/TensorRef {
 
 public class sk/ainet/lang/trace/TraceSession {
 	public fun <init> ()V
+	public final fun clear ()V
 	public fun refOf (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/trace/TensorRef;
 	public final fun refsOf (Ljava/util/List;)Ljava/util/List;
 	public fun resolve (Ljava/lang/String;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
@@ -1800,6 +1800,15 @@ public final class sk/ainet/lang/nn/normalization/LayerNormalization : sk/ainet/
 	public fun getParams ()Ljava/util/List;
 }
 
+public final class sk/ainet/lang/nn/normalization/RMSNormalization : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
+	public fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;)V
+	public synthetic fun <init> ([IDLjava/lang/String;Lsk/ainet/lang/tensor/Tensor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun forward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/context/ExecutionContext;)Lsk/ainet/lang/tensor/Tensor;
+	public fun getModules ()Ljava/util/List;
+	public fun getName ()Ljava/lang/String;
+	public fun getParams ()Ljava/util/List;
+}
+
 public final class sk/ainet/lang/nn/optim/AdamKt {
 	public static final fun adam (DDDDDZZ)Lsk/ainet/lang/nn/optim/Optimizer;
 	public static synthetic fun adam$default (DDDDDZZILjava/lang/Object;)Lsk/ainet/lang/nn/optim/Optimizer;
@@ -2288,8 +2297,10 @@ public class sk/ainet/lang/tensor/TensorCreationBenchmark {
 }
 
 public final class sk/ainet/lang/tensor/TensorExtensionsKt {
+	public static final fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun avgPool2d$default (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun cosineDistance (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;ID)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun cosineDistance$default (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IDILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun div (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
@@ -2299,27 +2310,34 @@ public final class sk/ainet/lang/tensor/TensorExtensionsKt {
 	public static synthetic fun elu$default (Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun flatten$default (Lsk/ainet/lang/tensor/Tensor;IIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun leakyRelu$default (Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun mean$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun plus (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun plus (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun plus (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun softmax$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun sqrt (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun squeeze (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
+	public static synthetic fun squeeze$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun sum$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun t (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
@@ -2328,6 +2346,8 @@ public final class sk/ainet/lang/tensor/TensorExtensionsKt {
 	public static final fun times (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun tril$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun upsample2d$default (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
@@ -2435,6 +2455,7 @@ public final class sk/ainet/lang/tensor/benchmark/SlicingBenchmarksKt {
 
 public final class sk/ainet/lang/tensor/data/DenseFloatArrayTensorData : sk/ainet/lang/tensor/data/FloatArrayTensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[F)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Float;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBuffer ()[F
@@ -2445,6 +2466,7 @@ public final class sk/ainet/lang/tensor/data/DenseFloatArrayTensorData : sk/aine
 
 public final class sk/ainet/lang/tensor/data/DenseIntArrayTensorData : sk/ainet/lang/tensor/data/IntArrayTensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[I)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Integer;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBuffer ()[I
@@ -2479,15 +2501,28 @@ public final class sk/ainet/lang/tensor/data/DenseTensorDataFactory : sk/ainet/l
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/FloatArrayTensorData : sk/ainet/lang/tensor/data/TensorData {
+	public fun copyToFloatArray ()[F
 	public abstract fun getBuffer ()[F
+}
+
+public final class sk/ainet/lang/tensor/data/FloatArrayTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/FloatArrayTensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/FloatBufferTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public abstract fun getFloatBuffer ()Ljava/nio/FloatBuffer;
 }
 
+public final class sk/ainet/lang/tensor/data/FloatBufferTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/FloatBufferTensorData;)[F
+}
+
 public abstract interface class sk/ainet/lang/tensor/data/IntArrayTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public abstract fun getBuffer ()[I
+}
+
+public final class sk/ainet/lang/tensor/data/IntArrayTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/IntArrayTensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/ItemsAccessor {
@@ -2497,6 +2532,7 @@ public abstract interface class sk/ainet/lang/tensor/data/ItemsAccessor {
 
 public final class sk/ainet/lang/tensor/data/MmapFloatTensorData : sk/ainet/lang/tensor/data/FloatBufferTensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;Ljava/nio/ByteBuffer;)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Float;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getFloatBuffer ()Ljava/nio/FloatBuffer;
@@ -2526,6 +2562,7 @@ public final class sk/ainet/lang/tensor/data/PprintKt {
 public final class sk/ainet/lang/tensor/data/Q4_KBlockTensorData : sk/ainet/lang/tensor/data/Q4_KTensorData {
 	public static final field Companion Lsk/ainet/lang/tensor/data/Q4_KBlockTensorData$Companion;
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[B)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Byte;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBlockCount ()I
@@ -2566,6 +2603,10 @@ public final class sk/ainet/lang/tensor/data/Q4_KTensorData$Companion {
 	public static final field SUB_BLOCK_SIZE I
 }
 
+public final class sk/ainet/lang/tensor/data/Q4_KTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/Q4_KTensorData;)[F
+}
+
 public final class sk/ainet/lang/tensor/data/Q4_KTensorDataKt {
 	public static final fun toFloatArray (Lsk/ainet/lang/tensor/data/Q4_KTensorData;)[F
 }
@@ -2573,6 +2614,7 @@ public final class sk/ainet/lang/tensor/data/Q4_KTensorDataKt {
 public final class sk/ainet/lang/tensor/data/Q8_0BlockTensorData : sk/ainet/lang/tensor/data/Q8_0TensorData {
 	public static final field Companion Lsk/ainet/lang/tensor/data/Q8_0BlockTensorData$Companion;
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[B)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Byte;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getBlockCount ()I
@@ -2603,12 +2645,21 @@ public final class sk/ainet/lang/tensor/data/Q8_0TensorData$Companion {
 	public static final field BYTES_PER_BLOCK I
 }
 
+public final class sk/ainet/lang/tensor/data/Q8_0TensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/Q8_0TensorData;)[F
+}
+
 public final class sk/ainet/lang/tensor/data/Q8_0TensorDataKt {
 	public static final fun toFloatArray (Lsk/ainet/lang/tensor/data/Q8_0TensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/TensorData : sk/ainet/lang/tensor/data/ItemsAccessor {
+	public fun copyToFloatArray ()[F
 	public abstract fun getShape ()Lsk/ainet/lang/tensor/Shape;
+}
+
+public final class sk/ainet/lang/tensor/data/TensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/TensorData;)[F
 }
 
 public abstract interface class sk/ainet/lang/tensor/data/TensorDataFactory {
@@ -2635,6 +2686,7 @@ public final class sk/ainet/lang/tensor/data/Ternary2BitTensorData : sk/ainet/la
 	public static final field Companion Lsk/ainet/lang/tensor/data/Ternary2BitTensorData$Companion;
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[BF)V
 	public synthetic fun <init> (Lsk/ainet/lang/tensor/Shape;[BFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Byte;
 	public synthetic fun get ([I)Ljava/lang/Object;
 	public fun getPackedData ()[B
@@ -2654,6 +2706,10 @@ public final class sk/ainet/lang/tensor/data/Ternary2BitTensorData$Companion {
 public abstract interface class sk/ainet/lang/tensor/data/TernaryTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public abstract fun getPackedData ()[B
 	public abstract fun getScale ()F
+}
+
+public final class sk/ainet/lang/tensor/data/TernaryTensorData$DefaultImpls {
+	public static fun copyToFloatArray (Lsk/ainet/lang/tensor/data/TernaryTensorData;)[F
 }
 
 public final class sk/ainet/lang/tensor/data/TernaryTensorDataKt {
@@ -2711,6 +2767,7 @@ public final class sk/ainet/lang/tensor/data/dense/DenseTernaryTensorArray$Compa
 
 public final class sk/ainet/lang/tensor/data/views/UnsqueezedTensorData : sk/ainet/lang/tensor/data/TensorData {
 	public fun <init> (Lsk/ainet/lang/tensor/data/TensorData;I)V
+	public fun copyToFloatArray ()[F
 	public fun get ([I)Ljava/lang/Object;
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
 	public fun set ([ILjava/lang/Object;)V
@@ -3075,9 +3132,11 @@ public final class sk/ainet/lang/tensor/ops/Conv2dOperation : sk/ainet/lang/tens
 }
 
 public abstract interface class sk/ainet/lang/tensor/ops/DifferentiableTensorOps {
+	public abstract fun absBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun addBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun addScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun avgPool2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public abstract fun clampBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun concatBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun conv1dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun conv2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -3094,6 +3153,8 @@ public abstract interface class sk/ainet/lang/tensor/ops/DifferentiableTensorOps
 	public abstract fun meanBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun mulScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun multiplyBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public abstract fun narrowBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
+	public abstract fun pad2dBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun rdivScalarBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun reluBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
 	public abstract fun reshapeBackward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Ljava/util/List;Ljava/util/Map;)Ljava/util/List;
@@ -3158,9 +3219,11 @@ public final class sk/ainet/lang/tensor/ops/InputOperation : sk/ainet/lang/tenso
 public final class sk/ainet/lang/tensor/ops/KspTensorOps : sk/ainet/lang/tensor/ops/TensorOps {
 	public fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/trace/OpSink;Lsk/ainet/lang/trace/TraceSession;)V
 	public synthetic fun <init> (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/trace/OpSink;Lsk/ainet/lang/trace/TraceSession;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
+	public fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv2d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;I)Lsk/ainet/lang/tensor/Tensor;
@@ -3170,19 +3233,24 @@ public final class sk/ainet/lang/tensor/ops/KspTensorOps : sk/ainet/lang/tensor/
 	public fun divide (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun elu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun split (Lsk/ainet/lang/tensor/Tensor;II)Ljava/util/List;
@@ -3193,6 +3261,7 @@ public final class sk/ainet/lang/tensor/ops/KspTensorOps : sk/ainet/lang/tensor/
 	public fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
@@ -3327,10 +3396,12 @@ public final class sk/ainet/lang/tensor/ops/SubtractOperation : sk/ainet/lang/te
 }
 
 public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
+	public abstract fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun avgPool2d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun conv1d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIIIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3345,11 +3416,13 @@ public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
 	public static synthetic fun elu$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun flatten$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IIILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun leakyRelu$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;FILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun maxPool2d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3357,11 +3430,14 @@ public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
 	public static synthetic fun mean$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun softmax$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3376,6 +3452,7 @@ public abstract interface class sk/ainet/lang/tensor/ops/TensorOps {
 	public abstract fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun tril$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
+	public abstract fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public abstract fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun upsample2d$default (Lsk/ainet/lang/tensor/ops/TensorOps;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;ZILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
@@ -3491,9 +3568,11 @@ public final class sk/ainet/lang/tensor/ops/ValidationResult$Valid : sk/ainet/la
 
 public final class sk/ainet/lang/tensor/ops/VoidTensorOps : sk/ainet/lang/tensor/ops/TensorOps {
 	public fun <init> ()V
+	public fun abs (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun add (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun addScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun avgPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Z)Lsk/ainet/lang/tensor/Tensor;
+	public fun clamp (Lsk/ainet/lang/tensor/Tensor;FF)Lsk/ainet/lang/tensor/Tensor;
 	public fun concat (Ljava/util/List;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv1d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun conv2d (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;I)Lsk/ainet/lang/tensor/Tensor;
@@ -3503,19 +3582,24 @@ public final class sk/ainet/lang/tensor/ops/VoidTensorOps : sk/ainet/lang/tensor
 	public fun divide (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun elu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun flatten (Lsk/ainet/lang/tensor/Tensor;II)Lsk/ainet/lang/tensor/Tensor;
+	public fun ge (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun gelu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun leakyRelu (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun logSoftmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun maxPool2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun mulScalar (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Number;)Lsk/ainet/lang/tensor/Tensor;
 	public fun multiply (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun narrow (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
+	public fun pad2d (Lsk/ainet/lang/tensor/Tensor;IIII)Lsk/ainet/lang/tensor/Tensor;
 	public fun rdivScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun relu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun reshape (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Shape;)Lsk/ainet/lang/tensor/Tensor;
 	public fun rsubScalar (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun sigmoid (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public fun sign (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun silu (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun softmax (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun split (Lsk/ainet/lang/tensor/Tensor;II)Ljava/util/List;
@@ -3526,6 +3610,7 @@ public final class sk/ainet/lang/tensor/ops/VoidTensorOps : sk/ainet/lang/tensor
 	public fun sum (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public fun transpose (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
@@ -3589,6 +3674,7 @@ public final class sk/ainet/lang/trace/TensorRef {
 
 public class sk/ainet/lang/trace/TraceSession {
 	public fun <init> ()V
+	public final fun clear ()V
 	public fun refOf (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/trace/TensorRef;
 	public final fun refsOf (Ljava/util/List;)Ljava/util/List;
 	public fun resolve (Ljava/lang/String;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-lang/skainet-lang-dag/api/android/skainet-lang-dag.api
+++ b/skainet-lang/skainet-lang-dag/api/android/skainet-lang-dag.api
@@ -28,12 +28,16 @@ public abstract interface class sk/ainet/lang/dag/GraphDslOps : sk/ainet/lang/te
 }
 
 public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
+	public static final fun abs (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun abs$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun add (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun add$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun addScalar (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/Number;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun addScalar$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/Number;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun avgPool2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun avgPool2d$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun clamp (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FFLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun clamp$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FFLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun concat (Lsk/ainet/lang/dag/DagBuilder;Ljava/util/List;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun concat$default (Lsk/ainet/lang/dag/DagBuilder;Ljava/util/List;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun conv1d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;IIIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -50,12 +54,16 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun elu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun flatten (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun flatten$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun ge (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun ge$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun gelu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun gelu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun leakyRelu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun leakyRelu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun logSoftmax (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun lt (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun lt$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun matmul (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun matmul$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun maxPool2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -66,6 +74,10 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun mulScalar$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/Number;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun multiply (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun multiply$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun narrow (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun narrow$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun pad2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun pad2d$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIIILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun rdivScalar (Lsk/ainet/lang/dag/DagBuilder;Ljava/lang/Number;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun rdivScalar$default (Lsk/ainet/lang/dag/DagBuilder;Ljava/lang/Number;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun relu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -76,6 +88,8 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun rsubScalar$default (Lsk/ainet/lang/dag/DagBuilder;Ljava/lang/Number;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun sigmoid (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun sigmoid$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun sign (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun sign$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun silu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun silu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun softmax (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -94,6 +108,8 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun transpose$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun tril (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun tril$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun unfold (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun unfold$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun unsqueeze (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun unsqueeze$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun upsample2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;ZLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;

--- a/skainet-lang/skainet-lang-dag/api/jvm/skainet-lang-dag.api
+++ b/skainet-lang/skainet-lang-dag/api/jvm/skainet-lang-dag.api
@@ -28,12 +28,16 @@ public abstract interface class sk/ainet/lang/dag/GraphDslOps : sk/ainet/lang/te
 }
 
 public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
+	public static final fun abs (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun abs$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun add (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun add$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun addScalar (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/Number;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun addScalar$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/Number;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun avgPool2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun avgPool2d$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;ZLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun clamp (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FFLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun clamp$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FFLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun concat (Lsk/ainet/lang/dag/DagBuilder;Ljava/util/List;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun concat$default (Lsk/ainet/lang/dag/DagBuilder;Ljava/util/List;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun conv1d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;IIIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -50,12 +54,16 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun elu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun flatten (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun flatten$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun ge (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun ge$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun gelu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun gelu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun leakyRelu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun leakyRelu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun logSoftmax (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun lt (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun lt$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;FLjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun matmul (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun matmul$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun maxPool2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lkotlin/Pair;Lkotlin/Pair;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -66,6 +74,10 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun mulScalar$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/Number;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun multiply (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun multiply$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun narrow (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun narrow$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun pad2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun pad2d$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIIILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun rdivScalar (Lsk/ainet/lang/dag/DagBuilder;Ljava/lang/Number;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun rdivScalar$default (Lsk/ainet/lang/dag/DagBuilder;Ljava/lang/Number;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun relu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -76,6 +88,8 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun rsubScalar$default (Lsk/ainet/lang/dag/DagBuilder;Ljava/lang/Number;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun sigmoid (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun sigmoid$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun sign (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun sign$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun silu (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun silu$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun softmax (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
@@ -94,6 +108,8 @@ public final class sk/ainet/lang/dag/GraphDslOpsGraphDslKt {
 	public static synthetic fun transpose$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Ljava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun tril (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun tril$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
+	public static final fun unfold (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
+	public static synthetic fun unfold$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;IIILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun unsqueeze (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;
 	public static synthetic fun unsqueeze$default (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;ILjava/lang/String;ILjava/lang/Object;)Lsk/ainet/lang/dag/GraphValue;
 	public static final fun upsample2d (Lsk/ainet/lang/dag/DagBuilder;Lsk/ainet/lang/dag/GraphValue;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;ZLjava/lang/String;)Lsk/ainet/lang/dag/GraphValue;


### PR DESCRIPTION
    Preparation for JavaLand 2026 workshop. Related to #10, fixes #371.

    - Add Q4/Q8 quantized data types to DataType enum and SafeTensors mapper
    - Create LlamaConfigParser for HuggingFace config.json parsing
    - Create LlamaSafeTensorsLoader with HF→GGUF tensor name mapping, Q4+qb dequantization, BF16/F16 conversion, and shape normalization
    - Add loadSafeTensors() method to LlamaIngestion
    - Add fromTokenizerJson() to GGUFTokenizer for HuggingFace tokenizer.json
    - Update CLI to detect and handle .safetensors files and model directories
    - Update DTypeMapping for QUANT4/QUANT8 exhaustive when branches

    Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>