### PR TITLE
Drop vestigial cpu dep from skainet-compile-hlo jvmMain (#472)

### DIFF
--- a/skainet-compile/skainet-compile-hlo/build.gradle.kts
+++ b/skainet-compile/skainet-compile-hlo/build.gradle.kts
@@ -54,8 +54,10 @@ kotlin {
         }
 
         jvmMain.dependencies {
+            // HloGenerator records traces with VoidTensorOps from
+            // skainet-lang-core — the JVM production path never needs a
+            // real backend implementation. No CPU-specific imports here.
             implementation(project(":skainet-lang:skainet-lang-models"))
-            implementation(project(":skainet-backends:skainet-backend-cpu"))
             implementation(libs.kotlinx.coroutines)
         }
 


### PR DESCRIPTION
Closes #472.

## Summary

Removes an unused \`implementation(project(\":skainet-backends:skainet-backend-cpu\"))\` from \`skainet-compile/skainet-compile-hlo/build.gradle.kts\`'s \`jvmMain.dependencies\` block. \`HloGenerator\` records traces with \`VoidTensorOps()\` from \`skainet-lang-core\` and the jvmMain Kotlin sources contain zero imports from \`sk.ainet.backend.cpu.*\` — the dependency was dead.

## Why this is the right first \"migration\" in the P0-2 track

Grepping every \`build.gradle.kts\` in the repo for \`skainet-backend-cpu\` showed that **every production-code dependency on the CPU backend is either a test source set (tests actually execute ops), an application runtime, or the BOM** — with one exception: \`skainet-compile-hlo\`'s jvmMain, where the dep was declared but unused. The originally-scoped candidate (\`skainet-compile-json\`) turned out not to be migratable: its CPU dep is in \`jvmTest\`, where tests genuinely need a real execution context, and \`skainet-backend-api\` is interface-only.

So the useful first step in P0-2 isn't \"migrate a consumer from CPU to api\" — it's removing the one place where CPU is on a production classpath without being referenced. That strictly shrinks the transitive closure of anything pulling in \`compile-hlo\` and demonstrates that \`skainet-lang-core\` alone is enough for the production HLO export path.

## Test plan

- [x] \`:skainet-compile:skainet-compile-hlo:compileKotlinJvm\` green
- [x] \`:skainet-compile:skainet-compile-hlo:jvmTest\` green (commonTest still has the CPU dep where tests need it)
- [x] \`:skainet-compile:skainet-compile-hlo:generateHlo\` runs cleanly and prints its expected \`--model is required\` usage message — no \`ClassNotFoundException\` for \`VoidTensorOps\` or anything else
- [ ] CI: full multiplatform build

## Out of scope

- Adding \`skainet-backend-api\` as a replacement dep — the code already only references types from \`skainet-lang-core\`, so a re-export would be pointless.
- Migrating the remaining test-source-set consumers off \`skainet-backend-cpu\`. Those deps are legitimate.
- Scaffolding a second backend to prove \`backend-api\` is actually sufficient. That's a better follow-up than another dep swap and should be a separate roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)