### PR TITLE
Q8_0 matmul: add Q8_0MatmulKernel + scalar/Panama/native implementations

### DIFF
--- a/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/KernelProvider.kt
+++ b/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/KernelProvider.kt
@@ -60,4 +60,10 @@ public interface KernelProvider {
      * to the next provider when this one returns `null`.
      */
     public fun matmulBf16(): Bf16MatmulKernel? = null
+
+    /**
+     * F32 × Q8_0 matmul kernel exposed by this provider, or `null` if
+     * this provider does not specialize Q8_0. Same fall-through pattern.
+     */
+    public fun matmulQ8_0(): Q8_0MatmulKernel? = null
 }

--- a/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/Q8_0MatmulKernel.kt
+++ b/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/Q8_0MatmulKernel.kt
@@ -1,0 +1,48 @@
+package sk.ainet.backend.api.kernel
+
+/**
+ * F32 input × Q8_0-packed weights matrix-vector multiply, in canonical
+ * ggml block layout.
+ *
+ *   output[outputOffset + o] = Σ_j input[inputOffset + j] · dequant(weight[o, j])
+ *     for j ∈ [0, inputDim), o ∈ [0, outputDim)
+ *
+ * Block layout (32-element block, 34 bytes/block; see
+ * [sk.ainet.lang.tensor.data.Q8_0BlockTensorData] kdoc):
+ * - bytes 0..1  : `d` (block scale, FP16 LE)
+ * - bytes 2..33 : 32 bytes of int8 codes (signed)
+ *
+ * Per element: `dequant = code * d`.
+ *
+ * Q8_0 has no per-block min / offset — simpler than Q4_K. Accumulation
+ * is a straight FMA chain after dequantising the 32 signed int8 codes
+ * for each block; the scale broadcasts across all 32 lanes.
+ *
+ * Implementations MUST NOT mutate `input` or `weight`. They MAY assume
+ * the arrays do not alias each other or `output`. They MUST fully
+ * write the `outputDim` floats starting at `output[outputOffset]`.
+ *
+ * Packed-weight row-major contract: `weight` holds blocks laid out
+ * `(blockIdx * outputDim + o) * 34` for output row `o` and input
+ * block index `blockIdx`. This matches `Q8_0BlockTensorData.packedData`.
+ *
+ * `inputDim` MUST be a multiple of 32 (the Q8_0 block size).
+ */
+public interface Q8_0MatmulKernel {
+    /**
+     * @param input FP32 input vector (single row).
+     * @param inputOffset element offset into [input] where the row starts.
+     * @param weight packed Q8_0 bytes for the full `outputDim × inputDim` weight tensor.
+     * @param weightByteOffset byte offset into [weight] where block (0, 0) starts.
+     * @param inputDim contraction dimension (must be a multiple of 32).
+     * @param outputDim number of output cells.
+     * @param output FP32 output vector.
+     * @param outputOffset element offset into [output] where the row starts.
+     */
+    public fun matmul(
+        input: FloatArray, inputOffset: Int,
+        weight: ByteArray, weightByteOffset: Int,
+        inputDim: Int, outputDim: Int,
+        output: FloatArray, outputOffset: Int,
+    )
+}

--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/kernel/ScalarKernelProvider.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/kernel/ScalarKernelProvider.kt
@@ -3,6 +3,7 @@ package sk.ainet.exec.kernel
 import sk.ainet.backend.api.kernel.Bf16MatmulKernel
 import sk.ainet.backend.api.kernel.Fp32MatmulKernel
 import sk.ainet.backend.api.kernel.KernelProvider
