### PR TITLE
Add canonical five-minute start path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@
 
 ## Start in 5 minutes
 
-New to SKaiNET? Choose the path that matches what you want to try first.
+SKaiNET is a Kotlin Multiplatform AI framework. New here? Choose the path that
+matches what you want to try first.
 
 | Goal | Start here | Time |
 |---|---|---:|
-| Run tensor operations on the JVM | [Quickstart](#quickstart) (below) | 2–5 min |
+| Run tensor operations | [Quickstart](#quickstart) (below) | 2–5 min |
+| Build and train a neural net | [Hello Neural Net](#hello-neural-net) (below) | 5 min |
 | Run a local GGUF model | [SKaiNET Transformers starter](https://github.com/SKaiNET-developers/SKaiNET-transformers#start-in-5-minutes) | 5 min after model setup |
-| Use SKaiNET from Java | [Java getting started](docs/modules/ROOT/pages/tutorials/java-getting-started.adoc) | 5 min |
+
+Working in Java? SKaiNET ships first-class Java support — see the
+[Java getting-started guide](docs/modules/ROOT/pages/tutorials/java-getting-started.adoc).
 
 Use the version shown in this README as the source of truth for first-run snippets.
 If another page shows a different version, please open an issue or PR.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
 
 ---
 
+## Start in 5 minutes
+
+New to SKaiNET? Choose the path that matches what you want to try first.
+
+| Goal | Start here | Time |
+|---|---|---:|
+| Run tensor operations on the JVM | [Quickstart](#quickstart) (below) | 2–5 min |
+| Run a local GGUF model | [SKaiNET Transformers starter](https://github.com/SKaiNET-developers/SKaiNET-transformers#start-in-5-minutes) | 5 min after model setup |
+| Use SKaiNET from Java | [Java getting started](docs/modules/ROOT/pages/tutorials/java-getting-started.adoc) | 5 min |
+
+Use the version shown in this README as the source of truth for first-run snippets.
+If another page shows a different version, please open an issue or PR.
+
+---
+
 ## Quickstart
 
 Add the core dependencies (Gradle Kotlin DSL):
@@ -16,7 +31,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.23.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.23.1"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -2,6 +2,15 @@
 
 [NOTE]
 ====
+This tutorial is one of the canonical SKaiNET *five-minute start paths*.
+If you are choosing between the Tensor, Transformers, and Java entry points,
+start from the repository
+https://github.com/SKaiNET-developers/SKaiNET#start-in-5-minutes[README "Start in 5 minutes"]
+section. The version shown there is the source of truth for first-run snippets.
+====
+
+[NOTE]
+====
 **Audience: Java consumers.** This page uses Java syntax and the
 `SKaiNET.context()` builder surface. Kotlin users — see
 xref:tutorials/graph-dsl.adoc[Graph DSL] for the equivalent walkthrough
@@ -37,7 +46,7 @@ The `skainet-bom` manages all SKaiNET module versions so you never have to keep 
 ----
 <project>
     <properties>
-        <skainet.version>0.22.2</skainet.version>
+        <skainet.version>0.23.1</skainet.version>
     </properties>
 
     <dependencyManagement>
@@ -135,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.22.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.23.1"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")
@@ -210,6 +219,22 @@ mvn compile exec:java
 # Gradle
 ./gradlew run
 ----
+
+==== Success looks like this
+
+A successful first run prints a `2 x 2` result shape and the activated tensor
+values `58, 64, 139, 154` (the matmul of the two matrices above; all values are
+positive, so ReLU leaves them unchanged):
+
+....
+matmul result shape: [2, 2]
+after relu:          [[58.0, 64.0], [139.0, 154.0]]
+....
+
+If you see this output, SKaiNET is installed correctly and you are ready to
+move on to the next steps. If the run fails with a `module jdk.incubator.vector
+not found` error, confirm the JVM flags from the
+xref:tutorials/java-getting-started.adoc#_jvm_flags[JVM Flags] section are applied.
 
 '''''
 

--- a/scripts/check-doc-versions.sh
+++ b/scripts/check-doc-versions.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Checks that the start-path docs reference the same SKaiNET version as the
+# README. The README "Start in 5 minutes" / Quickstart block is the documented
+# source of truth for first-run snippets.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+readme_version="$(grep -oE 'sk\.ainet:skainet-bom:[0-9]+\.[0-9]+\.[0-9]+' README.md \
+  | head -n1 | cut -d: -f3)"
+
+if [[ -z "${readme_version}" ]]; then
+  echo "FAIL: could not find a skainet-bom version in README.md"
+  exit 1
+fi
+
+echo "README source-of-truth version: ${readme_version}"
+
+status=0
+check() {
+  local file="$1"
+  local found
+  found="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "${file}" | sort -u | tr '\n' ' ' || true)"
+  if grep -q "${readme_version}" "${file}"; then
+    echo "OK   ${file}"
+  else
+    echo "FAIL ${file} does not reference ${readme_version} (found: ${found})"
+    status=1
+  fi
+}
+
+check docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+
+exit "${status}"


### PR DESCRIPTION
Adds a visible newcomer start path to the main README and aligns the Java getting-started tutorial with it.

Intended for KotlinConf visitors and first-time SKaiNET users who need one obvious first route into the project.

## Includes
- **README:** new "Start in 5 minutes" section with three clear entry paths (Tensor runtime / Transformers local LLM / Java).
- **Version consistency:** Quickstart snippet bumped `0.23.0 → 0.23.1` (latest stable on Maven Central).
- **`java-getting-started.adoc`:** fixed stale `0.22.2` coordinates → `0.23.1`; added a canonical-start-path note and a "Success looks like this" block.
- **`scripts/check-doc-versions.sh`:** lightweight drift guard, keyed to the README as the documented source of truth.

## Note for maintainers
`develop` carries `VERSION_NAME=0.23.0`, but `0.23.1` is the latest tag published to Maven Central and the `0.23.1` tag is not merged into `develop`. Snippets here use `0.23.1` so copy-paste users get the latest stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)