### PR TITLE
build(native-cpu): add publishing config + register in BOM

### DIFF
--- a/skainet-backends/skainet-backend-native-cpu/build.gradle.kts
+++ b/skainet-backends/skainet-backend-native-cpu/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.vanniktech.mavenPublish)
 }
 
 kotlin {

--- a/skainet-backends/skainet-backend-native-cpu/gradle.properties
+++ b/skainet-backends/skainet-backend-native-cpu/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-backend-native-cpu
+POM_NAME=skainet native (FFM) CPU kernel provider

--- a/skainet-bom/build.gradle.kts
+++ b/skainet-bom/build.gradle.kts
@@ -18,6 +18,12 @@ dependencies {
         // Backend abstraction + CPU backend
         api(project(":skainet-backends:skainet-backend-api"))
         api(project(":skainet-backends:skainet-backend-cpu"))
+        // Native (FFM) priority-100 kernel provider — bundles a
+        // libskainet_kernels shared library and overrides the
+        // priority-50 Panama kernels for Q4_K and FP32 matmul on
+        // hosts where the native lib resolves. Cascades to Panama
+        // otherwise (missing arch, sandbox, kill-switch).
+        api(project(":skainet-backends:skainet-backend-native-cpu"))
 
         // IO modules
         api(project(":skainet-io:skainet-io-core"))


### PR DESCRIPTION
## Summary

Layers the publishing setup that PR 1 of the native-FFM rollout (#571) deliberately deferred onto the now-shipped scaffolding + kernels. Downstream consumers (e.g. SKaiNET-transformers via composite build) can now substitute the published coordinates with a local project ref through the same path every other SKaiNET module uses.

## Changes

- **`skainet-backend-native-cpu/build.gradle.kts`** — add `alias(libs.plugins.vanniktech.mavenPublish)` to the plugins block. Auto-derives `sk.ainet.core:skainet-backend-native-cpu` coordinates from the root group + version + new `gradle.properties`.
- **`skainet-backend-native-cpu/gradle.properties`** (new) — `POM_ARTIFACT_ID=skainet-backend-native-cpu`, `POM_NAME=skainet native (FFM) CPU kernel provider`. Mirrors the convention every other publishable module uses.
- **`skainet-bom/build.gradle.kts`** — add `api(project(":skainet-backends:skainet-backend-native-cpu"))` alongside the existing backend-api / backend-cpu constraints so BOM consumers get a constrained version without a separate pin.

## Test plan

- [x] `./gradlew :skainet-backends:skainet-backend-native-cpu:publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false -PsignAllPublications=false` — publishes `sk.ainet.core:skainet-backend-native-cpu-jvm:0.22.0-SNAPSHOT` to `~/.m2`
- [x] `./gradlew publishToMavenLocal` (full repo) — green, no regressions
- [ ] PR 4's cross-arch CI matrix re-runs on this PR for the native module — confirms publishing didn't break anything per arch

## Note on multi-arch packaging

The published JAR carries only the host-arch shared library at `native/<os>-<arch>/libskainet_kernels.{so|dylib|dll}` — i.e. a JAR published from a Linux x86_64 host has only the `.so`. Multi-arch fat-JAR aggregation across the PR 4 CI matrix runners is still the deferred follow-up. Consumers on other arches cleanly fall through to Panama priority-50 when the native lib doesn't load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)