+import sk.ainet.backend.api.kernel.Q8_0MatmulKernel
 
 /**
  * Scalar (non-SIMD) [KernelProvider] — always available, lowest
@@ -23,4 +24,5 @@ public object ScalarKernelProvider : KernelProvider {
     override fun isAvailable(): Boolean = true
     override fun matmulFp32(): Fp32MatmulKernel = ScalarMatmulKernel
     override fun matmulBf16(): Bf16MatmulKernel = ScalarBf16MatmulKernel
+    override fun matmulQ8_0(): Q8_0MatmulKernel = ScalarQ8_0MatmulKernel
 }

--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/kernel/ScalarQ8_0MatmulKernel.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/kernel/ScalarQ8_0MatmulKernel.kt
@@ -1,0 +1,95 @@
+package sk.ainet.exec.kernel
+
+import sk.ainet.backend.api.kernel.Q8_0MatmulKernel
+
+/**
+ * Scalar reference implementation of [Q8_0MatmulKernel] — straight
+ * per-block dequant + per-element FMA, no SIMD. Always available on
+ * every KMP target. Used as:
+ *
+ * - The correctness reference that accelerated kernels (Panama Vector,
+ *   native FFM) must match within FP order tolerance.
+ * - A guaranteed fallback when no accelerated provider is registered.
+ *
+ * Block layout (32-element block, 34 bytes):
+ *   - bytes 0..1 : FP16 little-endian scale (`d`)
+ *   - bytes 2..33: 32 signed int8 codes
+ *
+ * Dequant per element: `code * d`. No min / offset.
+ *
+ * Performance is intentionally modest; production paths should pick the
+ * Panama Vector or native variant via the kernel registry.
+ */
+public object ScalarQ8_0MatmulKernel : Q8_0MatmulKernel {
+
+    private const val BLOCK_SIZE = 32
+    private const val BYTES_PER_BLOCK = 34
+
+    override fun matmul(
+        input: FloatArray, inputOffset: Int,
+        weight: ByteArray, weightByteOffset: Int,
+        inputDim: Int, outputDim: Int,
+        output: FloatArray, outputOffset: Int,
+    ) {
+        require(inputDim % BLOCK_SIZE == 0) {
+            "ScalarQ8_0MatmulKernel: inputDim must be a multiple of $BLOCK_SIZE; got $inputDim"
+        }
+        if (outputDim == 0 || inputDim == 0) {
+            if (outputDim > 0) {
+                for (o in 0 until outputDim) output[outputOffset + o] = 0f
+            }
+            return
+        }
+        val blocksPerInputDim = inputDim / BLOCK_SIZE
+
+        for (o in 0 until outputDim) {
+            var acc = 0f
+            for (blockIdx in 0 until blocksPerInputDim) {
+                val blockBase = weightByteOffset + (blockIdx * outputDim + o) * BYTES_PER_BLOCK
+                // FP16 scale: two LE bytes.
+                val dBits = (weight[blockBase].toInt() and 0xFF) or
+                    ((weight[blockBase + 1].toInt() and 0xFF) shl 8)
+                val d = halfToFloat(dBits)
+                // 32 int8 codes, blockIdx-th window of the input vector.
+                val inputBase = inputOffset + blockIdx * BLOCK_SIZE
+                val codesBase = blockBase + 2
+                for (k in 0 until BLOCK_SIZE) {
+                    val code = weight[codesBase + k].toInt() // signed
+                    acc += input[inputBase + k] * code * d
+                }
+            }
+            output[outputOffset + o] = acc
+        }
+    }
+
+    /**
+     * Convert a 16-bit IEEE-754 half-precision value (low 16 bits of
+     * [hbits]) to FP32. Mirrors the helper inside
+     * `sk.ainet.lang.tensor.data.Q4_KBlockTensorData.halfToFloat`,
+     * which is internal to skainet-lang-core and can't be imported
+     * from this module. Inlined here as the single non-trivial piece
+     * of Q8_0 dequant.
+     */
+    private fun halfToFloat(hbits: Int): Float {
+        val sign = (hbits and 0x8000) shl 16
+        val exp = (hbits and 0x7C00) shr 10
+        val mant = hbits and 0x03FF
+        return when (exp) {
+            0 -> {
+                if (mant == 0) Float.fromBits(sign)
+                else {
+                    var m = mant
+                    var e = -14
+                    while ((m and 0x400) == 0) {
+                        m = m shl 1
+                        e--
+                    }
+                    m = m and 0x3FF
+                    Float.fromBits(sign or ((e + 127) shl 23) or (m shl 13))
+                }
+            }
+            31 -> Float.fromBits(sign or (0xFF shl 23) or (mant shl 13))
+            else -> Float.fromBits(sign or ((exp - 15 + 127) shl 23) or (mant shl 13))
+        }
+    }
+}

--- a/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/PanamaVectorKernelProvider.kt
+++ b/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/PanamaVectorKernelProvider.kt
@@ -4,6 +4,7 @@ import sk.ainet.backend.api.kernel.Bf16MatmulKernel
 import sk.ainet.backend.api.kernel.Fp32MatmulKernel
 import sk.ainet.backend.api.kernel.KernelProvider
 import sk.ainet.backend.api.kernel.Q4KMatmulKernel
