### PR TITLE
Emit tensor_encoding comments in StableHLO output (#473)

### DIFF
--- a/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/ConversionContext.kt
+++ b/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/ConversionContext.kt
@@ -2,6 +2,8 @@ package sk.ainet.compile.hlo
 
 import sk.ainet.lang.graph.ComputeGraph
 import sk.ainet.lang.graph.GraphNode
+import sk.ainet.lang.tensor.ops.TensorSpec
+import sk.ainet.lang.tensor.ops.tensorEncoding
 
 /**
  * Context object for maintaining state during StableHLO conversion.
@@ -53,6 +55,38 @@ public class ConversionContext(
      */
     public fun emitComment(comment: String) {
         stringBuilder.appendLine("    // $comment")
+    }
+
+    /**
+     * Emit a `tensor_encoding` diagnostic comment when [spec] carries a
+     * non-null `tensorEncoding` (set via [sk.ainet.lang.tensor.ops.withTensorEncoding]).
+     *
+     * The emitted line has the shape:
+     *
+     * ```mlir
+     *     // tensor_encoding: role=<role> index=<i> name=<spec.name> encoding=<enc.name>
+     * ```
+     *
+     * MLIR tools ignore comments but text round-trips preserve them, so
+     * this is the cheapest way to keep SKaiNET's quantization metadata
+     * visible through the StableHLO emit boundary until a structured
+     * attribute or quant-dialect lowering lands. Emits nothing when the
+     * spec has no encoding — a `null` [sk.ainet.lang.tensor.storage.TensorEncoding]
+     * is the unknown / not-carried state, intentionally distinct from
+     * `TensorEncoding.Dense`.
+     *
+     * @param role Logical slot the spec occupies for the node being
+     *     emitted (e.g. `"input"` for function arguments, `"result"` for
+     *     node outputs). Free-form so individual converters can use
+     *     finer-grained tags if they call this helper directly.
+     * @param index Positional index of the spec within its role, e.g.
+     *     the output port index for a multi-result node.
+     */
+    public fun emitEncodingAnnotation(role: String, index: Int, spec: TensorSpec) {
+        val encoding = spec.tensorEncoding ?: return
+        emitComment(
+            "tensor_encoding: role=$role index=$index name=${spec.name} encoding=${encoding.name}"
+        )
     }
     
     /**

--- a/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/StableHloConverter.kt
+++ b/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/StableHloConverter.kt
@@ -111,10 +111,18 @@ public class StableHloConverter(
         inputNodes.forEachIndexed { idx, node ->
             val valueName = "%arg$idx"
             context.setValueName(node.id, valueName)
-            
+
             // Add comment for clarity
             node.outputs.firstOrNull()?.let { spec ->
                 context.emitComment("input ${node.id}: ${spec.name} : ${typeMapper.mapTensorType(spec)}")
+            }
+
+            // Preserve any physical storage encoding carried on the input
+            // spec (Q4_K / Q8_0 / TernaryPacked / TurboQuant / …) as an
+            // MLIR comment so downstream tools see that quantization
+            // flowed through. No-op when the spec has no encoding.
+            node.outputs.forEachIndexed { outIdx, spec ->
+                context.emitEncodingAnnotation(role = "input", index = outIdx, spec = spec)
             }
         }
     }
@@ -138,11 +146,19 @@ public class StableHloConverter(
     private fun processNode(node: GraphNode, context: ConversionContext) {
         val converter = registry.getConverter(node.operation.name)
             ?: throw UnsupportedOperationException("No converter found for operation: ${node.operation.name}")
-        
+
         // Get input operands from context
         val inputNodes = context.getInputNodes(node)
         val operands = inputNodes.mapNotNull { context.getValueName(it.id) }
-        
+
+        // Surface any physical storage encoding declared on this node's
+        // result specs as an MLIR comment before the operation is
+        // emitted. Converters that want finer-grained placement can call
+        // ConversionContext.emitEncodingAnnotation themselves.
+        node.outputs.forEachIndexed { outIdx, spec ->
+            context.emitEncodingAnnotation(role = "result", index = outIdx, spec = spec)
+        }
+
         // Convert the operation
         val result = converter.convert(node, operands, context)
         

--- a/skainet-compile/skainet-compile-hlo/src/commonTest/kotlin/sk/ainet/compile/hlo/EncodingAnnotationTest.kt
+++ b/skainet-compile/skainet-compile-hlo/src/commonTest/kotlin/sk/ainet/compile/hlo/EncodingAnnotationTest.kt
@@ -1,0 +1,128 @@
+package sk.ainet.compile.hlo
+
+import sk.ainet.lang.graph.DefaultComputeGraph
+import sk.ainet.lang.graph.GraphEdge
+import sk.ainet.lang.graph.GraphNode
+import sk.ainet.lang.tensor.ops.AddOperation
+import sk.ainet.lang.tensor.ops.InputOperation
+import sk.ainet.lang.tensor.ops.TensorSpec
+import sk.ainet.lang.tensor.ops.withTensorEncoding
+import sk.ainet.lang.tensor.storage.TensorEncoding
+import sk.ainet.lang.types.DType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the emitter hook added for #473: when a [TensorSpec] flowing
+ * through the graph carries a non-null `tensorEncoding`, the emitted
+ * StableHLO module must preserve that information as a comment so
+ * downstream tools (and humans reading the MLIR) can see that
+ * quantization flowed through the compile boundary.
+ */
+class EncodingAnnotationTest {
+
+    @Test
+    fun q8_0_weight_produces_tensor_encoding_comment() {
+        val graph = DefaultComputeGraph()
+
+        val inputA = GraphNode(
+            id = "a",
+            operation = InputOperation<DType, Any>(),
+            inputs = emptyList(),
+            outputs = listOf(TensorSpec("a", listOf(1, 4), "FP32"))
+        )
+
+        // A Q8_0 weight, synthesized the way TraceToGraphBuilder.finalize()
+        // produces its weight nodes after #469 landed: the spec carries
+        // TensorEncoding.Q8_0 on its metadata.
+        val weightSpec = TensorSpec("w", listOf(1, 4), "FP32")
+            .withTensorEncoding(TensorEncoding.Q8_0)
+        val weightNode = GraphNode(
+            id = "w",
+            operation = InputOperation<DType, Any>(),
+            inputs = emptyList(),
+            outputs = listOf(weightSpec)
+        )
+
+        val add = GraphNode(
+            id = "add1",
+            operation = AddOperation<DType, Any>(),
+            inputs = listOf(
+                TensorSpec("a", listOf(1, 4), "FP32"),
+                weightSpec
+            ),
+            outputs = listOf(TensorSpec("out", listOf(1, 4), "FP32"))
+        )
+
+        graph.addNode(inputA)
+        graph.addNode(weightNode)
+        graph.addNode(add)
+        graph.addEdge(GraphEdge("e1", inputA, add, 0, 0, inputA.outputs[0]))
+        graph.addEdge(GraphEdge("e2", weightNode, add, 0, 1, weightSpec))
+
+        val mlir = toStableHlo(graph, "quant_add").content
+        println("[DEBUG_LOG] quant-annotated export:\n$mlir")
+
+        // The emitter must have surfaced the encoding as a comment near
+        // the weight input's initialization. MLIR tools ignore comments
+        // but the text round-trips preserve them, so this is the cheapest
+        // way to keep SKaiNET's quantization metadata visible through the
+        // StableHLO emit boundary.
+        assertTrue(
+            mlir.contains("tensor_encoding"),
+            "emitter must include a tensor_encoding annotation comment"
+        )
+        assertTrue(
+            mlir.contains("encoding=Q8_0"),
+            "annotation must name the concrete TensorEncoding (Q8_0)"
+        )
+        assertTrue(
+            mlir.contains("name=w"),
+            "annotation must identify the tensor the encoding applies to"
+        )
+    }
+
+    @Test
+    fun dense_graph_emits_no_encoding_comment() {
+        // An all-FP32 graph with no encoding metadata must not introduce
+        // spurious tensor_encoding comments. A `null` tensorEncoding is
+        // the unknown / not-carried state, not "Dense", and the emitter
+        // must treat it as silent.
+        val graph = DefaultComputeGraph()
+
+        val inputA = GraphNode(
+            id = "a",
+            operation = InputOperation<DType, Any>(),
+            inputs = emptyList(),
+            outputs = listOf(TensorSpec("a", listOf(1, 4), "FP32"))
+        )
+        val inputB = GraphNode(
+            id = "b",
+            operation = InputOperation<DType, Any>(),
+            inputs = emptyList(),
+            outputs = listOf(TensorSpec("b", listOf(1, 4), "FP32"))
+        )
+        val add = GraphNode(
+            id = "add1",
+            operation = AddOperation<DType, Any>(),
+            inputs = listOf(
+                TensorSpec("a", listOf(1, 4), "FP32"),
+                TensorSpec("b", listOf(1, 4), "FP32")
+            ),
+            outputs = listOf(TensorSpec("c", listOf(1, 4), "FP32"))
+        )
+
+        graph.addNode(inputA)
+        graph.addNode(inputB)
+        graph.addNode(add)
+        graph.addEdge(GraphEdge("e1", inputA, add, 0, 0, inputA.outputs[0]))
+        graph.addEdge(GraphEdge("e2", inputB, add, 0, 1, inputB.outputs[0]))
+
+        val mlir = toStableHlo(graph, "dense_add").content
+        assertFalse(
+            mlir.contains("tensor_encoding"),
+            "dense graph must not emit any tensor_encoding annotation"
+        )
+    }
+}


### PR DESCRIPTION
Closes #473.

## Summary

First step after #469: teach the StableHLO emitter to read \`TensorSpec.tensorEncoding\` and preserve it through the compile boundary. Today, even though \`TraceToGraphBuilder.finalize\` carries \`TensorEncoding.Q8_0\` / \`Q4_K\` / \`TernaryPacked\` / \`TurboQuant\` onto weight-node output specs, \`StableHloConverter\` ignores the metadata and emits MLIR that looks identical to a dense FP32 graph. This PR is the cheapest reversible hook that fixes that.

Two commits:

### 1. Failing test
\`EncodingAnnotationTest\` with two cases:

- **Positive**: build a graph whose weight input \`TensorSpec\` is annotated with \`TensorEncoding.Q8_0\` via \`withTensorEncoding\` (matching what \`TraceToGraphBuilder.finalize\` produces after #469), run it through \`StableHloConverter\`, assert the emitted module text contains a \`tensor_encoding\` comment naming \`encoding=Q8_0\` and \`name=w\`. Red against \`main\`.
- **Negative**: a dense FP32 graph with no encoding metadata must emit **no** \`tensor_encoding\` annotation. A \`null\` \`tensorEncoding\` is the unknown / not-carried state, intentionally distinct from \`TensorEncoding.Dense\`, and the emitter has to treat it as silent. Green baseline.

### 2. The fix
- \`ConversionContext.emitEncodingAnnotation(role, index, spec)\` — helper that emits a single \`tensor_encoding\` MLIR comment when \`spec.tensorEncoding\` is non-null. No-op otherwise.
- \`StableHloConverter.initializeInputValues\` annotates each function-argument input with \`role=\"input\"\`.
- \`StableHloConverter.processNode\` annotates each non-input node's output specs with \`role=\"result\"\` immediately before the converter is invoked, so the annotation precedes the op that produces the encoded value.

Net effect: a Q8_0 weight node flowing through the emitter now produces a line like

\`\`\`mlir
    // tensor_encoding: role=result index=0 name=w encoding=Q8_0
\`\`\`

right before the op that materializes \`%w\`. MLIR tools ignore comments but text round-trips preserve them, so IREE and any downstream consumer can read the encoding from the emitted \`.mlir\` file. Converters that want finer-grained placement can call the helper themselves.

## Why comments, not real quant dialect ops

StableHLO's \`quant.\` dialect uses typed quant element types (\`!quant.uniform<i8:f32, 0.1:128>\`) that are fiddly to emit as text and are not yet consumed anywhere in the SKaiNET pipeline. Emitting them prematurely would just produce MLIR that no existing tool in this repo validates. Comments are the cheapest reversible first hop. Follow-up PRs in the P0-1 track can either grow the comment into a structured \`#skainet.tensor_encoding\` attribute or cut over to real \`stablehlo.custom_call @dequantize_q8_0\` stubs matching the style already used by \`ReductionOperationsConverter\`.

## Test plan

- [x] \`EncodingAnnotationTest\` — both cases green
- [x] Full \`:skainet-compile:skainet-compile-hlo:jvmTest\` — green (no regressions from the new comment)
- [ ] CI: full multiplatform build

## Out of scope

- Real \`stablehlo.uniform_quantize\` / quant dialect emission.
- Teaching IREE or any downstream tool to actually consume the comments. That's downstream work.
- Changing the shape of \`TensorEncoding\` or \`TensorSpec\`.
- Softmax / conv / attention lowering (#467 is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)