### PR TITLE
bench(kernel): KernelMatmulBench — scalar vs Panama (M5 evidence)

### DIFF
--- a/docs/modules/ROOT/pages/explanation/perf/jvm-cpu.adoc
+++ b/docs/modules/ROOT/pages/explanation/perf/jvm-cpu.adoc
@@ -6,7 +6,8 @@ This page explains how to run the JMH benchmarks for the JVM CPU backend and how
 
 * Elementwise: FP32 `add` on 1,000,000 elements
 * Reductions: FP32 `sum` and `mean` on 1,000,000 elements
-* Matmul: FP32 square `matmul` with sizes 256, 512, and 1024
+* Matmul (op-level): FP32 square `matmul` with sizes 256, 512, and 1024 — exercises `ctx.ops.matmul`, i.e. the production routing path
+* Matmul (kernel-level): direct `Fp32MatmulKernel.matmul` invocation, scalar vs Panama Vector, sizes 256/512/1024 — used to validate the M5 milestone target (Panama ≥1.5× scalar) without entanglement from the rest of the op pipeline
 
 Benchmarks are implemented in module:
 
@@ -17,6 +18,7 @@ Source files:
 * `src/jmh/kotlin/sk/ainet/bench/ElementwiseAdd1MBench.kt`
 * `src/jmh/kotlin/sk/ainet/bench/Reductions1MBench.kt`
 * `src/jmh/kotlin/sk/ainet/bench/MatmulBench.kt`
+* `src/jmh/kotlin/sk/ainet/bench/KernelMatmulBench.kt`
 
 ===== Prerequisites
 
@@ -73,6 +75,13 @@ This will build and execute all JMH benchmarks with the default parameters defin
   -Pjmh.include=MatmulBench \
   -Pjmh.param.vectorEnabled=true \
   -Pjmh.param.blasEnabled=true
+....
+
+* Kernel-level scalar vs Panama at all sizes (M5 ≥1.5× target):
+
+....
+./gradlew :skainet-backends:benchmarks:jvm-cpu-jmh:jmh \
+  -Pjmh.include=KernelMatmulBench
 ....
 
 * Matmul at 512 only, comparing BLAS on/off with vector on:

--- a/skainet-backends/benchmarks/jvm-cpu-jmh/build.gradle.kts
+++ b/skainet-backends/benchmarks/jvm-cpu-jmh/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":skainet-lang:skainet-lang-core"))
+    implementation(project(":skainet-backends:skainet-backend-api"))
     implementation(project(":skainet-backends:skainet-backend-cpu"))
 }
 