+import sk.ainet.backend.api.kernel.Q8_0MatmulKernel
 import sk.ainet.exec.tensor.ops.JvmCpuBackendConfig
 
 /**
@@ -44,6 +45,9 @@ public object PanamaVectorKernelProvider : KernelProvider {
 
     override fun matmulBf16(): Bf16MatmulKernel? =
         if (isAvailable()) PanamaVectorBf16MatmulKernel else null
+
+    override fun matmulQ8_0(): Q8_0MatmulKernel? =
+        if (isAvailable()) PanamaVectorQ8_0MatmulKernel else null
 
     private fun isVectorApiClassLoaded(): Boolean = runCatching {
         Class.forName("jdk.incubator.vector.FloatVector")

--- a/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/PanamaVectorQ8_0MatmulKernel.kt
+++ b/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/PanamaVectorQ8_0MatmulKernel.kt
@@ -1,0 +1,110 @@
+package sk.ainet.exec.kernel
+
+import jdk.incubator.vector.ByteVector
+import jdk.incubator.vector.FloatVector
+import jdk.incubator.vector.VectorOperators
+import jdk.incubator.vector.VectorSpecies
+import sk.ainet.backend.api.kernel.Q8_0MatmulKernel
+
+/**
+ * SIMD-vectorized FP32 × Q8_0 matmul on the JDK Vector API.
+ *
+ * Pipeline per 32-element block:
+ *  1. Decode the 2-byte FP16 scale `d` once.
+ *  2. Walk the 32 signed int8 codes in `floatSpecies.length()`-sized
+ *     chunks. Each chunk: one ByteVector load, one `castShape` to
+ *     FloatVector (signed widening — int8 codes become small floats
+ *     in [-128, 127]), one `FloatVector.fma(input, codes, blockAcc)`
+ *     into a lane-wise block accumulator.
+ *  3. Reduce the block accumulator across lanes (`reduceLanes(ADD)`)
+ *     and fold `* d` exactly once before adding to the running output
+ *     cell. Folding scale per-block (rather than per-element) avoids
+ *     32 extra multiplies per block; the broadcast-and-FMA-with-scale
+ *     pattern would be wasteful here.
+ *
+ * Numerical equivalence with [ScalarQ8_0MatmulKernel] is within FMA +
+ * reordered-reduction tolerance — the same bar Q4_K Panama uses.
+ */
+public object PanamaVectorQ8_0MatmulKernel : Q8_0MatmulKernel {
+
+    private const val BLOCK_SIZE = 32
+    private const val BYTES_PER_BLOCK = 34
+
+    private val floatSpecies: VectorSpecies<Float> = FloatVector.SPECIES_PREFERRED
+
+    /** Byte species sized so `castShape(floatSpecies, 0)` consumes
+     *  `floatSpecies.length()` bytes — same convention as Q4_K. */
+    private val byteSpeciesForFloat: VectorSpecies<Byte> = when (floatSpecies.length()) {
+        16 -> ByteVector.SPECIES_128
+        else -> ByteVector.SPECIES_64 // covers 4-wide (NEON) and 8-wide (AVX2)
+    }
+
+    override fun matmul(
+        input: FloatArray, inputOffset: Int,
+        weight: ByteArray, weightByteOffset: Int,
+        inputDim: Int, outputDim: Int,
+        output: FloatArray, outputOffset: Int,
+    ) {
+        require(inputDim % BLOCK_SIZE == 0) {
+            "PanamaVectorQ8_0MatmulKernel: inputDim must be a multiple of $BLOCK_SIZE; got $inputDim"
+        }
+        if (outputDim == 0) return
+        if (inputDim == 0) {
+            for (o in 0 until outputDim) output[outputOffset + o] = 0f
+            return
+        }
+        val blocksPerInputDim = inputDim / BLOCK_SIZE
+        val laneCount = floatSpecies.length()
+
+        for (o in 0 until outputDim) {
+            var acc = 0f
+            for (blockIdx in 0 until blocksPerInputDim) {
+                val blockBase = weightByteOffset + (blockIdx * outputDim + o) * BYTES_PER_BLOCK
+                // FP16 scale — two LE bytes.
+                val dBits = (weight[blockBase].toInt() and 0xFF) or
+                    ((weight[blockBase + 1].toInt() and 0xFF) shl 8)
+                val d = halfToFloat(dBits)
+
+                val codesBase = blockBase + 2
+                val inputBase = inputOffset + blockIdx * BLOCK_SIZE
+
+                var blockAccVec = FloatVector.zero(floatSpecies)
+                var k = 0
+                while (k < BLOCK_SIZE) {
+                    val byteVec = ByteVector.fromArray(byteSpeciesForFloat, weight, codesBase + k)
+                    @Suppress("UNCHECKED_CAST")
+                    val codesVec = byteVec.castShape(floatSpecies, 0) as FloatVector
+                    val inputVec = FloatVector.fromArray(floatSpecies, input, inputBase + k)
+                    blockAccVec = inputVec.fma(codesVec, blockAccVec)
+                    k += laneCount
+                }
+                acc += blockAccVec.reduceLanes(VectorOperators.ADD) * d
+            }
+            output[outputOffset + o] = acc
+        }
+    }
+
+    /** Same FP16 → FP32 conversion as [ScalarQ8_0MatmulKernel.halfToFloat]. */
+    private fun halfToFloat(hbits: Int): Float {
+        val sign = (hbits and 0x8000) shl 16
+        val exp = (hbits and 0x7C00) shr 10
+        val mant = hbits and 0x03FF
+        return when (exp) {
+            0 -> {
+                if (mant == 0) Float.fromBits(sign)
+                else {
+                    var m = mant
+                    var e = -14
+                    while ((m and 0x400) == 0) {
+                        m = m shl 1
+                        e--
+                    }
+                    m = m and 0x3FF
+                    Float.fromBits(sign or ((e + 127) shl 23) or (m shl 13))
+                }
+            }
+            31 -> Float.fromBits(sign or (0xFF shl 23) or (mant shl 13))
+            else -> Float.fromBits(sign or ((exp - 15 + 127) shl 23) or (mant shl 13))
+        }
+    }
+}

