### PR TITLE
Adopt skainet-docs-ui v1.1.1 + Diátaxis card-grid landing (#501)

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -30,7 +30,11 @@ asciidoc:
 
 ui:
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    # SKaiNET-branded UI bundle from the shared skainet-docs-ui repo:
+    #   https://github.com/SKaiNET-developers/skainet-docs-ui
+    # Pinned to a specific tag for reproducible builds. Bumping
+    # this URL to a newer version is a one-line PR.
+    url: https://github.com/SKaiNET-developers/skainet-docs-ui/releases/download/v1.1.1/ui-bundle.zip
     snapshot: true
 
 output:

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -9,26 +9,35 @@ platform compile targets, and a pluggable backend API that CPU,
 GPU, and NPU backends can implement independently.
 
 This documentation site is organized following the
-https://diataxis.fr/[Diátaxis / Divio framework]:
+https://diataxis.fr/[Diátaxis / Divio framework] — pick the
+section that matches what you're trying to do:
 
-Tutorials:: Learning-oriented. Start here if you are new to SKaiNET.
-How-to guides:: Task-oriented. Recipes for solving specific problems.
-Reference:: Information-oriented. Looking up APIs and op coverage.
-Explanation:: Understanding-oriented. Background on design decisions.
+[.card-grid]
+* xref:tutorials/java-getting-started.adoc[*Tutorials*]
++
+Learning-oriented walkthroughs. Start here if you are new to
+SKaiNET — set up a project, build your first tensor, run a
+forward pass.
+* xref:how-to/build.adoc[*How-to guides*]
++
+Task-oriented recipes. Build from source, load a GGUF model,
+generate C for Arduino, train a small network from Java.
+* xref:reference/architecture.adoc[*Reference*]
++
+Information-oriented lookup: architecture, the
+xref:reference/operators/generated/index.adoc[operator catalog],
+the xref:reference/ops-status-matrix.adoc[backend coverage matrix],
+and the link:../api/index.html[Dokka API reference].
+* xref:explanation/skainet-for-ai.adoc[*Explanation*]
++
+Understanding-oriented background: SKaiNET for AI/ML, the
+operator documentation system, mathematical theory, performance
+notes.
 
 [NOTE]
 ====
 LLM-specific runtimes (Llama, Gemma, Qwen, BERT) live in the
 sibling https://github.com/SKaiNET-developers/SKaiNET-transformers[SKaiNET-transformers]
-repository and its own documentation site. This site covers the
-engine layer only.
+repository and its own documentation site. Mainline SKaiNET
+covers the engine layer only.
 ====
-
-== Quick links
-
-* link:../api/index.html[API reference (Dokka)] (bundled at publish time)
-
-// The Tutorials / How-to / Reference / Explanation pages plus the
-// operator coverage xref land in follow-up commits (#2 and #3 of
-// the Antora migration). This page ships the landing copy first so
-// the scaffold build succeeds with a real start_page.


### PR DESCRIPTION
Closes #501.

## Summary

Swap mainline's Antora UI bundle for the new SKaiNET-branded
[\`skainet-docs-ui\`](https://github.com/SKaiNET-developers/skainet-docs-ui)
release, pinned to \`v1.1.1\`, and rewrite the docs landing page
to use its \`.card-grid\` component for a real Diátaxis
four-card grid.

## Two-line scope

\`\`\`diff
 ui:
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    url: https://github.com/SKaiNET-developers/skainet-docs-ui/releases/download/v1.1.1/ui-bundle.zip
     snapshot: true
\`\`\`

\`\`\`diff
- == Quick links
-
- * link:../api/index.html[API reference (Dokka)] (bundled at publish time)
+ [.card-grid]
+ * xref:tutorials/java-getting-started.adoc[*Tutorials*]
+ +
+ Learning-oriented walkthroughs. Start here if you are new to
+ SKaiNET — set up a project, build your first tensor, run a
+ forward pass.
+ * xref:how-to/build.adoc[*How-to guides*]
+ +
+ ... (etc, four cards total)
\`\`\`

## What ships in the new bundle

The skainet-docs-ui repo is the shared Antora UI for every
SKaiNET docs site (mainline, SKaiNET-transformers, future
siblings). Forked from upstream antora-ui-default and
SKaiNET-ified across six commits:

| Phase | What |
|---|---|
| 1 | Scaffold from upstream antora-ui-default (vanilla bundle works) |
| 2 | SKaiNET red palette via vars.css (light + dark mode) |
| 3 | Orbitron + Inter + Fira Code via Google Fonts |
| 4 | Dark mode toggle + header partial override (FOUC-safe inline bootstrap) |
| 5 | Aesthetic polish (6px scrollbar, rounded code blocks, focus glow) |
| 6 | GitHub Actions release workflow + v1.0.0 tag |
| v1.1.0 | \`.card-grid\` CSS for landing pages |
| v1.1.1 | Override upstream MPL-2.0 footer with SKaiNET footer |

## Visual changes you'll see

- **Brand color** flips from upstream Antora blue to SKaiNET red \`#dc2626\`
- **Typography** flips from Roboto / Roboto Mono to Orbitron headings + Inter body + Fira Code monospace
- **Dark mode** toggle button (🌓) in the navbar top-right; persists via localStorage; respects \`prefers-color-scheme\` on first visit
- **Code blocks** rounded 8px, GitHub-light \`#f6f8fa\` in light mode and GitHub-dark \`#0d1117\` in dark mode, with a 1px border in the matching shade
- **Landing page** replaces the placeholder \"Quick links\" with a responsive 4-card Diátaxis grid (Tutorials / How-to / Reference / Explanation)
- **Footer** replaces upstream \"This page was built using the Antora default UI ... MPL-2.0\" with SKaiNET attribution + cross-repo links to skainet-docs-ui / mainline / SKaiNET-transformers
- **Scrollbar** thin 6px in the SKaiNET muted-fg color
- **Focus glow** primary-red on links + buttons + nav items via \`:focus-visible\`
- **Card hover** lifts the .doc body slightly and adds a soft two-layer shadow in light mode

## Verification

Local docker build of the docs site against the **published** v1.1.1 bundle URL (no local override):

\`\`\`bash
docker run --rm --user \"\$(id -u):\$(id -g)\" \\
    -v \"\$PWD:/antora\" -w /antora \\
    skainet-antora:local docs/antora-playbook.yml
python3 -m http.server --directory docs/build/site 8080
\`\`\`

- [x] exit 0, no warnings, no errors
- [x] \`docs/build/site/skainet/index.html\` contains \`<div class=\"ulist card-grid\">\` with four \`<li>\` cards
- [x] rendered footer references \`skainet-docs-ui\` and \`MIT\`, no MPL-2.0
- [x] inline \`<head>\` script with the FOUC-safe theme bootstrap is present
- [x] navbar has the \`#theme-toggle\` button
- [x] code blocks render in the new GitHub-light/dark style
- [x] Mainline mermaid extension (docs/.docker/local-mermaid-extension.js) still resolves the diagrams to inline SVGs
- [ ] CI: full multiplatform docs.yml workflow on this branch

## Out of scope

- Bumping SKaiNET-transformers's playbook to the same bundle.
  Coordinated as a separate PR on that repo.
- Self-hosted fonts (Phase 5 still goes through Google Fonts at
  page load — fine for v1, can move to bundled @font-face files
  in a UI v1.2).
- Search wiring (\`SITE_SEARCH_PROVIDER\` env var still unset; the
  UI ships an input box already, just needs a search backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)