--- a/skainet-backends/benchmarks/jvm-cpu-jmh/src/jmh/kotlin/sk/ainet/bench/KernelMatmulBench.kt
+++ b/skainet-backends/benchmarks/jvm-cpu-jmh/src/jmh/kotlin/sk/ainet/bench/KernelMatmulBench.kt
@@ -1,0 +1,70 @@
+package sk.ainet.bench
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import sk.ainet.backend.api.kernel.Fp32MatmulKernel
+import sk.ainet.exec.kernel.PanamaVectorMatmulKernel
+import sk.ainet.exec.kernel.ScalarMatmulKernel
+
+/**
+ * Direct kernel-level matmul bench: `Fp32MatmulKernel.matmul` only,
+ * with no `TensorOps` wrapper / dispatch / context allocation in the
+ * timed region. Used to validate the M5 milestone target — Panama
+ * Vector kernel ≥ 1.5× scalar — independent of the rest of the op
+ * pipeline.
+ *
+ * Compare against `MatmulBench`, which exercises the same operation
+ * through `ctx.ops.matmul` (production routing). Until
+ * `DefaultCpuOpsJvm.matmul` is wired through `KernelRegistry`, only
+ * this bench reflects pure kernel-vs-kernel performance.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class KernelMatmulBench {
+
+    @Param("256", "512", "1024")
+    var size: Int = 512
+
+    @Param("scalar", "panama")
+    var provider: String = "panama"
+
+    private lateinit var kernel: Fp32MatmulKernel
+    private lateinit var a: FloatArray
+    private lateinit var b: FloatArray
+    private lateinit var out: FloatArray
+
+    @Setup(Level.Trial)
+    fun setup() {
+        kernel = when (provider) {
+            "scalar" -> ScalarMatmulKernel
+            "panama" -> PanamaVectorMatmulKernel
+            else -> error("unknown provider: $provider")
+        }
+        val n = size
+        // Same input seeding as MatmulBench so numbers compare cleanly.
+        a = FloatArray(n * n) { ((it % 251) - 125).toFloat() / 127f }
+        b = FloatArray(n * n) { ((it * 13 % 257) - 128).toFloat() / 127f }
+        out = FloatArray(n * n)
+    }
+
+    @Benchmark
+    fun matmul_fp32_square(): FloatArray {
+        val n = size
+        kernel.matmul(
+            a, 0, n,
+            b, 0, n,
+            out, 0, n,
+            n, n, n,
+        )
+        return out
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `KernelMatmulBench` to `:skainet-backends:benchmarks:jvm-cpu-jmh` — a direct `Fp32MatmulKernel.matmul` JMH harness with `provider ∈ {scalar, panama}` and `size ∈ {256, 512, 1024}`.
- Validates the **M5 milestone target** (Panama ≥1.5× scalar through the kernel SPI) **without** entanglement from `ctx.ops.matmul` routing — that routing change is the next follow-up.
- Adds `skainet-backend-api` as a direct dep on the bench module so JMH sources can see the SPI types directly.
- Documents the new bench in `docs/.../perf/jvm-cpu.adoc`.

## Local run — JDK 21.0.10, M-series macOS

| size | scalar (ms/op) | panama (ms/op) | **speedup** |
|------|----------------|----------------|-------------|
| 256  | 9.454 ± 0.364  | 1.356 ± 0.041  | **6.97×**   |
| 512  | 79.679 ± 0.754 | 13.620 ± 0.109 | **5.85×**   |
| 1024 | 862.754 ± 40.256 | 118.242 ± 0.507 | **7.30×** |

JMH config: `--enable-preview --add-modules jdk.incubator.vector`, 3 warmup × 10s + 5 measurement × 10s, 1 fork. Same input seeding as the existing `MatmulBench` so cross-bench comparison is meaningful.

Reference: `MatmulBench` (full op-level path, BLAS off, vector on) on the same machine clocks **9.74 ms @ 512²**, slightly faster than this kernel's **13.62 ms @ 512²**. The gap is the cache-blocked tiled implementation in `JvmVectorKernels.matmulFloatBlocked` that the production routing currently calls; the SPI kernel uses a simpler FMA + B^T pack. Closing that gap by porting the tiling into the SPI kernel is a fair follow-up if the production bench numbers regress after the routing change.

## Why direct kernel benching

`MatmulBench` exercises `ctx.ops.matmul`, which today still calls `JvmVectorKernels` directly (not the SPI). Until that routing change lands, only this new bench reflects scalar-vs-Panama through the kernel SPI in isolation. Once routing flips, the existing `MatmulBench` will exercise the same provider end-to-end and we can decide whether to keep both benches or fold one in.

## Test plan

- [x] `./gradlew :skainet-backends:benchmarks:jvm-cpu-jmh:jmhCompileGeneratedClasses` — compiles cleanly.
- [x] `./gradlew :skainet-backends:benchmarks:jvm-cpu-jmh:jmh -Pjmh.include=KernelMatmulBench` — produces the numbers above.

## Follow-ups (still in M5 hopper)

- Route `DefaultCpuOpsJvm.matmul` through `KernelRegistry`.
- `ServiceLoader` auto-discovery for kernel providers.
- Cache-blocked variant of `PanamaVectorMatmulKernel` if/when production routing exposes a regression vs the current `matmulFloatBlocked` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)