### PR TITLE
Docs: split nav into Using SKaiNET vs Contributing, annotate Java pages

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,34 +1,33 @@
 * xref:index.adoc[Overview]
 
-.Tutorials
-* xref:tutorials/java-getting-started.adoc[Java getting started]
-* xref:tutorials/hlo-getting-started.adoc[StableHLO getting started]
-* xref:tutorials/graph-dsl.adoc[Graph DSL]
-
-.How-to guides
-* xref:how-to/build-tensors.adoc[Build tensors with the data DSL]
-* xref:how-to/io-readers.adoc[Load models (GGUF, SafeTensors, ONNX)]
-* xref:how-to/java-model-training.adoc[Train a model from Java]
-* xref:how-to/arduino-c-codegen.adoc[Generate C for Arduino]
-
-.Reference
-* xref:reference/architecture.adoc[Architecture]
-* xref:reference/operators/generated/index.adoc[Operator reference]
-* xref:reference/ops-status-matrix.adoc[Operator coverage matrix]
-* xref:reference/api.adoc[API reference (Dokka)]
-
-.Explanation
-* xref:explanation/skainet-for-ai.adoc[SKaiNET for AI/ML]
-* xref:explanation/operator-design.adoc[Operator documentation system]
-* xref:explanation/theory/index.adoc[Mathematical theory]
-** xref:explanation/theory/matmul.adoc[Matrix multiplication]
-* xref:explanation/examples/index.adoc[Worked examples]
-** xref:explanation/examples/matmul.adoc[Matrix multiplication examples]
-* xref:explanation/perf/jvm-cpu.adoc[JVM CPU performance]
-* xref:explanation/perf/simd-kernels.adoc[How SIMD kernels are built]
-* xref:explanation/perf/quantized-simd-kernels.adoc[How quantized SIMD kernels are built]
-* xref:explanation/perf/java-25-cpu-backend.adoc[Java 25 CPU backend notes]
-* xref:explanation/issues/native-macos-accelerate-simd.adoc[Native macOS Accelerate SIMD issues]
+.Using SKaiNET
+* xref:using/index.adoc[About this section]
+* Tutorials
+** xref:tutorials/java-getting-started.adoc[Java getting started]
+** xref:tutorials/hlo-getting-started.adoc[StableHLO getting started]
+** xref:tutorials/graph-dsl.adoc[Graph DSL]
+* How-to guides
+** xref:how-to/build-tensors.adoc[Build tensors with the data DSL]
+** xref:how-to/io-readers.adoc[Load models (GGUF, SafeTensors, ONNX)]
+** xref:how-to/java-model-training.adoc[Train a model from Java]
+** xref:how-to/arduino-c-codegen.adoc[Generate C for Arduino]
+* Reference
+** xref:reference/architecture.adoc[Architecture]
+** xref:reference/operators/generated/index.adoc[Operator reference]
+** xref:reference/ops-status-matrix.adoc[Operator coverage matrix]
+** xref:reference/api.adoc[API reference (Dokka)]
+* Explanation
+** xref:explanation/skainet-for-ai.adoc[SKaiNET for AI/ML]
+** xref:explanation/operator-design.adoc[Operator documentation system]
+** xref:explanation/theory/index.adoc[Mathematical theory]
+*** xref:explanation/theory/matmul.adoc[Matrix multiplication]
+** xref:explanation/examples/index.adoc[Worked examples]
+*** xref:explanation/examples/matmul.adoc[Matrix multiplication examples]
+** xref:explanation/perf/jvm-cpu.adoc[JVM CPU performance]
+** xref:explanation/perf/simd-kernels.adoc[How SIMD kernels are built]
+** xref:explanation/perf/quantized-simd-kernels.adoc[How quantized SIMD kernels are built]
+** xref:explanation/perf/java-25-cpu-backend.adoc[Java 25 CPU backend notes]
+** xref:explanation/issues/native-macos-accelerate-simd.adoc[Native macOS Accelerate SIMD issues]
 
 .Contributing
 * xref:contributing/index.adoc[Audience and scope]

