### PR TITLE
feat(gguf): implement createRandomAccessSource on Kotlin/Native via pread

### DIFF
--- a/skainet-io/skainet-io-core/src/nativeMain/kotlin/sk/ainet/io/PosixPreadRandomAccessSource.kt
+++ b/skainet-io/skainet-io-core/src/nativeMain/kotlin/sk/ainet/io/PosixPreadRandomAccessSource.kt
@@ -1,0 +1,104 @@
+package sk.ainet.io
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.usePinned
+import platform.posix.O_RDONLY
+import platform.posix.errno
+import platform.posix.fstat
+import platform.posix.pread
+import platform.posix.stat
+import platform.posix.strerror
+
+/**
+ * Native [RandomAccessSource] backed by POSIX `pread(2)`.
+ *
+ * `pread` is positional and atomic — it does not advance any shared seek
+ * pointer — so concurrent reads from different positions are safe without
+ * locking. [close] is single-shot.
+ *
+ * Used on macOS, iOS, and Linux native targets (which all share the
+ * `nativeMain` source set in this module). Android uses a separate JNI
+ * actual; JS / Wasm don't have a viable `pread` equivalent and continue
+ * to fall back to the legacy GGUF reader.
+ */
+@OptIn(ExperimentalForeignApi::class)
+public class PosixPreadRandomAccessSource private constructor(
+    private val fd: Int,
+    override val size: Long
+) : RandomAccessSource {
+
+    private var closed = false
+
+    override fun readAt(position: Long, length: Int): ByteArray {
+        require(position >= 0) { "Position must be non-negative: $position" }
+        require(length >= 0) { "Length must be non-negative: $length" }
+        require(position + length <= size) {
+            "Read beyond end of file: position=$position, length=$length, size=$size"
+        }
+        if (length == 0) return ByteArray(0)
+
+        val buffer = ByteArray(length)
+        val bytesRead = readAt(position, buffer, 0, length)
+        return if (bytesRead < length) buffer.copyOf(bytesRead) else buffer
+    }
+
+    override fun readAt(position: Long, buffer: ByteArray, offset: Int, length: Int): Int {
+        require(position >= 0) { "Position must be non-negative: $position" }
+        require(offset >= 0) { "Offset must be non-negative: $offset" }
+        require(length >= 0) { "Length must be non-negative: $length" }
+        require(offset + length <= buffer.size) {
+            "Buffer overflow: offset=$offset, length=$length, buffer.size=${buffer.size}"
+        }
+        check(!closed) { "Source is closed" }
+        if (length == 0) return 0
+
+        return buffer.usePinned { pinned ->
+            var totalRead = 0
+            while (totalRead < length) {
+                val n = pread(
+                    fd,
+                    pinned.addressOf(offset + totalRead),
+                    (length - totalRead).convert(),
+                    (position + totalRead).convert()
+                ).toInt()
+                if (n < 0) {
+                    val cause = strerror(errno)?.toKString() ?: "errno=$errno"
+                    error("pread failed at offset ${position + totalRead}: $cause")
+                }
+                if (n == 0) break // EOF
+                totalRead += n
+            }
+            totalRead
+        }
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        platform.posix.close(fd)
+    }
+
+    public companion object {
+        /**
+         * Open [path] for read-only random access. Returns `null` if the
+         * file cannot be opened or stat'd — matches [JvmRandomAccessSource]
+         * behaviour, letting consumers fall back to the legacy reader.
+         */
+        public fun open(path: String): PosixPreadRandomAccessSource? = memScoped {
+            val fd = platform.posix.open(path, O_RDONLY)
+            if (fd < 0) return@memScoped null
+            val st = alloc<stat>()
+            if (fstat(fd, st.ptr) != 0) {
+                platform.posix.close(fd)
+                return@memScoped null
+            }
+            PosixPreadRandomAccessSource(fd, st.st_size.toLong())
+        }
+    }
+}

