### PR TITLE
Fix conv1d/conv3d static shape loss in HLO trace (#530)

### DIFF
--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultExecutionTape.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultExecutionTape.kt
@@ -74,17 +74,19 @@ public open class DefaultExecutionTape(
             val outputDTypes = (trace.attributes["outputDTypes"] as? List<*>)?.map { it?.toString() }
 
             val inputs = List(trace.inputs.size) { i ->
+                val ref = trace.inputs[i]
                 TensorSpec(
-                    name = trace.inputs[i].id,
-                    shape = inputShapes?.getOrNull(i),
-                    dtype = inputDTypes?.getOrNull(i) ?: "unknown",
+                    name = ref.id,
+                    shape = inputShapes?.getOrNull(i) ?: ref.shape.dimensions.toList(),
+                    dtype = inputDTypes?.getOrNull(i) ?: ref.dtype.name,
                 )
             }
             val outputs = List(trace.outputs.size) { i ->
+                val ref = trace.outputs[i]
                 TensorSpec(
-                    name = trace.outputs[i].id,
-                    shape = outputShapes?.getOrNull(i),
-                    dtype = outputDTypes?.getOrNull(i) ?: "unknown",
+                    name = ref.id,
+                    shape = outputShapes?.getOrNull(i) ?: ref.shape.dimensions.toList(),
+                    dtype = outputDTypes?.getOrNull(i) ?: ref.dtype.name,
                 )
             }
 

--- a/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/grad/DefaultExecutionTapeTest.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/grad/DefaultExecutionTapeTest.kt
@@ -14,6 +14,8 @@ import sk.ainet.lang.tensor.*
 import sk.ainet.lang.tensor.data.FloatArrayTensorData
 import sk.ainet.lang.graph.DefaultExecutionTape
 import sk.ainet.lang.tensor.ops.AddOperation
+import sk.ainet.lang.trace.OpTrace
+import kotlin.test.assertEquals
 
 class DefaultExecutionTapeTest {
 
@@ -146,5 +148,39 @@ class DefaultExecutionTapeTest {
         assertTrue(prunedTape.operations.size == 2)
         assertTrue(prunedTape.operations[0].operation is AddOperation<*, *>)
         assertTrue(prunedTape.operations[1].operation is AddOperation<*, *>)
+    }
+
+    @Test
+    fun recordTrace_without_shape_attributes_falls_back_to_tensor_ref_shape() {
+        val trainCtx = createTrainCtx()
+        val input = trainCtx.fromFloatArray<FP32, Float>(Shape(1, 80, 3000), FP32::class, FloatArray(1 * 80 * 3000))
+        val weight = trainCtx.fromFloatArray<FP32, Float>(Shape(384, 80, 3), FP32::class, FloatArray(384 * 80 * 3))
+        val output = trainCtx.fromFloatArray<FP32, Float>(Shape(1, 384, 3000), FP32::class, FloatArray(1 * 384 * 3000))
+
+        val tape = DefaultExecutionTape(trainCtx.session)
+        tape.startRecording()
+        val inputRef = tape.session.refOf(input)
+        val weightRef = tape.session.refOf(weight)
+        val outputRef = tape.session.refOf(output)
+
+        tape.recordTrace(
+            OpTrace(
+                opType = "conv1d",
+                inputs = listOf(inputRef, weightRef),
+                outputs = listOf(outputRef),
+                attributes = mapOf(
+                    "stride" to 1,
+                    "padding" to 1,
+                    "dilation" to 1,
+                    "groups" to 1
+                )
+            )
+        )
+        tape.stopRecording()
+
+        val recorded = tape.operations.single { it.operation.name == "conv1d" }
+        assertEquals(listOf(1, 384, 3000), recorded.outputs.single().shape)
+        assertEquals(listOf(1, 80, 3000), recorded.inputs[0].shape)
+        assertEquals(listOf(384, 80, 3), recorded.inputs[1].shape)
     }
 }


### PR DESCRIPTION
Fixes #530.

## Summary
- `DefaultExecutionTape.recordTrace` now falls back to `TensorRef.shape.dimensions.toList()` and `TensorRef.dtype.name` when the trace's `inputShapes` / `outputShapes` / `inputDTypes` / `outputDTypes` attributes are absent.
- The KSP tracer wrapper only emits those attributes for a conv2d-specific factory and an allowlist of unary/binary/scalar/shape ops. `conv1d` and `conv3d` fell through `AttributeStrategy.DefaultMapping` and recorded only scalar params — producing `TensorSpec(shape = null)` and `tensor<?xf32>` in the emitted MLIR (12 occurrences in the Whisper encoder, which blocks `iree-compile`).
- The `TensorRef` already carries the correct static `Shape` captured from the runtime tensor, so this is a free, always-correct fallback.

## Test plan
- [x] New regression test `DefaultExecutionTapeTest.recordTrace_without_shape_attributes_falls_back_to_tensor_ref_shape` synthesizes a `conv1d` `OpTrace` with only stride/padding/dilation/groups and asserts the recorded `TensorSpec.shape` is the static `[1, 384, 3000]` (output) / `[1, 80, 3000]` (input) / `[384, 80, 3]` (weight) from the `TensorRef`.
- [x] `./gradlew :skainet-compile:skainet-compile-dag:jvmTest --tests 'sk.ainet.compile.grad.DefaultExecutionTapeTest.*'` passes locally.
- [ ] End-to-end verification on skainet-whisper's `WhisperHloExportTest` + `iree-compile` (depends on bumping the skainet version in that repo).

## Out of scope
- `RecordingTensorOpsDecorator.conv1d` / `.conv3d` in `skainet-compile-core` still skip `record(...)` entirely (unlike `conv2d`). Filed as a separate follow-up — the Whisper path doesn't exercise that decorator today, so it isn't load-bearing for the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)