--- a/docs/modules/ROOT/pages/how-to/java-model-training.adoc
+++ b/docs/modules/ROOT/pages/how-to/java-model-training.adoc
@@ -1,5 +1,12 @@
 == Java Model Training Guide
 
+[NOTE]
+====
+**Audience: Java consumers.** This page uses Java syntax. The training
+concepts (optimizers, autograd tape, loss functions) are the same on
+the Kotlin side — only the surface differs.
+====
+
 This guide covers building neural networks, defining loss functions and optimizers, loading datasets, and running training loops -- all from plain Java.
 
 === Prerequisites

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -8,31 +8,22 @@ loaders (GGUF, SafeTensors, ONNX), quantization primitives
 platform compile targets, and a pluggable backend API that CPU,
 GPU, and NPU backends can implement independently.
 
-This documentation site is organized following the
-https://diataxis.fr/[Diátaxis / Divio framework] — pick the
-section that matches what you're trying to do:
+This site is split by what you're here to do:
 
 [.card-grid]
-* xref:tutorials/java-getting-started.adoc[*Tutorials*]
+* xref:using/index.adoc[*Using SKaiNET*]
 +
-Learning-oriented walkthroughs. Start here if you are new to
-SKaiNET — set up a project, build your first tensor, run a
-forward pass.
-* xref:contributing/build-from-source.adoc[*How-to guides*]
+You're building an app with SKaiNET — pulling artifacts from a BOM,
+constructing tensors, running a forward pass, loading a GGUF model,
+training a small network. Inside, content follows the
+https://diataxis.fr/[Diátaxis] framework: Tutorials (learning-oriented),
+How-to guides (task-oriented), Reference (lookup), Explanation
+(background). Java consumers — see the "From Java" callout on that page.
+* xref:contributing/index.adoc[*Contributing to SKaiNET*]
 +
-Task-oriented recipes. Build from source, load a GGUF model,
-generate C for Arduino, train a small network from Java.
-* xref:reference/architecture.adoc[*Reference*]
-+
-Information-oriented lookup: architecture, the
-xref:reference/operators/generated/index.adoc[operator catalog],
-the xref:reference/ops-status-matrix.adoc[backend coverage matrix],
-and the link:../api/index.html[Dokka API reference].
-* xref:explanation/skainet-for-ai.adoc[*Explanation*]
-+
-Understanding-oriented background: SKaiNET for AI/ML, the
-operator documentation system, mathematical theory, performance
-notes.
+You're modifying SKaiNET itself — building from source, adding
+kernels, running the benchmark suite, maintaining CI, operating the
+self-hosted runner. Audience admonition at the top of each page.
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -1,5 +1,13 @@
 == Java Getting Started Guide
 
+[NOTE]
+====
+**Audience: Java consumers.** This page uses Java syntax and the
+`SKaiNET.context()` builder surface. Kotlin users — see
+xref:tutorials/graph-dsl.adoc[Graph DSL] for the equivalent walkthrough
+with extension functions and operator overloading.
+====
+
 This guide gets you from zero to running tensor operations with SKaiNET in under 5 minutes. SKaiNET is a Kotlin Multiplatform AI framework, but every JVM-facing API is designed for idiomatic Java usage -- no Kotlin knowledge required.
 
 === Prerequisites

