### PR TITLE
hotfix/0.23.1: complete BOM dependencyManagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-05-02
+
+### Fixed
+
+- **`skainet-bom` was missing nine published engine modules from `<dependencyManagement>`** — the umbrella BOM enumerated 16 modules but `sk.ainet.core` ships 25 from this repo. Notably absent: `skainet-compile-opt`, called out in #592, plus `skainet-compile-c`, `skainet-compile-dag`, `skainet-compile-json`, `skainet-io-iree-params`, `skainet-lang-dag`, `skainet-lang-models`, `skainet-lang-ksp-annotations`, and `skainet-lang-ksp-processor`. Effect: when a downstream pulled in the BOM and a transitive consumer requested an old version of any of these (e.g. `skainet-transformers-inference-bert:0.21.1` requesting `skainet-compile-opt:0.21.0`), Gradle resolved the unmanaged module at the older version and left a single-artifact version skew across an otherwise consistent engine. Reproduced against the BOM at 0.23.0; `skainet-compile-opt:0.21.0` stayed at `0.21.0` instead of upgrading to `0.23.0`. The BOM build script now constrains every module published from this repo, audited against `https://repo.maven.apache.org/maven2/sk/ainet/core/` so any module that ships a 0.23.x POM also has a constraint. (Issue #592)
+
 ## [0.23.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.23.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.23.1"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -143,6 +143,10 @@ SKaiNET is a modular ecosystem. While this repository contains the core engine, 
 
 ---
 
+## What's New in 0.23.1
+
+- **`skainet-bom` now constrains every published engine module** — 0.23.0 was missing 9 of 25, including `skainet-compile-opt`, leaving downstreams with version-skewed transitive deps. (Issue #592)
+
 ## What's New in 0.23.0
 
 - **Real-model GGUFs no longer OOM at network construction.** The DSL pre-allocated zero-filled `FloatArray(shape.volume)` for every Linear / Conv weight at module-creation time, even though downstream loaders overwrite those zeros immediately. For an Apertus-8B Q4_K_S GGUF (4.7 GB on disk) that was ~27 GB of FP32 zeros allocated and thrown away — OOMed at 12 GB heap. New `TensorDataFactory.placeholder(...)` API; every eager `zeros(...)` call site in the network builders routes through it. Lazy materialization fires only if a caller actually reads the tensor (which the load path never does). Verified end-to-end against `unsloth/Apertus-8B-Instruct-2509-GGUF`: now loads in 12 GB heap. Same fix benefits Gemma / Llama / Qwen / Voxtral DSL paths transparently. (Issue #587, PR #588)
@@ -150,6 +154,7 @@ SKaiNET is a modular ecosystem. While this repository contains the core engine, 
 
 ### Recent releases
 
+- **0.23.0** — Lazy zero-init for DSL parameter placeholders (Apertus-8B Q4_K_S now loads in 12 GB heap); K/N `pread`-backed random-access source so GGUFs over ~2 GiB load on macOS / Linux / iOS native. (PRs #588, #591)
 - **0.22.2** — `sk.ainet:skainet-bom` now resolves from Maven Central (earlier versions shipped at the wrong coordinates). (Issue #584)
 - **0.22.1** — `StreamingShardedSafeTensorsReader.loadTensorStorageMapped` for zero-copy reads of multi-shard tensors above the 2 GB JVM `ByteArray` limit. (PR #582)
 - **0.22.0** — Native (FFM) CPU kernel provider: **4–6× faster Q4_K matmul, 1.5–1.8× FP32 SGEMM** vs Panama Vector; auto-selected via `KernelRegistry.bestAvailable()`. (PR #571)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.23.0
+VERSION_NAME=0.23.1
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/

--- a/skainet-bom/build.gradle.kts
+++ b/skainet-bom/build.gradle.kts
@@ -26,8 +26,12 @@ javaPlatform {
 
 dependencies {
     constraints {
-        // Core language module
+        // Language modules
         api(project(":skainet-lang:skainet-lang-core"))
+        api(project(":skainet-lang:skainet-lang-dag"))
+        api(project(":skainet-lang:skainet-lang-models"))
+        api(project(":skainet-lang:skainet-lang-ksp-annotations"))
+        api(project(":skainet-lang:skainet-lang-ksp-processor"))
 
         // Backend abstraction + CPU backend
         api(project(":skainet-backends:skainet-backend-api"))
@@ -45,6 +49,7 @@ dependencies {
         api(project(":skainet-io:skainet-io-safetensors"))
         api(project(":skainet-io:skainet-io-onnx"))
         api(project(":skainet-io:skainet-io-image"))
+        api(project(":skainet-io:skainet-io-iree-params"))
 
         // Data modules
         api(project(":skainet-data:skainet-data-api"))
@@ -53,7 +58,11 @@ dependencies {
 
         // Compilation
         api(project(":skainet-compile:skainet-compile-core"))
+        api(project(":skainet-compile:skainet-compile-dag"))
+        api(project(":skainet-compile:skainet-compile-opt"))
+        api(project(":skainet-compile:skainet-compile-json"))
         api(project(":skainet-compile:skainet-compile-hlo"))
+        api(project(":skainet-compile:skainet-compile-c"))
 
         // Pipeline
         api(project(":skainet-pipeline"))


### PR DESCRIPTION
## Summary

- Fixes #592 — `skainet-bom` 0.23.0 listed 16 modules but `sk.ainet.core` ships 25; downstream transitive deps on the unmanaged ones resolved at the requesting version instead of upgrading via the BOM.
- Adds the 9 missing constraints to the BOM: `skainet-compile-opt`, `-c`, `-dag`, `-json`, `skainet-io-iree-params`, `skainet-lang-dag`, `-models`, `-ksp-annotations`, `-ksp-processor`. Audited against `https://repo.maven.apache.org/maven2/sk/ainet/core/` so every module that ships a 0.23.x POM has a constraint.
- Bumps `VERSION_NAME` to 0.23.1; updates README quickstart and CHANGELOG.

## Test plan

- [x] `./gradlew :skainet-bom:generatePomFileForMavenPublication` — generated POM has 25 `<dependency>` entries, all `<groupId>sk.ainet.core</groupId>` at `0.23.1`, including `skainet-compile-opt`.
- [ ] Reproducer from #592: with `platform("sk.ainet:skainet-bom:0.23.1")` + `skainet-transformers-inference-bert:0.21.1`, `./gradlew dependencies --configuration runtimeClasspath` shows `skainet-compile-opt:0.21.0 -> 0.23.1` (verify after publish).
- [ ] CI: `validate-published-poms.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)