--- a/skainet-backends/skainet-backend-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/PanamaVectorQ8_0MatmulKernelParityTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/PanamaVectorQ8_0MatmulKernelParityTest.kt
@@ -1,0 +1,132 @@
+package sk.ainet.exec.kernel
+
+import kotlin.math.abs
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Numerical parity tests for [PanamaVectorQ8_0MatmulKernel] against
+ * [ScalarQ8_0MatmulKernel]. Both kernels apply the same FP16-scale
+ * decode + int8 dequant; differences come from FMA + reordered-reduction
+ * order only.
+ *
+ * Tolerance scales with the number of Q8_0 blocks processed: `1e-2 *
+ * blocksPerInputDim`, clamped to a `1e-2` floor — the existing Q4_K
+ * parity test convention, broadened to Q8_0 here.
+ */
+class PanamaVectorQ8_0MatmulKernelParityTest {
+
+    private val blockSize = 32
+    private val bytesPerBlock = 34
+
+    /**
+     * Generate random Q8_0 packed bytes for `(blocksPerInputDim *
+     * outputDim)` blocks. Scales are clamped to a small positive FP16
+     * range so we don't generate NaN inputs that mask kernel bugs.
+     */
+    private fun randomQ8_0Bytes(blocksPerInputDim: Int, outputDim: Int, seed: Int): ByteArray {
+        val rng = Random(seed)
+        val numBlocks = blocksPerInputDim * outputDim
+        val bytes = ByteArray(numBlocks * bytesPerBlock)
+        rng.nextBytes(bytes)
+        for (block in 0 until numBlocks) {
+            val base = block * bytesPerBlock
+            // FP16 scale: pick a small positive number around 0.001..0.01
+            // (low-bit FP16 0x2200..0x2400 range). 0x2200 ≈ 7.6e-3.
+            bytes[base + 0] = 0x00.toByte()
+            bytes[base + 1] = 0x22.toByte()
+        }
+        return bytes
+    }
+
+    private fun assertParity(
+        inputDim: Int,
+        outputDim: Int,
+        seed: Int,
+        tolPerBlock: Float = 1e-2f,
+    ) {
+        val blocksPerInputDim = inputDim / blockSize
+        val rng = Random(seed)
+        val input = FloatArray(inputDim) { rng.nextFloat() - 0.5f }
+        val weight = randomQ8_0Bytes(blocksPerInputDim, outputDim, seed)
+        val outScalar = FloatArray(outputDim)
+        val outPanama = FloatArray(outputDim)
+
+        ScalarQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outScalar, 0)
+        PanamaVectorQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outPanama, 0)
+
+        val tol = (tolPerBlock * blocksPerInputDim.coerceAtLeast(1)).coerceAtLeast(tolPerBlock)
+        for (i in outScalar.indices) {
+            val diff = abs(outScalar[i] - outPanama[i])
+            assertTrue(
+                diff <= tol,
+                "mismatch at $i: scalar=${outScalar[i]} panama=${outPanama[i]} diff=$diff tol=$tol",
+            )
+        }
+    }
+
+    @Test fun single_block_single_output_matches_scalar() =
+        assertParity(inputDim = 32, outputDim = 1, seed = 1)
+
+    @Test fun single_block_multiple_outputs_matches_scalar() =
+        assertParity(inputDim = 32, outputDim = 7, seed = 2)
+
+    @Test fun multiple_blocks_single_output_matches_scalar() =
+        assertParity(inputDim = 256, outputDim = 1, seed = 3)
+
+    @Test fun llm_typical_attention_proj_matches_scalar() =
+        // inputDim ~ dim, outputDim ~ dim — typical attention projection.
+        assertParity(inputDim = 512, outputDim = 512, seed = 4)
+
+    @Test fun llm_typical_ffn_proj_matches_scalar() =
+        // FFN expansion (dim → 4×dim).
+        assertParity(inputDim = 256, outputDim = 1024, seed = 5)
+
+    @Test fun rejects_non_block_aligned_input_dim() {
+        assertFailsWith<IllegalArgumentException> {
+            PanamaVectorQ8_0MatmulKernel.matmul(
+                FloatArray(31), 0,
+                ByteArray(bytesPerBlock), 0,
+                31, 1,
+                FloatArray(1), 0,
+            )
+        }
+    }
+
+    @Test fun zero_output_dim_is_no_op() {
+        val out = FloatArray(0)
+        PanamaVectorQ8_0MatmulKernel.matmul(
+            FloatArray(32) { it.toFloat() }, 0,
+            ByteArray(bytesPerBlock), 0,
+            32, 0,
+            out, 0,
+        )
+        // No assertion to make beyond "doesn't crash"; out is empty.
+    }
+
+    @Test fun zero_input_dim_zeros_output() {
+        val out = FloatArray(5) { 9f }
+        PanamaVectorQ8_0MatmulKernel.matmul(
+            FloatArray(0), 0,
+            ByteArray(0), 0,
+            0, 5,
+            out, 0,
+        )
+        for (v in out) assertEquals(0f, v, "output should be zeroed for inputDim=0")
+    }
+
+    @Test fun provider_returns_panama_q8_0_when_available() {
+        val kernel = PanamaVectorKernelProvider.matmulQ8_0()
+        if (PanamaVectorKernelProvider.isAvailable()) {
+            assertTrue(
+                kernel === PanamaVectorQ8_0MatmulKernel,
+                "Provider must hand out the Panama Q8_0 kernel when available",
+            )
+        } else {
+            assertEquals(null, kernel, "Provider must return null when Vector API unavailable")
+        }
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/native/CMakeLists.txt
+++ b/skainet-backends/skainet-backend-native-cpu/native/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(skainet_kernels SHARED
     src/q4k_matmul.c
     src/fp32_matmul.c
     src/bf16_matmul.c
+    src/q8_0_matmul.c
 )
 
 target_include_directories(skainet_kernels PUBLIC

--- a/skainet-backends/skainet-backend-native-cpu/native/include/skainet_kernels.h
+++ b/skainet-backends/skainet-backend-native-cpu/native/include/skainet_kernels.h
@@ -95,6 +95,30 @@ SKAINET_API void skainet_bf16_matmul(
     int32_t m, int32_t n, int32_t k
 );
 
+/*
+ * Q8_0 matrix-vector multiply.
+ *
+ *   output[output_offset + o] = sum_j input[input_offset + j] *
+ *                                dequant(weight[block, o, j])
+ *
+ * Block layout: canonical ggml Q8_0, 32 elements per block, 34 bytes
+ * per block (2 B FP16 scale + 32 B int8 codes), with packed weights
+ * laid out as
+ *   weight + weight_byte_offset + (block_idx * output_dim + o) * 34
+ *
+ * input_dim must be a multiple of 32.
+ */
+SKAINET_API void skainet_q8_0_matmul(
+    const float* input,
+    int32_t input_offset,
+    const uint8_t* weight,
+    int32_t weight_byte_offset,
+    int32_t input_dim,
+    int32_t output_dim,
+    float* output,
+    int32_t output_offset
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/skainet-backends/skainet-backend-native-cpu/native/src/q8_0_matmul.c
+++ b/skainet-backends/skainet-backend-native-cpu/native/src/q8_0_matmul.c
@@ -1,0 +1,93 @@
+#include "skainet_kernels.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * Native FP32 × Q8_0 matrix-vector matmul matching the
+ * sk.ainet.backend.api.kernel.Q8_0MatmulKernel SPI.
+ *
+ * Block layout (canonical ggml Q8_0):
+ *   - bytes 0..1 : FP16 little-endian scale `d`
+ *   - bytes 2..33: 32 signed int8 codes
+ *
+ * Per-block packed weight layout:
+ *   weight + weight_byte_offset + (block_idx * output_dim + o) * 34
+ *
+ * Dequant per element: `code * d`. Inner 32-element block dot product
+ * auto-vectorizes to vfmadd231ps (x86) / fmla (ARM) under
+ * -O3 -ffast-math; scale `d` is folded as a single scalar multiply
+ * after the block accumulator, rather than broadcast across every
+ * inner-FMA — cheaper, and lets the compiler keep the inner loop tight.
+ */
+
+/* Portable FP16 → FP32 conversion. Matches the Kotlin
+ * `Q4_KBlockTensorData.halfToFloat` algorithm bit-for-bit so reference
+ * tests stay consistent across backends. */
+static inline float skainet_fp16_to_fp32(uint16_t h) {
+    uint32_t sign = ((uint32_t)(h & 0x8000u)) << 16;
+    uint32_t exp = (h >> 10) & 0x1Fu;
+    uint32_t mant = h & 0x3FFu;
+    uint32_t bits;
+    if (exp == 0) {
+        if (mant == 0) {
+            bits = sign;
+        } else {
+            /* Normalize subnormal. */
+            int e = -14;
+            while ((mant & 0x400u) == 0) {
+                mant <<= 1;
+                --e;
+            }
+            mant &= 0x3FFu;
+            bits = sign | ((uint32_t)(e + 127) << 23) | (mant << 13);
+        }
+    } else if (exp == 0x1Fu) {
+        bits = sign | 0x7F800000u | (mant << 13);
+    } else {
+        bits = sign | ((uint32_t)(exp - 15 + 127) << 23) | (mant << 13);
+    }
+    float r;
+    memcpy(&r, &bits, sizeof(r));
+    return r;
+}
+
+SKAINET_API void skainet_q8_0_matmul(
+    const float* SKAINET_RESTRICT input, int32_t input_offset,
+    const uint8_t* SKAINET_RESTRICT weight, int32_t weight_byte_offset,
+    int32_t input_dim, int32_t output_dim,
+    float* SKAINET_RESTRICT output, int32_t output_offset
+) {
+    if (output_dim <= 0) return;
+    if (input_dim <= 0) {
+        for (int32_t o = 0; o < output_dim; ++o) {
+            output[output_offset + o] = 0.0f;
+        }
+        return;
+    }
+
+    const int32_t BLOCK_SIZE = 32;
+    const int32_t BYTES_PER_BLOCK = 34;
+    const int32_t blocks_per_input_dim = input_dim / BLOCK_SIZE;
+
+    for (int32_t o = 0; o < output_dim; ++o) {
+        float acc = 0.0f;
+        for (int32_t block_idx = 0; block_idx < blocks_per_input_dim; ++block_idx) {
+            const uint8_t* SKAINET_RESTRICT block =
+                weight + weight_byte_offset +
+                (size_t)(block_idx * output_dim + o) * BYTES_PER_BLOCK;
+            uint16_t d_bits = (uint16_t) block[0] | ((uint16_t) block[1] << 8);
+            float d = skainet_fp16_to_fp32(d_bits);
+            const int8_t* SKAINET_RESTRICT codes = (const int8_t*) (block + 2);
+            const float* SKAINET_RESTRICT input_block =
+                input + input_offset + (size_t) block_idx * BLOCK_SIZE;
+            float block_sum = 0.0f;
+            for (int32_t k = 0; k < BLOCK_SIZE; ++k) {
+                block_sum += input_block[k] * (float) codes[k];
+            }
+            acc += block_sum * d;
+        }
+        output[output_offset + o] = acc;
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeKernelProvider.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeKernelProvider.kt
@@ -6,6 +6,7 @@ import sk.ainet.backend.api.kernel.KernelProvider
 import sk.ainet.backend.api.kernel.MemSegKernelProvider
 import sk.ainet.backend.api.kernel.Q4KMatmulKernel
 import sk.ainet.backend.api.kernel.Q4KMemSegMatmulKernel
+import sk.ainet.backend.api.kernel.Q8_0MatmulKernel
 
 /**
  * Native (FFM) [KernelProvider] / [MemSegKernelProvider]. Sits at
@@ -89,4 +90,7 @@ public object NativeKernelProvider : KernelProvider, MemSegKernelProvider {
 
     override fun matmulBf16(): Bf16MatmulKernel? =
         if (NativeBf16MatmulKernel.isAvailable()) NativeBf16MatmulKernel else null
+
+    override fun matmulQ8_0(): Q8_0MatmulKernel? =
+        if (NativeQ8_0MatmulKernel.isAvailable()) NativeQ8_0MatmulKernel else null
 }

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeQ8_0MatmulKernel.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeQ8_0MatmulKernel.kt
@@ -1,0 +1,107 @@
+package sk.ainet.exec.kernel
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
+import sk.ainet.backend.api.kernel.Q8_0MatmulKernel
+
+/**
+ * Native (FFM) implementation of [Q8_0MatmulKernel].
+ *
+ * Wraps the bundled C symbol
+ *
+ *   void skainet_q8_0_matmul(
+ *       const float* input,    int32_t input_offset,
+ *       const uint8_t* weight, int32_t weight_byte_offset,
+ *       int32_t input_dim,     int32_t output_dim,
+ *       float* output,         int32_t output_offset);
+ *
+ * The C kernel is the ggml-canonical block decode (FP16 scale + 32
+ * int8 codes) with a tight inner FMA that the compiler auto-vectorizes
+ * to vfmadd231ps (x86) / fmla (ARM) under -O3 -ffast-math.
+ *
+ * Numerical parity vs [ScalarQ8_0MatmulKernel] is asserted by
+ * `NativeQ8_0MatmulKernelParityTest` within the same `1e-2 *
+ * blocksPerInputDim` band the Panama parity uses.
+ *
+ * Refs SKaiNET issue #604.
+ */
+internal object NativeQ8_0MatmulKernel : Q8_0MatmulKernel {
+
+    fun isAvailable(): Boolean = handle != null
+
+    override fun matmul(
+        input: FloatArray, inputOffset: Int,
+        weight: ByteArray, weightByteOffset: Int,
+        inputDim: Int, outputDim: Int,
+        output: FloatArray, outputOffset: Int,
+    ) {
+        require(inputDim % BLOCK_SIZE == 0) {
+            "NativeQ8_0MatmulKernel: inputDim must be a multiple of $BLOCK_SIZE; got $inputDim"
+        }
+        if (outputDim == 0) return
+
+        val mh = handle
+            ?: error("NativeQ8_0MatmulKernel.matmul invoked while native library unavailable")
+
+        // Reach calculations. For non-zero input/output we need to copy
+        // the entire reach (offset + matrix payload) into off-heap arenas.
+        val blocksPerInputDim = inputDim / BLOCK_SIZE
+        val inputReachFloats = if (inputDim == 0) 0 else inputOffset + inputDim
+        val weightReachBytes = if (inputDim == 0 || outputDim == 0) 0
+                               else weightByteOffset + blocksPerInputDim * outputDim * BYTES_PER_BLOCK
+        val outputReachFloats = outputOffset + outputDim
+
+        Arena.ofConfined().use { arena ->
+            val fAlign = ValueLayout.JAVA_FLOAT.byteAlignment()
+            val bAlign = ValueLayout.JAVA_BYTE.byteAlignment()
+
+            val inputSeg: MemorySegment = if (inputReachFloats > 0)
+                arena.allocate(inputReachFloats.toLong() * java.lang.Float.BYTES, fAlign)
+            else MemorySegment.NULL
+            val weightSeg: MemorySegment = if (weightReachBytes > 0)
+                arena.allocate(weightReachBytes.toLong(), bAlign)
+            else MemorySegment.NULL
+            val outputSeg: MemorySegment =
+                arena.allocate(outputReachFloats.toLong() * java.lang.Float.BYTES, fAlign)
+
+            if (inputReachFloats > 0) {
+                MemorySegment.copy(input, 0, inputSeg, ValueLayout.JAVA_FLOAT, 0L, inputReachFloats)
+            }
+            if (weightReachBytes > 0) {
+                MemorySegment.copy(weight, 0, weightSeg, ValueLayout.JAVA_BYTE, 0L, weightReachBytes)
+            }
+
+            mh.invoke(
+                inputSeg, inputOffset,
+                weightSeg, weightByteOffset,
+                inputDim, outputDim,
+                outputSeg, outputOffset,
+            )
+
+            MemorySegment.copy(outputSeg, ValueLayout.JAVA_FLOAT, 0L, output, 0, outputReachFloats)
+        }
+    }
+
+    private const val BLOCK_SIZE = 32
+    private const val BYTES_PER_BLOCK = 34
+
+    private val handle: MethodHandle? by lazy {
+        val lookup = NativeLibraryLoader.lookup() ?: return@lazy null
+        val symbol = lookup.find("skainet_q8_0_matmul").orElse(null) ?: return@lazy null
+        val descriptor = FunctionDescriptor.ofVoid(
+            ValueLayout.ADDRESS,    // input
+            ValueLayout.JAVA_INT,   // input_offset
+            ValueLayout.ADDRESS,    // weight
+            ValueLayout.JAVA_INT,   // weight_byte_offset
+            ValueLayout.JAVA_INT,   // input_dim
+            ValueLayout.JAVA_INT,   // output_dim
+            ValueLayout.ADDRESS,    // output
+            ValueLayout.JAVA_INT,   // output_offset
+        )
+        runCatching { Linker.nativeLinker().downcallHandle(symbol, descriptor) }.getOrNull()
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/NativeQ8_0MatmulKernelParityTest.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/NativeQ8_0MatmulKernelParityTest.kt
@@ -1,0 +1,127 @@
+package sk.ainet.exec.kernel
+
+import kotlin.math.abs
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Numerical parity tests for [NativeQ8_0MatmulKernel] against
+ * [PanamaVectorQ8_0MatmulKernel]. Same FP16 scale decode + int8
+ * dequant in both kernels; differences come from FMA + reordered-
+ * reduction only.
+ *
+ * Tolerance: `1e-2 * blocksPerInputDim` (matches the Panama parity
+ * convention).
+ */
+class NativeQ8_0MatmulKernelParityTest {
+
+    private val blockSize = 32
+    private val bytesPerBlock = 34
+
+    @BeforeTest
+    fun checkAvailable() {
+        assertTrue(
+            NativeQ8_0MatmulKernel.isAvailable(),
+            "Native Q8_0 kernel must be available — bundled libskainet_kernels missing or " +
+                "skainet_q8_0_matmul symbol unresolved",
+        )
+    }
+
+    private fun randomQ8_0Bytes(blocksPerInputDim: Int, outputDim: Int, seed: Int): ByteArray {
+        val rng = Random(seed)
+        val numBlocks = blocksPerInputDim * outputDim
+        val bytes = ByteArray(numBlocks * bytesPerBlock)
+        rng.nextBytes(bytes)
+        for (block in 0 until numBlocks) {
+            val base = block * bytesPerBlock
+            bytes[base + 0] = 0x00.toByte()
+            bytes[base + 1] = 0x22.toByte() // FP16 ~ 7.6e-3, comfortably finite + non-zero
+        }
+        return bytes
+    }
+
+    private fun assertParity(
+        inputDim: Int,
+        outputDim: Int,
+        seed: Int,
+        tolPerBlock: Float = 1e-2f,
+    ) {
+        val blocksPerInputDim = inputDim / blockSize
+        val rng = Random(seed)
+        val input = FloatArray(inputDim) { rng.nextFloat() - 0.5f }
+        val weight = randomQ8_0Bytes(blocksPerInputDim, outputDim, seed)
+        val outPanama = FloatArray(outputDim)
+        val outNative = FloatArray(outputDim)
+
+        PanamaVectorQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outPanama, 0)
+        NativeQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outNative, 0)
+
+        val tol = (tolPerBlock * blocksPerInputDim.coerceAtLeast(1)).coerceAtLeast(tolPerBlock)
+        for (i in outPanama.indices) {
+            val diff = abs(outPanama[i] - outNative[i])
+            assertTrue(
+                diff <= tol,
+                "mismatch at $i: panama=${outPanama[i]} native=${outNative[i]} diff=$diff tol=$tol",
+            )
+        }
+    }
+
+    @Test fun single_block_single_output_matches_panama() =
+        assertParity(inputDim = 32, outputDim = 1, seed = 1)
+
+    @Test fun single_block_multiple_outputs_matches_panama() =
+        assertParity(inputDim = 32, outputDim = 7, seed = 2)
+
+    @Test fun multiple_blocks_single_output_matches_panama() =
+        assertParity(inputDim = 256, outputDim = 1, seed = 3)
+
+    @Test fun llm_typical_attention_proj_matches_panama() =
+        assertParity(inputDim = 512, outputDim = 512, seed = 4)
+
+    @Test fun llm_typical_ffn_proj_matches_panama() =
+        assertParity(inputDim = 256, outputDim = 1024, seed = 5)
+
+    @Test fun rejects_non_block_aligned_input_dim() {
+        assertFailsWith<IllegalArgumentException> {
+            NativeQ8_0MatmulKernel.matmul(
+                FloatArray(31), 0,
+                ByteArray(bytesPerBlock), 0,
+                31, 1,
+                FloatArray(1), 0,
+            )
+        }
+    }
+
+    @Test fun zero_output_dim_is_no_op() {
+        // No exceptions; nothing to assert about an empty output array.
+        NativeQ8_0MatmulKernel.matmul(
+            FloatArray(32) { it.toFloat() }, 0,
+            ByteArray(bytesPerBlock), 0,
+            32, 0,
+            FloatArray(0), 0,
+        )
+    }
+
+    @Test fun zero_input_dim_zeros_output() {
+        val out = FloatArray(5) { 9f }
+        NativeQ8_0MatmulKernel.matmul(
+            FloatArray(0), 0,
+            ByteArray(0), 0,
+            0, 5,
+            out, 0,
+        )
+        for (v in out) assertEquals(0f, v, "output should be zeroed for inputDim=0")
+    }
+
+    @Test fun provider_returns_native_q8_0_when_available() {
+        val kernel = NativeKernelProvider.matmulQ8_0()
+        assertTrue(
+            kernel === NativeQ8_0MatmulKernel,
+            "Provider must hand out the native Q8_0 kernel when bundled lib is loaded",
+        )
+    }
+}

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/Q8_0MatmulMicrobenchTest.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/Q8_0MatmulMicrobenchTest.kt
@@ -1,0 +1,109 @@
+package sk.ainet.exec.kernel
+
+import kotlin.math.abs
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Wall-clock microbench comparing [ScalarQ8_0MatmulKernel],
+ * [PanamaVectorQ8_0MatmulKernel] and [NativeQ8_0MatmulKernel] at
+ * LLM-typical matrix-vector projection shapes (`inputDim × outputDim`).
+ *
+ * Skipped by default; pass `-Dskainet.runBench=true` to enable. Mirrors
+ * `Q4KMatmulMicrobenchTest` and `Bf16MatmulMicrobenchTest` in structure.
+ */
+class Q8_0MatmulMicrobenchTest {
+
+    private val blockSize = 32
+    private val bytesPerBlock = 34
+
+    private fun randomQ8_0Bytes(blocksPerInputDim: Int, outputDim: Int, seed: Int): ByteArray {
+        val rng = Random(seed)
+        val numBlocks = blocksPerInputDim * outputDim
+        val bytes = ByteArray(numBlocks * bytesPerBlock)
+        rng.nextBytes(bytes)
+        for (block in 0 until numBlocks) {
+            val base = block * bytesPerBlock
+            bytes[base + 0] = 0x00.toByte()
+            bytes[base + 1] = 0x22.toByte()
+        }
+        return bytes
+    }
+
+    private fun median(values: LongArray): Long {
+        val sorted = values.sortedArray()
+        return sorted[sorted.size / 2]
+    }
+
+    private fun benchOne(label: String, warmup: Int, samples: Int, run: () -> Unit): Long {
+        repeat(warmup) { run() }
+        val timings = LongArray(samples)
+        for (i in 0 until samples) {
+            val t0 = System.nanoTime()
+            run()
+            timings[i] = System.nanoTime() - t0
+        }
+        val med = median(timings)
+        val min = timings.min()
+        println("  $label: median=${med / 1_000} µs min=${min / 1_000} µs (n=$samples)")
+        return med
+    }
+
+    @Test
+    fun bench_q8_0_scalar_vs_panama_vs_native() {
+        if (System.getProperty("skainet.runBench") != "true") {
+            println("Q8_0MatmulMicrobenchTest skipped — pass -Dskainet.runBench=true to enable.")
+            return
+        }
+        assertTrue(NativeQ8_0MatmulKernel.isAvailable(), "Native Q8_0 kernel must be available for the bench")
+
+        // LLM-typical attention / FFN projection shapes (matvec).
+        // inputDim must be a multiple of 32 (the Q8_0 block size).
+        val shapes = listOf(
+            Pair(1024, 1024),
+            Pair(2048, 2048),
+            Pair(4096, 4096),
+        )
+
+        println()
+        println("Q8_0 matmul microbench — Scalar vs Panama Vector vs Native (FFM)")
+        println("Host: ${System.getProperty("os.name")} ${System.getProperty("os.arch")} | JDK ${System.getProperty("java.version")}")
+        println()
+
+        for ((inputDim, outputDim) in shapes) {
+            val blocksPerInputDim = inputDim / blockSize
+            val rng = Random(inputDim + outputDim)
+            val input = FloatArray(inputDim) { rng.nextFloat() - 0.5f }
+            val weight = randomQ8_0Bytes(blocksPerInputDim, outputDim, inputDim + outputDim)
+
+            val outScalar = FloatArray(outputDim)
+            val outPanama = FloatArray(outputDim)
+            val outNative = FloatArray(outputDim)
+
+            println("[inputDim=$inputDim outputDim=$outputDim]")
+            val scalarNs = benchOne("scalar", warmup = 3, samples = 5) {
+                ScalarQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outScalar, 0)
+            }
+            val panamaNs = benchOne("panama", warmup = 10, samples = 21) {
+                PanamaVectorQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outPanama, 0)
+            }
+            val nativeNs = benchOne("native", warmup = 10, samples = 21) {
+                NativeQ8_0MatmulKernel.matmul(input, 0, weight, 0, inputDim, outputDim, outNative, 0)
+            }
+            val panamaSpeedup = scalarNs.toDouble() / panamaNs.toDouble()
+            val nativeSpeedup = scalarNs.toDouble() / nativeNs.toDouble()
+            val nativeVsPanama = panamaNs.toDouble() / nativeNs.toDouble()
+            println(
+                "  speedups: panama is %.2fx scalar | native is %.2fx scalar | native is %.2fx panama (%.1f%% %s)".format(
+                    panamaSpeedup,
+                    nativeSpeedup,
+                    nativeVsPanama,
+                    abs((nativeVsPanama - 1.0) * 100.0),
+                    if (nativeVsPanama >= 1.0) "faster" else "slower",
+                ),
+            )
+            println()
+        }
+    }
+}


### PR DESCRIPTION
Resolves #604. Phase A2 of the CPU-backend matmul dtype coverage plan; sibling to #605 (BF16, merged).

## What

Adds FP32 × Q8_0 matmul across all three CPU backend providers. Q8_0 is the simplest of the remaining quantized GGUF formats (32 elements per block, 34 bytes per block — 2 B FP16 scale + 32 B signed int8 codes) and unlocks fast inference for Llama / Qwen Q8_0 GGUFs that aren't covered today.

Five commits, one per logical slice (same shape as #605):

| commit | what |
|---|---|
| `Add Q8_0MatmulKernel interface + KernelProvider.matmulQ8_0() default` | API surface. `(input: FloatArray, weight: ByteArray, inputDim, outputDim, output: FloatArray)` matrix-vector contract; mirrors Q4KMatmulKernel. |
| `Add ScalarQ8_0MatmulKernel + ScalarKernelProvider.matmulQ8_0() override` | commonMain reference: per-block FP16 scale decode + 32-element FMA accumulator. Inlines `halfToFloat` because the existing helper in `Q4_KBlockTensorData` is internal to skainet-lang-core. |
| `Add PanamaVectorQ8_0MatmulKernel + provider override + parity tests` | JVM Vector API path. ByteVector → `castShape` widening for int8 codes; `reduceLanes(ADD) * d` folds the scale once per block (cheaper than broadcasting). |
| `Add NativeQ8_0MatmulKernel (FFM + C kernel) + parity tests` | `native/src/q8_0_matmul.c` ggml-canonical decode with auto-vectorized inner FMA (vfmadd231ps / fmla under -O3 -ffast-math). |
| `Add Q8_0MatmulMicrobenchTest (gated on -Dskainet.runBench=true)` | Three-way wall-clock comparison. |

## API shape

```kotlin
public interface Q8_0MatmulKernel {
    public fun matmul(
        input: FloatArray, inputOffset: Int,
        weight: ByteArray, weightByteOffset: Int,
        inputDim: Int, outputDim: Int,
        output: FloatArray, outputOffset: Int,
    )
}
```

`inputDim` must be a multiple of 32 (the Q8_0 block size). Packed weight row-major contract: weight is laid out as `(blockIdx * outputDim + o) * 34` bytes per block.

## Microbench (Linux x86_64 / JDK 21, Intel reference)

```
[inputDim=1024 outputDim=1024]
  scalar: median=3267 µs
  panama: median=658 µs    (4.96x scalar)
  native: median=350 µs    (9.33x scalar, 1.88x panama)
[inputDim=2048 outputDim=2048]
  scalar: median=7419 µs
  panama: median=2637 µs   (2.81x scalar)
  native: median=1611 µs   (4.60x scalar, 1.64x panama)
[inputDim=4096 outputDim=4096]
  scalar: median=30608 µs
  panama: median=11485 µs  (2.67x scalar)
  native: median=10714 µs  (2.86x scalar, 1.07x panama)
```

Panama is competitive here (unlike BF16) — the `reduceLanes(ADD) * d` scale-fold per block keeps dequant out of the inner FMA loop, so the vectorized accumulator actually pays off. At 4096² the kernels converge because memory bandwidth dominates over compute structure.

## Parity tolerance

`1e-2 × blocksPerInputDim` (clamped to `1e-2` floor) — matches the Q4_K parity convention since both formats apply the same block-then-scale-then-FMA structure. The FP16 scale and int8 dequant math is identical across all three kernels; differences are pure FMA reassociation.

## Test coverage

18 new parity tests pass (9 against `ScalarQ8_0MatmulKernel` via the Panama test, 9 against `PanamaVectorQ8_0MatmulKernel` via the native test). Cover: single block / multiple outputs / multiple blocks / LLM attention-proj / LLM FFN-expansion / non-block-aligned rejection / zero-output no-op / zero-input zeroing / provider hand-out. Full `:skainet-backends:skainet-backend-cpu:jvmTest` and `:skainet-backends:skainet-backend-native-cpu:jvmTest` suites green on linux-x86_64 with `--add-modules jdk.incubator.vector`.

## Out of scope (deferred)

- **Phase B2 NEON intrinsics** — auto-vec C already lands well; hand-tuning waits for measurement on a reference ARM core.
- **`objdump -d` verification on ARM64** — same caveat as the BF16 PR (#605): the bench was run on x86_64 only.
- **Q8_0 × Q8_0 (both operands quantized) variant** — ggml has it, no current SKaiNET consumer uses it.
- **End-to-end smoke against a Llama Q8_0 GGUF** — wires the new kernel into `DefaultCpuOps.matmul` dispatch, asserts first-step logits within `1e-3` cosine of an FP32 reference. Belongs in a follow-up PR alongside the dispatch wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)