--- a/docs/modules/ROOT/pages/using/index.adoc
+++ b/docs/modules/ROOT/pages/using/index.adoc
@@ -1,0 +1,62 @@
+= Using SKaiNET — Audience and Scope
+:description: What lives in the Using SKaiNET section, who it's for, and where Java consumers should look.
+
+[NOTE]
+====
+**Audience: people building apps with SKaiNET.** These pages document
+how to *call* SKaiNET as a library — pulling artifacts from a BOM,
+constructing tensors, running a forward pass, training a model. If you
+are *modifying* SKaiNET itself — adding kernels, running benchmarks,
+operating CI — see xref:contributing/index.adoc[Contributing].
+====
+
+== What this section covers
+
+The Using SKaiNET section is for the engineer who:
+
+- Adds SKaiNET to a Gradle / Maven build.
+- Builds tensors, runs forward passes, trains small models.
+- Loads pre-trained weights (GGUF, SafeTensors, ONNX).
+- Targets StableHLO / IREE for cross-platform deployment.
+- Reads the operator catalog to discover what's supported on which
+  backend.
+
+Inside, content follows the
+https://diataxis.fr/[Diátaxis / Divio framework]:
+
+[cols="1,3",options="header"]
+|===
+| Sub-section | What it answers
+| Tutorials | Learning-oriented walkthroughs. Start here if you are new to SKaiNET.
+| How-to guides | Task-oriented recipes — "I need to load a GGUF model", "I need to train from Java".
+| Reference | Information-oriented lookup: architecture, operator catalog, coverage matrix, Dokka API.
+| Explanation | Understanding-oriented background: theory, performance notes, design rationale.
+|===
+
+== Using SKaiNET from Java
+
+SKaiNET is a Kotlin Multiplatform library; the JVM artifact is consumable
+from Java but the idioms differ (builder factories instead of extension
+functions, no operator overloading). The following pages target Java
+specifically:
+
+- xref:tutorials/java-getting-started.adoc[Java getting started] — set up a Maven / Gradle project, run a forward pass.
+- xref:how-to/java-model-training.adoc[Train a model from Java] — assemble a training loop using the Java surface.
+
+The rest of this section is written in Kotlin. The concepts transfer
+directly; only the syntax differs.
+
+[NOTE]
+====
+LLM-specific Java runtimes (Llama, Gemma, Qwen, BERT) moved to the
+sibling https://github.com/SKaiNET-developers/SKaiNET-transformers[SKaiNET-transformers]
+repository in 2026.
+====
+
+== What this section deliberately does *not* cover
+
+- **How SKaiNET is built, benchmarked, or released.** See
+  xref:contributing/index.adoc[Contributing].
+- **Commit conventions, branch policy, issue reports.** Those live in
+  repo-root files (`CONTRIBUTING.md`, `GITFLOW.adoc`, `CHANGELOG.md`,
+  `FAQ.md`) and intentionally aren't duplicated here.


### PR DESCRIPTION
## Summary

The Contributing section already had an explicit Audience admonition + scope-statement landing page; the consumer track was only implicit. This PR makes the split symmetric.

- New \`using/index.adoc\` mirrors \`contributing/index.adoc\` — same Audience admonition pattern, same scope statement.
- Top-level \`index.adoc\` replaces the four-card Diátaxis grid with two audience cards (Using SKaiNET / Contributing to SKaiNET). The Diátaxis breakdown moves into the \`using/\` landing page where it's actually relevant.
- \`nav.adoc\` regroups Tutorials / How-to / Reference / Explanation under a "Using SKaiNET" heading; Contributing stays as a sibling top-level section. **Pages don't move** — only the grouping changed, so every existing xref still resolves.
- The 2 live Java consumer pages (\`tutorials/java-getting-started.adoc\`, \`how-to/java-model-training.adoc\`) get an Audience admonition. Deprecated Java stubs are skipped (they already say "moved").

A separate Java Antora component would be premature at 2 live pages — revisit if the Java surface grows past ~5 pages.

## Test plan

- [x] \`docker build -t skainet-antora:local docs/.docker/\` → image builds clean.
- [x] \`docker run … skainet-antora:local antora-playbook.yml\` → 36 pages generated (was 35; +1 for new \`using/index.html\`), no warnings.
- [x] Top \`index.html\` renders the two new audience cards with correct xrefs.
- [x] \`using/index.html\` renders the Audience admonition + Diátaxis table + "From Java?" callout.
- [x] Both Java pages render their Audience admonition.
- [x] Nav renders "Using SKaiNET" and "Contributing" as sibling sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)