### PR TITLE
feat(native-cpu): scaffold FFM kernel provider module (PR 1 of 5)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include("skainet-compile:skainet-compile-c")
 // ====== BACKENDS
 include("skainet-backends:skainet-backend-api")
 include("skainet-backends:skainet-backend-cpu")
+include("skainet-backends:skainet-backend-native-cpu")
 
 // ====== BENCHMARKS
 include("skainet-backends:benchmarks:jvm-cpu-jmh")

--- a/skainet-backends/skainet-backend-native-cpu/build.gradle.kts
+++ b/skainet-backends/skainet-backend-native-cpu/build.gradle.kts
@@ -1,0 +1,115 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+}
+
+kotlin {
+    explicitApi()
+    jvm()
+
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                implementation(project(":skainet-backends:skainet-backend-api"))
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+        }
+    }
+}
+
+// --- Native (CMake) wiring -------------------------------------------------
+//
+// PR 1 builds for the host arch only. Cross-arch CI matrix is deferred per
+// the native-ffm-plan asciidoc. The artifact lands at
+//   build/native/resources/native/<os>-<arch>/libskainet_kernels.{so|dylib|dll}
+// and is bundled into the JAR via an extra resources srcDir on jvmMain.
+
+val nativeOsArch: String = run {
+    val os = System.getProperty("os.name").lowercase()
+    val osTag = when {
+        os.contains("linux") -> "linux"
+        os.contains("mac") || os.contains("darwin") -> "macos"
+        os.contains("windows") -> "windows"
+        else -> error("Unsupported OS for skainet-backend-native-cpu: $os")
+    }
+    val archRaw = System.getProperty("os.arch").lowercase()
+    val archTag = when (archRaw) {
+        "x86_64", "amd64" -> "x86_64"
+        "aarch64", "arm64" -> "arm64"
+        else -> error("Unsupported arch for skainet-backend-native-cpu: $archRaw")
+    }
+    "$osTag-$archTag"
+}
+
+// Capture as plain Strings up front so configuration-cache serialization
+// doesn't have to walk back to the build script for Provider resolution.
+val nativeSourcePath: String = layout.projectDirectory.dir("native").asFile.absolutePath
+val cmakeBuildPath: String = layout.buildDirectory.dir("native/cmake-build").get().asFile.absolutePath
+val nativeResourcesRoot = layout.buildDirectory.dir("native/resources")
+val nativeResourceTargetDir = nativeResourcesRoot.map { it.dir("native/$nativeOsArch") }
+
+val configureNativeKernels by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Run CMake configure step for the native kernels library."
+    inputs.file("$nativeSourcePath/CMakeLists.txt")
+    inputs.dir("$nativeSourcePath/src")
+    inputs.dir("$nativeSourcePath/include")
+    outputs.dir(cmakeBuildPath)
+    // CMake auto-creates the -B directory; no doFirst mkdirs needed.
+    commandLine = listOf(
+        "cmake",
+        "-S", nativeSourcePath,
+        "-B", cmakeBuildPath,
+        "-DCMAKE_BUILD_TYPE=Release",
+    )
+}
+
+val buildNativeKernels by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Build the native kernels shared library via CMake."
+    dependsOn(configureNativeKernels)
+    inputs.file("$nativeSourcePath/CMakeLists.txt")
+    inputs.dir("$nativeSourcePath/src")
+    inputs.dir("$nativeSourcePath/include")
+    outputs.dir(cmakeBuildPath)
+    commandLine = listOf(
+        "cmake",
+        "--build", cmakeBuildPath,
+        "--config", "Release",
+    )
+}
+
+val packageNativeKernels by tasks.registering(Copy::class) {
+    group = "build"
+    description = "Stage the built native kernels library into JVM resources."
+    dependsOn(buildNativeKernels)
+    from(cmakeBuildPath) {
+        include(
+            "libskainet_kernels.so",
+            "libskainet_kernels.dylib",
+            "skainet_kernels.dll",
+            "Release/skainet_kernels.dll",
+        )
+        eachFile { path = name }
+    }
+    into(nativeResourceTargetDir)
+}
+
+kotlin.sourceSets.named("jvmMain") {
+    resources.srcDir(nativeResourcesRoot)
+}
+
+tasks.named("jvmProcessResources") {
+    dependsOn(packageNativeKernels)
+}
+
+tasks.withType<Test>().configureEach {
+    jvmArgs("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+}
+
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+}

--- a/skainet-backends/skainet-backend-native-cpu/native/CMakeLists.txt
+++ b/skainet-backends/skainet-backend-native-cpu/native/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.20)
+project(skainet_kernels C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+add_library(skainet_kernels SHARED
+    src/skainet_smoke.c
+)
+
+target_include_directories(skainet_kernels PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+# Strip the "lib" prefix on Windows so the artifact name is consistent
+# with the resource-bundle path skainet_kernels.{dll,so,dylib}.
+if(WIN32)
+    set_target_properties(skainet_kernels PROPERTIES PREFIX "")
+endif()
+
+# Hide non-exported symbols on ELF / Mach-O for a smaller surface area.
+if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+    target_compile_options(skainet_kernels PRIVATE -fvisibility=hidden -Wall -Wextra)
+    set_target_properties(skainet_kernels PROPERTIES C_VISIBILITY_PRESET hidden)
+endif()

--- a/skainet-backends/skainet-backend-native-cpu/native/include/skainet_kernels.h
+++ b/skainet-backends/skainet-backend-native-cpu/native/include/skainet_kernels.h
@@ -1,0 +1,32 @@
+#ifndef SKAINET_KERNELS_H
+#define SKAINET_KERNELS_H
+
+#include <stdint.h>
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  define SKAINET_API __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#  define SKAINET_API __attribute__((visibility("default")))
+#else
+#  define SKAINET_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Trivial smoke kernel proving the FFM downcall pipeline end-to-end.
+ *
+ *   for (int i = 0; i < length; ++i) output[i] = 2.0f * input[i];
+ *
+ * The Kotlin caller owns the memory backing `input` and `output`; the
+ * kernel must not retain pointers past return.
+ */
+SKAINET_API void skainet_smoke_double(const float* input, float* output, int32_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SKAINET_KERNELS_H */

--- a/skainet-backends/skainet-backend-native-cpu/native/src/skainet_smoke.c
+++ b/skainet-backends/skainet-backend-native-cpu/native/src/skainet_smoke.c
@@ -1,0 +1,7 @@
+#include "skainet_kernels.h"
+
+void skainet_smoke_double(const float* input, float* output, int32_t length) {
+    for (int32_t i = 0; i < length; ++i) {
+        output[i] = 2.0f * input[i];
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeFfmSmoke.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeFfmSmoke.kt
@@ -1,0 +1,58 @@
+package sk.ainet.exec.kernel
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
+
+/**
+ * End-to-end smoke test of the FFM downcall pipeline used by the
+ * native kernel provider. Calls the bundled native function
+ *
+ *   void skainet_smoke_double(const float* input, float* output, int32_t length);
+ *
+ * which writes `output[i] = 2.0f * input[i]`. This object exists only
+ * to validate the loader → Linker → MethodHandle path on real hardware
+ * before any production kernel ships in PR 2.
+ *
+ * Not part of the public SPI: `internal` visibility, exposed to tests
+ * via the same package.
+ */
+internal object NativeFfmSmoke {
+
+    fun isAvailable(): Boolean = handle != null
+
+    /**
+     * Run the bundled smoke kernel on [input] and return a fresh
+     * `FloatArray` with `output[i] = 2.0f * input[i]`. Returns `null`
+     * when the native lib failed to load (callers fall back to a
+     * pure-Kotlin reference).
+     */
+    fun double(input: FloatArray): FloatArray? {
+        val mh = handle ?: return null
+        val output = FloatArray(input.size)
+        val byteSize = input.size.toLong() * java.lang.Float.BYTES
+        val byteAlign = ValueLayout.JAVA_FLOAT.byteAlignment()
+        Arena.ofConfined().use { arena ->
+            val inSeg = arena.allocate(byteSize, byteAlign)
+            val outSeg = arena.allocate(byteSize, byteAlign)
+            MemorySegment.copy(input, 0, inSeg, ValueLayout.JAVA_FLOAT, 0L, input.size)
+            mh.invoke(inSeg, outSeg, input.size)
+            MemorySegment.copy(outSeg, ValueLayout.JAVA_FLOAT, 0L, output, 0, output.size)
+        }
+        return output
+    }
+
+    private val handle: MethodHandle? by lazy {
+        val lookup = NativeLibraryLoader.lookup() ?: return@lazy null
+        val symbol = lookup.find("skainet_smoke_double").orElse(null) ?: return@lazy null
+        val descriptor = FunctionDescriptor.ofVoid(
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+            ValueLayout.JAVA_INT,
+        )
+        runCatching { Linker.nativeLinker().downcallHandle(symbol, descriptor) }.getOrNull()
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeKernelProvider.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeKernelProvider.kt
@@ -1,0 +1,33 @@
+package sk.ainet.exec.kernel
+
+import sk.ainet.backend.api.kernel.Fp32MatmulKernel
+import sk.ainet.backend.api.kernel.KernelProvider
+import sk.ainet.backend.api.kernel.Q4KMatmulKernel
+
+/**
+ * Native (FFM) [KernelProvider]. Sits at priority `100`, above
+ * [PanamaVectorKernelProvider] (`50`) and the scalar reference (`0`).
+ *
+ * PR 1 of the staged native-FFM rollout (see the `native-ffm-plan`
+ * asciidoc) only ships the module scaffolding: the Gradle ↔ CMake
+ * pipeline that produces a host-arch shared library, its bundling into
+ * JAR resources, and an end-to-end FFM smoke downcall test. No real
+ * matmul kernel is wired into the public SPI yet.
+ *
+ * Until [NativeQ4KMatmulKernel] (or its `MemSegment`-input sibling)
+ * lands in PR 2, this provider deliberately reports `isAvailable() =
+ * false` and returns `null` from every kernel accessor. That keeps
+ * `KernelRegistry.bestAvailable()` cleanly cascading down to the
+ * Panama priority-50 provider on every shape we measure today, so
+ * adding the new module to the classpath produces no behavior change.
+ */
+public object NativeKernelProvider : KernelProvider {
+    override val name: String = "native-ffm"
+    override val priority: Int = 100
+
+    override fun isAvailable(): Boolean = false
+
+    override fun matmulFp32(): Fp32MatmulKernel? = null
+
+    override fun matmulQ4K(): Q4KMatmulKernel? = null
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeKernelProviderFactory.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeKernelProviderFactory.kt
@@ -1,0 +1,16 @@
+package sk.ainet.exec.kernel
+
+import sk.ainet.backend.api.kernel.KernelProvider
+
+/**
+ * `ServiceLoader`-friendly wrapper around [NativeKernelProvider]. The
+ * platform `ServiceLoader` machinery requires a public no-arg
+ * constructor, which a Kotlin `object` does not expose; this factory
+ * delegates every [KernelProvider] member back to the singleton.
+ *
+ * Listed in
+ * `META-INF/services/sk.ainet.backend.api.kernel.KernelProvider` so
+ * `KernelServiceLoader.installAll()` discovers the provider on JVM
+ * startup.
+ */
+public class NativeKernelProviderFactory : KernelProvider by NativeKernelProvider

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeLibraryLoader.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeLibraryLoader.kt
@@ -1,0 +1,107 @@
+package sk.ainet.exec.kernel
+
+import java.lang.foreign.Arena
+import java.lang.foreign.SymbolLookup
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Locates the bundled `libskainet_kernels` shared library shipped in
+ * this module's JAR resources, extracts it to a process-scoped temp
+ * directory, calls `System.load` on the resulting absolute path, and
+ * exposes a process-lifetime [SymbolLookup] for FFM downcalls.
+ *
+ * Resource layout: `native/<os>-<arch>/<libname>` where `<libname>` is
+ *  - `libskainet_kernels.so` on Linux
+ *  - `libskainet_kernels.dylib` on macOS
+ *  - `skainet_kernels.dll` on Windows
+ *
+ * `<os>-<arch>` is the same tag the Gradle build uses when staging the
+ * artifact (`linux-x86_64`, `linux-arm64`, `macos-arm64`, ...). PR 1
+ * only ships one variant per build host; cross-arch shipping comes in
+ * a later PR.
+ *
+ * Failure modes are non-fatal: missing resource, unsupported platform,
+ * or `System.load` failure → [tryInit] returns `false` and `lookup`
+ * stays `null`. Callers (notably [NativeKernelProvider.isAvailable])
+ * cascade to a lower-priority provider.
+ */
+internal object NativeLibraryLoader {
+
+    @Volatile
+    private var initialized: Boolean = false
+
+    @Volatile
+    private var loadedLookup: SymbolLookup? = null
+
+    /**
+     * The shared [Arena] that owns the [SymbolLookup]. Lifetime is the
+     * JVM process; deliberately not closed because the lib stays
+     * loaded until JVM exit.
+     */
+    private val arena: Arena = Arena.ofShared()
+
+    /** `true` when the lib has been resolved and `System.load`-ed. */
+    fun isLoaded(): Boolean = tryInit()
+
+    /** Symbol lookup for the loaded lib, or `null` if loading failed. */
+    fun lookup(): SymbolLookup? {
+        tryInit()
+        return loadedLookup
+    }
+
+    @Synchronized
+    private fun tryInit(): Boolean {
+        if (initialized) return loadedLookup != null
+        initialized = true
+
+        val resourcePath = resolveResourcePath() ?: return false
+        val loader = NativeLibraryLoader::class.java.classLoader
+            ?: ClassLoader.getSystemClassLoader()
+
+        val stream = loader.getResourceAsStream(resourcePath) ?: return false
+        val tmpDir: Path = Files.createTempDirectory("skainet-native-")
+        tmpDir.toFile().deleteOnExit()
+        val libFile = tmpDir.resolve(resourcePath.substringAfterLast('/'))
+        stream.use { Files.copy(it, libFile, StandardCopyOption.REPLACE_EXISTING) }
+        libFile.toFile().deleteOnExit()
+
+        return runCatching {
+            System.load(libFile.toAbsolutePath().toString())
+            loadedLookup = SymbolLookup.libraryLookup(libFile, arena)
+            true
+        }.getOrElse { false }
+    }
+
+    private fun resolveResourcePath(): String? {
+        val osTag = osTag() ?: return null
+        val archTag = archTag() ?: return null
+        val libName = when (osTag) {
+            "linux" -> "libskainet_kernels.so"
+            "macos" -> "libskainet_kernels.dylib"
+            "windows" -> "skainet_kernels.dll"
+            else -> return null
+        }
+        return "native/$osTag-$archTag/$libName"
+    }
+
+    private fun osTag(): String? {
+        val os = System.getProperty("os.name")?.lowercase() ?: return null
+        return when {
+            os.contains("linux") -> "linux"
+            os.contains("mac") || os.contains("darwin") -> "macos"
+            os.contains("windows") -> "windows"
+            else -> null
+        }
+    }
+
+    private fun archTag(): String? {
+        val arch = System.getProperty("os.arch")?.lowercase() ?: return null
+        return when (arch) {
+            "x86_64", "amd64" -> "x86_64"
+            "aarch64", "arm64" -> "arm64"
+            else -> null
+        }
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/services/sk.ainet.backend.api.kernel.KernelProvider
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/services/sk.ainet.backend.api.kernel.KernelProvider
@@ -1,0 +1,1 @@
+sk.ainet.exec.kernel.NativeKernelProviderFactory

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/NativeFfmPipelineTest.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/NativeFfmPipelineTest.kt
@@ -1,0 +1,54 @@
+package sk.ainet.exec.kernel
+
+import sk.ainet.backend.api.kernel.KernelRegistry
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NativeFfmPipelineTest {
+
+    @AfterTest
+    fun resetRegistry() {
+        KernelRegistry.clearForTesting()
+    }
+
+    @Test
+    fun `smoke kernel doubles its inputs end-to-end via FFM`() {
+        assertTrue(
+            NativeLibraryLoader.isLoaded(),
+            "Bundled libskainet_kernels resource missing for the host platform — " +
+                "did the CMake build run before jvmProcessResources?",
+        )
+        assertTrue(NativeFfmSmoke.isAvailable(), "skainet_smoke_double symbol not resolved")
+
+        val input = floatArrayOf(0f, 1f, -2.5f, 3.14159f, 1e6f)
+        val output = NativeFfmSmoke.double(input)
+        assertNotNull(output)
+        for (i in input.indices) {
+            assertEquals(2.0f * input[i], output[i], 0f, "index $i")
+        }
+    }
+
+    @Test
+    fun `provider stays unavailable in PR 1 so registry falls through`() {
+        assertEquals("native-ffm", NativeKernelProvider.name)
+        assertEquals(100, NativeKernelProvider.priority)
+        assertFalse(
+            NativeKernelProvider.isAvailable(),
+            "PR 1 deliberately keeps isAvailable() = false until a real kernel ships in PR 2",
+        )
+        assertEquals(null, NativeKernelProvider.matmulFp32())
+        assertEquals(null, NativeKernelProvider.matmulQ4K())
+    }
+
+    @Test
+    fun `factory delegates to the singleton`() {
+        val factory = NativeKernelProviderFactory()
+        assertEquals(NativeKernelProvider.name, factory.name)
+        assertEquals(NativeKernelProvider.priority, factory.priority)
+        assertEquals(NativeKernelProvider.isAvailable(), factory.isAvailable())
+    }
+}


### PR DESCRIPTION
## Summary
- New `skainet-backends/skainet-backend-native-cpu` module — stage 1 of the staged native-FFM rollout described in `docs/modules/ROOT/pages/explanation/perf/native-ffm-plan.adoc` (the rehome of the FFM PRD that was dropped from 0.21.0).
- Gradle ↔ CMake ↔ JAR-resources ↔ FFM downcall pipeline end-to-end with a trivial smoke C kernel (`output[i] = 2.0f * input[i]`). No production matmul wired in yet — that's PR 2.
- `NativeKernelProvider` registers at priority 100 but reports `isAvailable() = false`, so `KernelRegistry.bestAvailable()` cleanly cascades to `PanamaVectorKernelProvider` (priority 50) on every shape until a real Q4_K kernel ships.

## What's in the module
- `native/CMakeLists.txt` + `native/src/skainet_smoke.c` + `native/include/skainet_kernels.h` — single-source shared lib `libskainet_kernels.{so,dylib,dll}` with hidden default visibility and an explicit `SKAINET_API` export macro.
- `build.gradle.kts` — three Gradle tasks (`configureNativeKernels` → `buildNativeKernels` → `packageNativeKernels`) staged into `jvmProcessResources`, configuration-cache-clean. The `xnnpack` template the asciidoc references doesn't exist in-tree; rolled minimal Exec-based equivalent.
- `NativeKernelProvider` + `NativeKernelProviderFactory` + `META-INF/services/sk.ainet.backend.api.kernel.KernelProvider` for ServiceLoader auto-discovery.
- `NativeLibraryLoader` (resource extraction → `System.load` → process-lifetime `SymbolLookup` via `Arena.ofShared`).
- `NativeFfmSmoke` internal object — the actual `Linker.nativeLinker().downcallHandle` wiring, same shape as `JvmBlas.kt`'s precedent.

## Toolchain
Stays on JDK 21 with `--enable-preview` (FFM is preview in 21, finalized in 22). Test/JavaExec tasks add `--enable-preview --enable-native-access=ALL-UNNAMED`.

## Test plan
- [x] `:skainet-backends:skainet-backend-native-cpu:jvmJar` — 15 KB lib lands at `native/linux-x86_64/libskainet_kernels.so` inside the JAR
- [x] `:skainet-backends:skainet-backend-native-cpu:jvmTest` — 3/3 pass on linux-x86_64 + JDK 21.0.10 (FFM downcall doubles inputs end-to-end, provider stays unavailable, factory delegates)
- [x] `:skainet-backends:skainet-backend-cpu:jvmTest` — 218/218 pass, 0 failures, 0 skipped (priority-100 stub does not affect cascade)
- [ ] CI to verify on macOS arm64 / Linux arm64 (cross-arch matrix is PR 4)

## Out of scope (deferred per asciidoc staging)
- PR 2: Real Q4_K NEON kernel + parity vs `PanamaVectorQ4KMatmulKernel` + JMH bench
- PR 3: `Q4KMemSegMatmulKernel` SPI sibling for zero-copy mmap'd weights
- PR 4: linuxX64 AVX2 + cross-arch CI matrix
- PR 5: Native FP32 / Q6_K / Q8_0 kernels
- Maven Central native classifier publishing (separate plan)
- `vanniktech.mavenPublish`, `binary-compatibility-validator`, `sk.ainet.dokka` plugins on the new module — fold in when publishing matters

🤖 Generated with [Claude Code](https://claude.com/claude-code)