### PR TITLE
ci(native-cpu): drop linux-arm64 runner from multiarch matrix

### DIFF
--- a/.github/workflows/native-cpu-multiarch.yml
+++ b/.github/workflows/native-cpu-multiarch.yml
@@ -40,9 +40,10 @@ jobs:
           - os: ubuntu-latest
             arch_label: linux-x86_64
             lib_name: libskainet_kernels.so
-          - os: ubuntu-24.04-arm
-            arch_label: linux-arm64
-            lib_name: libskainet_kernels.so
+          # ubuntu-24.04-arm runner is removed for now — see #574 follow-up.
+          # Re-add once the runner-side issue is resolved (or replace with
+          # a self-hosted ARM64 runner). Linux ARM64 consumers fall back
+          # to the priority-50 Panama Vector provider until then.
           - os: macos-14
             arch_label: macos-arm64
             lib_name: libskainet_kernels.dylib


### PR DESCRIPTION
## Summary

Temporarily removes the `ubuntu-24.04-arm` runner from the native-cpu cross-arch CI matrix introduced in #574 — it's been failing on this repo. The other three hosts (linux-x86_64, macos-arm64, windows-x86_64) keep running.

Linux ARM64 consumers fall back to Panama priority-50 cleanly when no native lib resolves — same cascade path the rest of the cross-arch story relies on. **Re-adding is a one-line uncomment** once either the GitHub-hosted ARM runner stabilises or a self-hosted ARM64 runner is wired in.

## Test plan

- [x] Workflow still triggers on the three remaining matrix entries
- [ ] CI run on this PR is green for linux-x86_64 / macos-arm64 / windows-x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)