### PR TITLE
Prepare 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-04-30
+
+### Added
+
+- **`StreamingShardedSafeTensorsReader.loadTensorStorageMapped`** — by-name and by-`ShardedTensorInfo` overloads that mirror the existing single-file `StreamingSafeTensorsReader.loadTensorStorageMapped(tensor, filePath)`. Both return a `TensorStorage` whose `BufferHandle.FileBacked` references the resolved shard file's tensor byte range, enabling zero-copy / memory-mapped reads of tensors that exceed the 2 GB JVM `ByteArray` limit. The new methods delegate internally to the per-shard reader; callers don't need to know which physical shard contains a given tensor. Unblocks downstream consumers (e.g. SKaiNET-transformers' Gemma 4 PLE token-embedding table at ~4.7 GB BF16 on E2B) that previously rolled their own `FileChannel.map`. (PR #582)
+
 ## [0.22.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Add the core dependencies (Gradle Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("sk.ainet.core:SKaiNET-lang-core:0.22.0")
-    implementation("sk.ainet.core:SKaiNET-backend-cpu:0.22.0")
+    implementation("sk.ainet.core:SKaiNET-lang-core:0.22.1")
+    implementation("sk.ainet.core:SKaiNET-backend-cpu:0.22.1")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.22.0
+VERSION_NAME=0.22.1
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/


### PR DESCRIPTION
## Summary

Routine post-release merge bringing the `0.22.1` version bump + CHANGELOG entry forward into `develop`. Mirrors the 0.22.0 convention (PR #580).

`0.22.1` was tagged from this branch and is already live on Maven Central via `publish.yml` (`tags: '**'` triggers on tag push, not on this PR's merge). This PR is purely the develop-side housekeeping so:

- `gradle.properties` `VERSION_NAME` advances from `0.22.0` → `0.22.1` on develop
- The CHANGELOG `[0.22.1] - 2026-04-30` entry lands on develop
- README Quickstart coordinates show `0.22.1`
- Future releases branch from a develop that reflects the latest published version

Single commit (`6586ad9e`) on top of `develop`'s post-#582 tip — the same prep-commit shape as PR #580.

## Release content (already on Maven Central)

- **PR #582** — `loadTensorStorageMapped` on `StreamingShardedSafeTensorsReader`, by-name and by-`ShardedTensorInfo` overloads. File-backed `TensorStorage` for tensors that exceed the 2 GB JVM `ByteArray` limit. End-to-end consumer in SKaiNET-transformers: the Gemma 4 PLE token-embedding table (~4.7 GB BF16 on E2B) — see SKaiNET-transformers PR #90.

No other behavioural changes vs `0.22.0`.

## Test plan

- [x] `./gradlew allTests` on `release/0.22.1` HEAD — pass in 1m 38s, 1068 tasks (verified pre-tag).
- [x] Maven Central publish (`publish.yml` run `25181718325`) — completed, artifact `sk.ainet.core:skainet-io-safetensors:0.22.1` is resolvable.
- [x] Downstream verification: SKaiNET-transformers `feature/gemma4-ple-use-upstream-mmap` CI run `25184460014` — `Build & Test → completed success` resolving 0.22.1 from Maven Central (no `includeBuild` shortcut on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)