### PR TITLE
Fix #620: order getInputNodes by destinationInputIndex

### DIFF
--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/ComputeGraph.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/ComputeGraph.kt
@@ -49,7 +49,16 @@ public interface ComputeGraph {
     public fun getOutputNodes(): List<GraphNode>
     
     /**
-     * Gets nodes that are inputs to the given node
+     * Gets nodes that are inputs to the given node, ordered by the
+     * destination input index. Callers depend on this order being
+     * positional (`result[i]` is the producer for the consumer's
+     * i-th operand) — emitters that map producers to MLIR operands
+     * (e.g. `dot_general %lhs, %rhs`) would otherwise mis-pair
+     * operands with the consumer's declared input types. Edge
+     * insertion order is not stable: nodes whose first operand has
+     * no producer at trace time only get their edge added during
+     * [TraceToGraphBuilder.finalize], producing an out-of-order
+     * `_edges` list (issue #620).
      */
     public fun getInputNodes(node: GraphNode): List<GraphNode>
     

--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultComputeGraph.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultComputeGraph.kt
@@ -66,6 +66,7 @@ public class DefaultComputeGraph : ComputeGraph {
     override fun getInputNodes(node: GraphNode): List<GraphNode> {
         return _edges
             .filter { it.destination == node }
+            .sortedBy { it.destinationInputIndex }
             .map { it.source }
     }
 

--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/SimpleComputeGraph.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/SimpleComputeGraph.kt
@@ -42,7 +42,8 @@ public class SimpleComputeGraph(
     override fun getInputNodes(): List<GraphNode> = _nodes.filter { n -> _edges.none { it.destination == n } }
     override fun getOutputNodes(): List<GraphNode> = _nodes.filter { n -> _edges.none { it.source == n } }
 
-    override fun getInputNodes(node: GraphNode): List<GraphNode> = _edges.filter { it.destination == node }.map { it.source }
+    override fun getInputNodes(node: GraphNode): List<GraphNode> =
+        _edges.filter { it.destination == node }.sortedBy { it.destinationInputIndex }.map { it.source }
     override fun getOutputNodes(node: GraphNode): List<GraphNode> = _edges.filter { it.source == node }.map { it.destination }
 
     override fun getTopologicalOrder(): List<GraphNode> {

--- a/skainet-compile/skainet-compile-hlo/src/commonTest/kotlin/sk/ainet/compile/hlo/LinalgOperationsConverterTest.kt
+++ b/skainet-compile/skainet-compile-hlo/src/commonTest/kotlin/sk/ainet/compile/hlo/LinalgOperationsConverterTest.kt
@@ -156,6 +156,62 @@ class LinalgOperationsConverterTest {
     }
 
     @Test
+    fun testMatmulOperandOrderingWithOutOfOrderEdgeInsertion() {
+        // Regression for issue #620: a dense layer whose input has no producer
+        // at trace time only gets its edge added during TraceToGraphBuilder.finalize(),
+        // so _edges contains (weight->matmul, idx=1) BEFORE (input->matmul, idx=0).
+        // getInputNodes(node) must order by destinationInputIndex, otherwise the
+        // emitter pairs operand[0]=weight with the declared lhsType=input
+        // (read from node.inputs[0]) and the resulting MLIR fails the verifier.
+        val graph = DefaultComputeGraph()
+
+        val input = GraphNode(
+            id = "x",
+            operation = InputOperation<DType, Any>(),
+            inputs = emptyList(),
+            outputs = listOf(TensorSpec("x", listOf(1, 1), "FP32"))
+        )
+        val weight = GraphNode(
+            id = "w",
+            operation = InputOperation<DType, Any>(),
+            inputs = emptyList(),
+            outputs = listOf(TensorSpec("w", listOf(1, 16), "FP32"))
+        )
+        val matmul = createMatmulNode(
+            "matmul1",
+            listOf(
+                TensorSpec("x", listOf(1, 1), "FP32"),
+                TensorSpec("w", listOf(1, 16), "FP32"),
+            ),
+            TensorSpec("y", listOf(1, 16), "FP32"),
+        )
+
+        graph.addNode(input)
+        graph.addNode(weight)
+        graph.addNode(matmul)
+
+        // Deliberately add the weight edge (idx=1) BEFORE the input edge (idx=0)
+        // to reproduce the post-finalize() edge ordering produced by the tape.
+        graph.addEdge(GraphEdge("e_w", weight, matmul, 0, 1, weight.outputs[0]))
+        graph.addEdge(GraphEdge("e_x", input, matmul, 0, 0, input.outputs[0]))
+
+        val converter = StableHloConverterFactory.createBasic()
+        val module = converter.convert(graph, "test_oop_matmul")
+
+        // The expected emission is `dot_general %arg0, %arg1 ... (1x1, 1x16) -> 1x16`.
+        // Pre-fix bug would emit operands `%arg1, %arg0` against type signature
+        // `(1x1, 1x16)`, which MLIR rejects.
+        assertTrue(
+            module.content.contains(
+                "stablehlo.dot_general %arg0, %arg1, " +
+                    "contracting_dims = [1] x [0] : " +
+                    "(tensor<1x1xf32>, tensor<1x16xf32>) -> tensor<1x16xf32>"
+            ),
+            "Expected operand order to match type signature; got:\n${module.content}",
+        )
+    }
+
+    @Test
     fun testMatmulWithDifferentDataTypes() {
         // Test matmul with different data types
         val graph = DefaultComputeGraph()


### PR DESCRIPTION
## Summary

Fixes #620 — the StableHLO exporter emitted the first `stablehlo.dot_general` with operands swapped relative to the type signature, so IREE's MLIR verifier rejected the file.

Root cause: the exporter pairs each `dot_general` operand with a declared input type from two different sources — operands from `ComputeGraph.getInputNodes(node)` (edge order) and types from `node.inputs[i]` (positional). `getInputNodes` did not sort edges by `destinationInputIndex`, returning producers in raw `_edges` insertion order.

For a dense layer whose input has no producer at trace time, the input edge is only added during `TraceToGraphBuilder.finalize()` — *after* the weight edge. The first `dot_general` was emitted with operands `(weight, input)` while the type signature stayed `(input, weight)`. Layers 2 & 3 were unaffected because both their inputs have producers during tracing, so edges land in order.

## Changes

- `DefaultComputeGraph.getInputNodes(node)` / `SimpleComputeGraph.getInputNodes(node)` — sort filtered edges by `destinationInputIndex` so the result is positional regardless of edge insertion order.
- `ComputeGraph` interface — documented the positional-order contract, citing #620.
- `LinalgOperationsConverterTest` — added `testMatmulOperandOrderingWithOutOfOrderEdgeInsertion`, which adds edges weight-first/input-last and asserts the emitted `dot_general` operands match the type signature.

## Test plan

- [x] `LinalgOperationsConverterTest` — 9/9 pass, including the new regression
- [x] End-to-end: regenerated the issue's `sinus-mlp.mlir` (1-16-16-1 ReLU MLP) against the patched source; the first `dot_general` is now `%arg0, %v6 ... : (tensor<1x1xf32>, tensor<1x16xf32>) -> tensor<1x16xf32>` — operands match types; layers 2 & 3 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)