### PR TITLE
Set HOME=/tmp in Antora image so chromium crashpad can launch

### DIFF
--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -7,8 +7,14 @@ LABEL org.opencontainers.image.title="SKaiNET Antora" \
 # Chromium for mermaid-cli (puppeteer)
 RUN apk add --no-cache chromium font-noto
 
+# HOME=/tmp: chromium's crashpad handler writes its database under $HOME and
+# aborts with `chrome_crashpad_handler: --database is required` when the
+# container runs as `--user $(id -u):$(id -g)` and $HOME falls back to `/`
+# (no passwd entry, not writable). Same motivation as runtime.cache_dir in
+# antora-playbook.yml.
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
-    PUPPETEER_SKIP_DOWNLOAD=true
+    PUPPETEER_SKIP_DOWNLOAD=true \
+    HOME=/tmp
 
 # Install Antora + mermaid-cli into /opt/antora (not /antora which gets
 # volume-mounted at run time). asciidoctor-kroki is intentionally NOT
@@ -37,10 +43,14 @@ RUN echo '{ \
 # Antora playbook can reference it without any volume-mount gymnastics.
 COPY local-mermaid-extension.js /opt/antora/local-mermaid-extension.js
 
-# Verify mermaid-cli works end to end at image build time.
+# Verify mermaid-cli works end to end at image build time. The cleanup
+# also removes mode-0700 root-owned dirs (e.g. /tmp/.config/puppeteer,
+# /tmp/.local/share/chromium) that puppeteer/chromium drop into $HOME
+# during this run — leaving them in place would make cosmiconfig EACCES
+# when the container is later launched with a non-root --user.
 RUN echo 'graph TD; A-->B;' > /tmp/test.mmd \
     && npx mmdc -i /tmp/test.mmd -o /tmp/test.svg -p /opt/antora/puppeteer-config.json \
-    && rm /tmp/test.mmd /tmp/test.svg
+    && rm -rf /tmp/test.mmd /tmp/test.svg /tmp/.config /tmp/.local /tmp/.npm /tmp/.cache
 
 ENTRYPOINT ["/opt/antora/node_modules/.bin/antora"]
 CMD ["--stacktrace", "antora-playbook.yml"]


### PR DESCRIPTION
## Summary
- Mermaid blocks were rendering as the error literal in the Docs workflow ([example run](https://github.com/SKaiNET-developers/SKaiNET/actions/runs/24634875310)) with `chrome_crashpad_handler: --database is required` → `Failed to launch the browser process`.
- Root cause: the workflow runs the Antora container with `--user $(id -u):$(id -g)`, which has no passwd entry inside the Alpine image. `$HOME` falls back to `/` (read-only for non-root), so chromium's crashpad handler cannot create its default DB.
- Fix: pin `HOME=/tmp` in the image, plus clean up the mode-0700 root-owned dirs that the build-time smoke test drops into `/tmp` (otherwise the runtime non-root user EACCES on `cosmiconfig` walking `/tmp/.config/puppeteer`). Same root cause is already worked around for Antora's cache via `runtime.cache_dir` in `antora-playbook.yml`.

## Test plan
- [x] Rebuild image locally with `--no-cache`
- [x] Run `mmdc` against the failing `flowchart LR` snippet under `--user $(id -u):$(id -g)` → produces a valid SVG (10.5 KB) instead of the crashpad error
- [ ] Docs workflow on this PR completes the Antora build with mermaid diagrams rendered inline (no `mermaid-error` literals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)