### PR TITLE
Fix WasmJS/JS/Native compile: replace putIfAbsent with common idiom

### DIFF
--- a/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/StableHloConverter.kt
+++ b/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/StableHloConverter.kt
@@ -200,17 +200,22 @@ public class StableHloConverter(
      * `name -> encoding` map of every tensor that carries a non-null
      * [TensorEncoding]. Duplicates (the same name appearing in multiple
      * nodes) collapse to a single entry — first-writer-wins.
+     *
+     * Implementation note: uses an explicit `!in` check rather than
+     * `MutableMap.putIfAbsent` because the latter is a JVM-only
+     * extension and does not exist in Kotlin common-stdlib for WasmJS
+     * / JS / Native targets.
      */
     private fun collectTensorEncodings(nodes: List<GraphNode>): Map<String, TensorEncoding> {
         val result = linkedMapOf<String, TensorEncoding>()
         for (node in nodes) {
             for (spec in node.outputs) {
                 val encoding = spec.tensorEncoding ?: continue
-                result.putIfAbsent(spec.name, encoding)
+                if (spec.name !in result) result[spec.name] = encoding
             }
             for (spec in node.inputs) {
                 val encoding = spec.tensorEncoding ?: continue
-                result.putIfAbsent(spec.name, encoding)
+                if (spec.name !in result) result[spec.name] = encoding
             }
         }
         return result


### PR DESCRIPTION
## Summary

Hotfix for a red multiplatform build on develop introduced by #477 (merged via #478). \`MutableMap.putIfAbsent(key, value)\` is a **JVM-only extension** — it lives on \`java.util.Map\`, not in Kotlin common-stdlib. The two call sites I added in \`StableHloConverter.collectTensorEncodings\` compiled fine on JVM but broke \`compileKotlinWasmJs\` (and by extension JS / Native) with:

    e: StableHloConverter.kt:209:24 Unresolved reference 'putIfAbsent'
    e: StableHloConverter.kt:213:24 Unresolved reference 'putIfAbsent'

develop's \`build-job\` CI has been red since #478 merged.

## Root cause

Local verification for #477 ran only \`:skainet-compile:skainet-compile-hlo:jvmTest\`. KMP's per-target compilation means a JVM-only stdlib call silently passes JVM checks and only fails on the first non-JVM compile. \`allTests\` would have caught it locally — that's now in my standing discipline for this repo going forward.

## Fix

Replaces both call sites with the common-compatible idiom:

\`\`\`kotlin
if (spec.name !in result) result[spec.name] = encoding
\`\`\`

Same first-writer-wins semantics, works on every KMP target.

## Test plan

- [x] \`:skainet-compile:skainet-compile-hlo:compileKotlinWasmJs\` — was red, now green
- [x] \`:skainet-compile:skainet-compile-hlo:allTests -x kotlinWasmStoreYarnLock\` — green across **jvmTest, wasmJsTest, wasmJsBrowserTest, wasmWasiTest, wasmWasiNodeTest, macosArm64Test, iosSimulatorArm64Test** (\`linuxX64Test\` skipped on macOS host)
- [ ] CI: full multiplatform build across all targets

## Note on \`kotlinWasmStoreYarnLock\`

Running \`allTests\` without \`-x kotlinWasmStoreYarnLock\` fails with \"Lock file was changed. Run the \`kotlinWasmUpgradeYarnLock\` task to actualize lock file\" on clean develop, unrelated to this PR. That's a separate pre-existing issue worth tracking but not blocking this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)