--- a/skainet-io/skainet-io-core/src/nativeTest/kotlin/sk/ainet/io/PosixPreadRandomAccessSourceTest.kt
+++ b/skainet-io/skainet-io-core/src/nativeTest/kotlin/sk/ainet/io/PosixPreadRandomAccessSourceTest.kt
@@ -1,0 +1,126 @@
+package sk.ainet.io
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.write
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PosixPreadRandomAccessSourceTest {
+
+    private val expected = ByteArray(8192) { (it and 0xFF).toByte() } // 0..255 repeating
+    private lateinit var path: Path
+
+    @BeforeTest
+    fun setUp() {
+        path = Path(SystemTemporaryDirectory, "pread-test-${kotlin.random.Random.nextLong()}.bin")
+        SystemFileSystem.sink(path).buffered().use { it.write(expected) }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (SystemFileSystem.exists(path)) SystemFileSystem.delete(path)
+    }
+
+    @Test
+    fun open_reports_correct_size() {
+        val src = PosixPreadRandomAccessSource.open(path.toString())!!
+        try {
+            assertEquals(expected.size.toLong(), src.size)
+        } finally {
+            src.close()
+        }
+    }
+
+    @Test
+    fun read_at_zero_returns_prefix() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            val got = src.readAt(0, 16)
+            assertContentEquals(expected.copyOfRange(0, 16), got)
+        }
+    }
+
+    @Test
+    fun read_at_arbitrary_offset_returns_slice() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            val got = src.readAt(1234, 256)
+            assertContentEquals(expected.copyOfRange(1234, 1234 + 256), got)
+        }
+    }
+
+    @Test
+    fun read_at_end_returns_suffix() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            val got = src.readAt(expected.size - 32L, 32)
+            assertContentEquals(expected.copyOfRange(expected.size - 32, expected.size), got)
+        }
+    }
+
+    @Test
+    fun read_into_buffer_reports_bytes_read() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            val buf = ByteArray(64)
+            val n = src.readAt(100L, buf, 0, 64)
+            assertEquals(64, n)
+            assertContentEquals(expected.copyOfRange(100, 164), buf)
+        }
+    }
+
+    @Test
+    fun read_into_buffer_with_offset() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            val buf = ByteArray(128)
+            val n = src.readAt(50L, buf, offset = 32, length = 64)
+            assertEquals(64, n)
+            assertContentEquals(expected.copyOfRange(50, 114), buf.copyOfRange(32, 96))
+            // Bytes outside the requested window must remain zero.
+            for (i in 0 until 32) assertEquals(0, buf[i])
+            for (i in 96 until 128) assertEquals(0, buf[i])
+        }
+    }
+
+    @Test
+    fun read_past_end_throws() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            assertFailsWith<IllegalArgumentException> { src.readAt(expected.size - 1L, 16) }
+        }
+    }
+
+    @Test
+    fun negative_position_throws() {
+        PosixPreadRandomAccessSource.open(path.toString())!!.use { src ->
+            assertFailsWith<IllegalArgumentException> { src.readAt(-1L, 4) }
+        }
+    }
+
+    @Test
+    fun read_after_close_throws() {
+        val src = PosixPreadRandomAccessSource.open(path.toString())!!
+        src.close()
+        assertFailsWith<IllegalStateException> {
+            src.readAt(0L, ByteArray(4), 0, 4)
+        }
+    }
+
+    @Test
+    fun close_is_idempotent() {
+        val src = PosixPreadRandomAccessSource.open(path.toString())!!
+        src.close()
+        src.close() // must not throw
+        assertTrue(true)
+    }
+
+    @Test
+    fun open_missing_file_returns_null() {
+        val missing = Path(SystemTemporaryDirectory, "definitely-does-not-exist-${kotlin.random.Random.nextLong()}.bin")
+        assertNull(PosixPreadRandomAccessSource.open(missing.toString()))
+    }
+}

--- a/skainet-io/skainet-io-gguf/src/nativeMain/kotlin/sk/ainet/io/gguf/RandomAccessSourceFactory.native.kt
+++ b/skainet-io/skainet-io-gguf/src/nativeMain/kotlin/sk/ainet/io/gguf/RandomAccessSourceFactory.native.kt
@@ -1,13 +1,14 @@
 package sk.ainet.io.gguf
 
+import sk.ainet.io.PosixPreadRandomAccessSource
 import sk.ainet.io.RandomAccessSource
 
 /**
- * Native implementation of [createRandomAccessSource].
+ * Native implementation of [createRandomAccessSource] using POSIX `pread(2)`.
  *
- * Returns null as native random file access is not yet implemented.
- * Callers should fall back to legacy GGUFReader which loads the full file.
- *
- * Future: Could implement using POSIX pread() for efficient random access.
+ * Returns `null` if the file cannot be opened (missing, permission denied,
+ * etc.), matching the JVM actual's contract so callers can fall back to the
+ * legacy sequential reader.
  */
-public actual fun createRandomAccessSource(filePath: String): RandomAccessSource? = null
+public actual fun createRandomAccessSource(filePath: String): RandomAccessSource? =
+    PosixPreadRandomAccessSource.open(filePath)


### PR DESCRIPTION
## Summary

Adds a POSIX-pread-backed `RandomAccessSource` so K/N consumers can read GGUF files of arbitrary size instead of slurping into a single `ByteArray` (capped at ~2 GiB / `Int.MAX_VALUE` bytes). `pread` is positional and atomic, so concurrent reads are safe without locking.

## Changes

- New `PosixPreadRandomAccessSource` in `skainet-io-core`'s `nativeMain` — covers `macosArm64`, `linuxX64`, `linuxArm64`, `iosArm64`, `iosSimulatorArm64` (everything in the default `nativeMain` source set on this module).
- `skainet-io-gguf`'s `nativeMain` factory delegates to it instead of returning `null`. Behaviour matches the JVM actual: returns `null` on open/stat failure so callers cleanly fall back to the legacy reader.
- 11 `nativeTest` cases covering size, partial reads, offset/length variants, EOF/argument validation, idempotent close, and missing-file null return.

## Test plan

- [x] `./gradlew :skainet-io:skainet-io-core:macosArm64Test` — 11/11 new tests pass
- [x] `./gradlew :skainet-io:skainet-io-core:jvmTest` — still passes (impl is K/N-only)
- [x] `./gradlew :skainet-io:skainet-io-gguf:macosArm64Test` — passes

Fixes #589