### PR TITLE
perf(kernel): cache-block PanamaVectorMatmulKernel (8x8x128 tiles)

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/PanamaVectorMatmulKernel.kt
+++ b/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/PanamaVectorMatmulKernel.kt
@@ -12,15 +12,20 @@ import sk.ainet.backend.api.kernel.Fp32MatmulKernel
  *
  * Strategy:
  * - Pack `B` into a transposed buffer `bt` of shape `(n, k)` so the
- *   inner reduction streams contiguously over `k` for both operands —
- *   `a[i, kk]` walks one row of `A` and `bt[j, kk]` walks one row of
- *   the packed transpose.
- * - Inner loop is a vector-width FMA accumulator (`v.fma(w, acc)`),
- *   reduced once per `(i, j)` pair via `reduceLanes(ADD)`.
- * - Tail elements that don't fill a vector lane are handled in scalar.
+ *   inner reduction streams contiguously over `k` for both operands.
+ * - Cache-block the `(m, n, k)` iteration space with tiles
+ *   ([TILE_M], [TILE_N], [TILE_K]). Default 8×8×128 keeps a working
+ *   set well under L1 — eight A rows × 128 floats + eight Bᵀ rows ×
+ *   128 floats ≈ 8 KB, within typical 32 KB L1.
+ * - Inner reduction is a vector-width FMA accumulator
+ *   (`v.fma(w, acc)`), reduced via `reduceLanes(ADD)` once per
+ *   `(i, j)` cell per K-tile. Tail elements that don't fill a vector
+ *   lane are handled in scalar.
+ * - Output is zeroed once up front; per-tile work accumulates via `+=`
+ *   so the K-loop can split across multiple tiles cleanly.
  *
- * The B-pack is `O(n * k)` floats per call; that's cheap relative to
- * the `O(m * n * k)` FLOPs but still allocates each invocation. A
+ * The B-pack is `O(n * k)` floats per call; cheap relative to the
+ * `O(m * n * k)` FLOPs but still allocates each invocation. A
  * scratch-pool integration is out of scope for this kernel and lives
  * one layer up (see `ScratchPool` SPI in `skainet-lang-core`).
  *
