### PR TITLE
Build: drop js() from skainet-io-iree-params (closes #527)

### DIFF
--- a/skainet-io/skainet-io-iree-params/build.gradle.kts
+++ b/skainet-io/skainet-io-iree-params/build.gradle.kts
@@ -33,10 +33,10 @@ kotlin {
     linuxX64()
     linuxArm64()
 
-    js {
-        browser()
-    }
-
+    // `js()` is intentionally omitted: this module depends on
+    // :skainet-compile-hlo, which does not publish a JS target. Wasm
+    // targets are still compatible — they use `wasm` rather than `js`
+    // platform attributes. See issue #527.
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()


### PR DESCRIPTION
## Summary
- `./gradlew allTests` fails on develop with a platform-type variant mismatch: `skainet-io-iree-params` declares `js()` but its transitive dep `:skainet-compile:skainet-compile-hlo` does not publish a JS target.
- Drop `js()`. Wasm targets keep working (they use the `wasm` platform attribute, which the upstream dep does publish).

## Background
This fix was originally committed to PR #525's branch (commit `fdd378e7`) but only the first commit made it into the merge, so develop landed in a broken state. Re-applying as a narrow standalone fix.

## Test plan
- [x] `./gradlew allTests` passes — 1056 tasks, 28 executed + 1028 cached, all green.
- [x] `./gradlew :skainet-io:skainet-io-iree-params:jvmTest` still green.

Closes #527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)