@@ -30,6 +35,10 @@ import sk.ainet.backend.api.kernel.Fp32MatmulKernel
  */
 public object PanamaVectorMatmulKernel : Fp32MatmulKernel {
     private val species: VectorSpecies<Float> = FloatVector.SPECIES_PREFERRED
+
+    private const val TILE_M = 8
+    private const val TILE_N = 8
+    private const val TILE_K = 128
 
     override fun matmul(
         a: FloatArray, aOffset: Int, aStride: Int,
@@ -41,13 +50,14 @@ public object PanamaVectorMatmulKernel : Fp32MatmulKernel {
             "PanamaVectorMatmulKernel: m, n, k must be non-negative; got m=$m n=$n k=$k"
         }
         if (m == 0 || n == 0) return
-        if (k == 0) {
-            for (i in 0 until m) {
-                val rowOff = outOffset + i * outStride
-                for (j in 0 until n) out[rowOff + j] = 0f
-            }
-            return
+        // Zero the m×n output block once. The K-tile loop accumulates
+        // via `+=`, so the contract "fully overwrite the output block"
+        // is preserved even when k == 0 (no tile loop runs).
+        for (i in 0 until m) {
+            val rowOff = outOffset + i * outStride
+            for (j in 0 until n) out[rowOff + j] = 0f
         }
+        if (k == 0) return
 
         // Pack B^T: bt[j, kk] = b[kk, j].
         val bt = FloatArray(n * k)
@@ -59,28 +69,44 @@ public object PanamaVectorMatmulKernel : Fp32MatmulKernel {
         }
 
         val step = species.length()
-        val loopBound = species.loopBound(k)
 
-        for (i in 0 until m) {
-            val aRow = aOffset + i * aStride
-            val outRow = outOffset + i * outStride
-            for (j in 0 until n) {
-                val btRow = j * k
-                var acc = FloatVector.zero(species)
-                var idx = 0
-                while (idx < loopBound) {
-                    val va = FloatVector.fromArray(species, a, aRow + idx)
-                    val vb = FloatVector.fromArray(species, bt, btRow + idx)
-                    acc = va.fma(vb, acc)
-                    idx += step
+        var mTile = 0
+        while (mTile < m) {
+            val mEnd = minOf(mTile + TILE_M, m)
+            var nTile = 0
+            while (nTile < n) {
+                val nEnd = minOf(nTile + TILE_N, n)
+                var kTile = 0
+                while (kTile < k) {
+                    val kEnd = minOf(kTile + TILE_K, k)
+                    val kLen = kEnd - kTile
+                    val loopBound = species.loopBound(kLen)
+                    for (i in mTile until mEnd) {
+                        val aRowBase = aOffset + i * aStride + kTile
+                        val outRowBase = outOffset + i * outStride
+                        for (j in nTile until nEnd) {
+                            val btRowBase = j * k + kTile
+                            var acc = FloatVector.zero(species)
+                            var idx = 0
+                            while (idx < loopBound) {
+                                val va = FloatVector.fromArray(species, a, aRowBase + idx)
+                                val vb = FloatVector.fromArray(species, bt, btRowBase + idx)
+                                acc = va.fma(vb, acc)
+                                idx += step
+                            }
+                            var sum = acc.reduceLanes(VectorOperators.ADD)
+                            while (idx < kLen) {
+                                sum += a[aRowBase + idx] * bt[btRowBase + idx]
+                                idx++
+                            }
+                            out[outRowBase + j] += sum
+                        }
+                    }
+                    kTile = kEnd
                 }
-                var sum = acc.reduceLanes(VectorOperators.ADD)
-                while (idx < k) {
-                    sum += a[aRow + idx] * bt[btRow + idx]
-                    idx++
-                }
-                out[outRow + j] = sum
+                nTile = nEnd
             }
+            mTile = mEnd
         }
     }
 }


### PR DESCRIPTION
## Summary

- Ports the `(m, n, k)`-tile blocking pattern from `JvmVectorKernels.matmulFloatBlocked` into `PanamaVectorMatmulKernel`. Tiles: `tileM=8`, `tileN=8`, `tileK=128`. Working set per tile ≈ 8 KB, comfortably within typical L1 (32 KB).
- Closes the perf gap flagged by #558. The SPI kernel now matches or beats the existing production blocked path within JMH noise — **routing `DefaultCpuOpsJvm.matmul` through `KernelRegistry` won't show a regression any more**, just slight wins at small/medium sizes.
- Output block is zeroed once up front; K-tile loop accumulates via `+=`. Cleaner than the original `matmulFloatBlocked`'s "init only on first tile" gating, which only worked because callers happen to pass freshly-allocated zero buffers.
- Boundary semantics unchanged: `m == 0 || n == 0` no-op, `k == 0` zeros the output block.

## Numbers

`KernelMatmulBench` (JDK 21.0.10, M-series macOS, fresh JMH run):

| size | scalar | panama (tiled) | **speedup** | prior simple panama | improvement |
|------|--------|----------------|-------------|---------------------|-------------|
| 256  | 9.77 ms | 1.13 ms | **8.61×** | 1.36 ms | -16% |
| 512  | 81.55 ms | 9.47 ms | **8.62×** | 13.62 ms | -30% |
| 1024 | 865.54 ms | 79.88 ms | **10.83×** | 118.24 ms | -32% |

`MatmulBench` (production routing, `vectorEnabled=true`, `blasEnabled=false`) on the same run:

| size | SPI tiled | production blocked | delta |
|------|-----------|-------------------|-------|
| 256  | 1.13 ms | 1.24 ms | **SPI 8.5% faster** |
| 512  | 9.47 ms | 10.38 ms | **SPI 8.8% faster** |
| 1024 | 79.88 ms | 78.32 ms | SPI 2% slower (within noise) |

`MatmulBench` for `vectorEnabled=false` (scalar production, sanity check): 10.07/83.95/864.56 ms at 256/512/1024 — matches `KernelMatmulBench` scalar within ±3% across the full table, confirming the bench is measuring the right thing in both harnesses.

## Test plan

- [x] `./gradlew :skainet-backends:skainet-backend-cpu:jvmTest --tests "sk.ainet.exec.kernel.*"` — all 30 kernel tests pass (8 PanamaVectorMatmulKernel + 5 provider + 4 ServiceLoader + 6 registry + 7 scalar). Parity tolerance unchanged at `1e-5 * k`.
- [x] The randomized 31×17×23 parity test exercises partial tiles in all three dims (m=31 → tiles 0-7, 8-15, 16-23, 24-30; n=17 → tiles 0-7, 8-15, 16; k=23 → single 0-22 tile shorter than `TILE_K`). Still passes.
- [x] `./gradlew :skainet-backends:benchmarks:jvm-cpu-jmh:jmh` — full bench run, numbers above.

## Out of scope

- **Routing `DefaultCpuOpsJvm.matmul` through `KernelRegistry`** — now safe to do as the next M5 PR. With this change merged, that PR is purely a wiring switch; no perf risk.
- Further tuning of `TILE_*` constants for specific microarchitectures.
- Register-blocking variants (broadcast `va`, accumulate `tileN` j-cells in parallel) — would push throughput further but the simple tile+FMA already tracks production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)