### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-25
+
+### Added
+
+- **BF16 matmul end-to-end.** New `Bf16TensorData` + `Bf16DenseTensorData` (PR #610), opt-in SafeTensors loader policy to keep BF16 native through the loader chain (PR #612), and `DefaultCpuOpsJvm` BF16 dispatch wired against `Bf16TensorData` (PR #614). The matmul kernel itself ships as `Bf16MatmulKernel` with scalar, Panama, and native implementations registered with the `KernelRegistry` SPI (PR #605).
+- **Q8_0 matmul end-to-end.** `Q8_0MatmulKernel` with scalar, Panama, and native implementations (PR #606); `DefaultCpuOpsJvm.chooseQuantizedMatmul` now resolves through the `KernelRegistry` SPI so the best-available Q8_0 kernel wins automatically (PR #608).
+- **Autograd completeness for `pow`, `log`, and conv/pool/upsample/split.** New `pow` / `powScalar` ops plus a `PowSpecializationPass` (Tier A of #617), `log` / `log2` / `log10` ops (Tier B), backward formulas filled in for `pow` / `log` with the matching dispatch arms (Tier C partial), and the remaining conv / pool / upsample / split backward formulas (Tier C). End-to-end CNN training-step test (Tier D) pins the contract. (PR #618)
+- **Hybrid adaptive DSL with optional dtype constraints — RFC implementation.** `DTypeConstraintResolutionPass` registered in the pipeline (W7), a `dtypePolicy(...)` extension on `DagBuilder` (W6), `StreamingGgufParametersLoader.withPolicy(DTypePolicy)` (W0c), a typed `ResolvedComputeGraph` view (W8), and a `toStableHlo(ResolvedComputeGraph)` overload (W9). (Issue #615, PR #616)
+- **`@DarcValidated` annotation for operator documentation.** New `sk.ainet.lang.ops.DarcValidated` annotation in `skainet-lang-ksp-annotations`; the KSP `OperatorDocProcessor` threads its values through `operators.json`, and the doc generator renders a `✅ / ⚠ / ✖` badge above each function's signature plus a `Validated` column on the operator coverage matrix. `matmul` is annotated as the worked example. The Antora `Contributing` section gains a dedicated `darc-workflow.adoc` page that defines the workflow and the criteria for setting the annotation; `.github/ISSUE_TEMPLATE/darc_feature_request.md` was aligned (`DEFINE` → `DOCUMENT`, `CONTRIBUTE` → `CODE`). (Issue #627, PR #628)
+- **SentencePiece special-token splitter.** New `SpecialTokenSplitter` decorator in `skainet-io-core` plus fixes for SentencePiece HF JSON gaps that previously misrouted control tokens. (PR #595)
+
+### Changed
+
+- **`operator-doc-schema-v1.json` widened to match what the processor actually emits.** Added the `composite` modality, the `inherited` backend status, `version: "unknown"` (mirroring the existing `commit` handling), and the `description` note type. The optional `validated` / `validatedBy` / `validatedOn` / `validatedCommit` / `referencesChecked` fields were added in support of `@DarcValidated`. `validateOperatorSchema` goes from `0/4 valid` to `4/4 valid`. (PR #628)
+
+### Fixed
+
+- **`getInputNodes` ordering.** Now ordered by `destinationInputIndex` so DAG consumers see operands in the right slot. (Issue #620, PR #622)
+
+### Documentation
+
+- **DARC workflow contributor page** (`contributing/darc-workflow.adoc`) — authoritative in-repo definition of Document / Assess / Research / Code, with the operator-doc specialisation. The Antora docs site is now declared the authoritative source over the GitHub wiki. (PR #628)
+- **SIMD kernels deep-dive + arc42 architecture page.** How FP32 and quantized Panama Vector kernels are built; how to read the matmul benchmark; the priority-100 native FFM provider plan. (PR #623)
+- **Nav split: Using SKaiNET vs Contributing.** The left nav now separates the consumer-facing Tutorials / How-to / Reference / Explanation tree from the maintainer-facing Contributing tree, and Java-specific pages are annotated. (PR #619)
+- **Canonical five-minute start path.** New tutorial path that gets a reader from zero to a working SKaiNET call in five minutes; deliberately Kotlin-first to match the framework's primary surface. (PR #624, plus follow-up "keep the start path Kotlin-first")
+- **Architecture goal in the README.** Single paragraph stating what SKaiNET is optimising for, so readers landing on the README know the framework's centre of gravity. (PR #625)
+- **`native-ffm-plan.adoc` removed from the published docs.** The page read as a PRD/issue, not user-facing reference; content is preserved as an untracked draft for promotion to a real issue. The nine incoming xrefs across six pages were surgically rewritten. (PR #628)
+
+### Dependencies
+
+- Bump `androidGradlePlugin` to 9.2.1 (PR #597).
+- Bump `org.jetbrains.kotlinx:kotlinx-benchmark-runtime` to 0.4.17 (PR #599).
+- Bump `org.jetbrains.kotlinx:kotlinx-coroutines-core` to 1.11.0 (PR #600).
+- Bump Gradle wrapper to 9.5.1 (PR #601).
+- Bump `io.ktor:ktor-client-core` to 3.5.0 (PR #602).
+- Bump `org.junit.jupiter:junit-jupiter` to 6.1.0 (PR #621).
+
 ## [0.23.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.23.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -193,13 +193,17 @@ deployment, the StableHLO path for native and edge targets.
 
 ---
 
-## What's New in 0.23.0
+## What's New in 0.25.0
 
-- **Real-model GGUFs no longer OOM at network construction.** The DSL pre-allocated zero-filled `FloatArray(shape.volume)` for every Linear / Conv weight at module-creation time, even though downstream loaders overwrite those zeros immediately. For an Apertus-8B Q4_K_S GGUF (4.7 GB on disk) that was ~27 GB of FP32 zeros allocated and thrown away — OOMed at 12 GB heap. New `TensorDataFactory.placeholder(...)` API; every eager `zeros(...)` call site in the network builders routes through it. Lazy materialization fires only if a caller actually reads the tensor (which the load path never does). Verified end-to-end against `unsloth/Apertus-8B-Instruct-2509-GGUF`: now loads in 12 GB heap. Same fix benefits Gemma / Llama / Qwen / Voxtral DSL paths transparently. (Issue #587, PR #588)
-- **Kotlin/Native: GGUFs over ~2 GiB now load.** `createRandomAccessSource(filePath)` had no native actual; K/N consumers fell through to the legacy slurp-into-`ByteArray` reader, which capped at `Int.MAX_VALUE` bytes (~2 GiB). Practical impact: macOS / Linux / iOS native couldn't open Q8 models above ~1B parameters or Q4 above ~3B. New POSIX-`pread`-backed `PosixPreadRandomAccessSource` covers `macosArm64`, `linuxX64`, `linuxArm64`, `iosArm64`, `iosSimulatorArm64`. (Issue #589, PR #591)
+- **BF16 and Q8_0 matmul kernels across the provider stack.** End-to-end dtype paths for both formats: new `Bf16TensorData` / `Bf16DenseTensorData`, `Bf16MatmulKernel` and `Q8_0MatmulKernel` with scalar / Panama / native implementations, opt-in SafeTensors BF16-preserving loader policy, and `DefaultCpuOpsJvm.chooseQuantizedMatmul` routed through the `KernelRegistry` SPI so the best-available kernel wins automatically. (PRs #605, #606, #608, #610, #612, #614)
+- **Autograd completeness.** Backward formulas filled in for `pow` / `log` / `log2` / `log10`, the conv / pool / upsample / split family, with an end-to-end CNN training-step test pinning the contract. (PR #618)
+- **Hybrid adaptive DSL with optional dtype constraints (RFC implementation).** `DTypeConstraintResolutionPass` plus a `dtypePolicy(...)` extension on `DagBuilder`, an opt-in `StreamingGgufParametersLoader.withPolicy(...)`, and a typed `ResolvedComputeGraph` view that flows into `toStableHlo(...)`. (PR #616)
+- **DARC validation flag for operator documentation.** New `@DarcValidated` annotation read by the KSP processor and surfaced as a `✅ / ⚠ / ✖` badge on every generated operator page plus a `Validated` column on the coverage matrix. The Antora `Contributing` section gains a dedicated DARC workflow page. (Issue #627, PR #628)
+- **SentencePiece tokenizer: special-token-aware splitting.** New `SpecialTokenSplitter` decorator covering the HF JSON gaps that previously misrouted control tokens. (PR #595)
 
 ### Recent releases
 
+- **0.23.0** — Real-model GGUFs no longer OOM at network construction (lazy `TensorDataFactory.placeholder(...)`); Kotlin/Native can finally load GGUFs over 2 GiB via the new POSIX-`pread`-backed `PosixPreadRandomAccessSource`. (Issues #587, #589; PRs #588, #591)
 - **0.22.2** — `sk.ainet:skainet-bom` now resolves from Maven Central (earlier versions shipped at the wrong coordinates). (Issue #584)
 - **0.22.1** — `StreamingShardedSafeTensorsReader.loadTensorStorageMapped` for zero-copy reads of multi-shard tensors above the 2 GB JVM `ByteArray` limit. (PR #582)
 - **0.22.0** — Native (FFM) CPU kernel provider: **4–6× faster Q4_K matmul, 1.5–1.8× FP32 SGEMM** vs Panama Vector; auto-selected via `KernelRegistry.bestAvailable()`. (PR #571)

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.22.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.22.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/java-model-training.adoc
+++ b/docs/modules/ROOT/pages/how-to/java-model-training.adoc
@@ -23,7 +23,7 @@ This guide covers building neural networks, defining loss functions and optimize
         <dependency>
             <groupId>sk.ainet</groupId>
             <artifactId>skainet-bom</artifactId>
-            <version>0.22.2</version>
+            <version>0.25.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/modules/ROOT/pages/reference/operators/generated/index.adoc
+++ b/docs/modules/ROOT/pages/reference/operators/generated/index.adoc
@@ -1,6 +1,6 @@
 = AI-NET Operators Reference
 
-Generated from version `0.23.0` on 2026-05-24
+Generated from version `0.25.0` on 2026-05-25
 
 == Operators by Modality
 

--- a/docs/modules/ROOT/pages/reference/ops-status-matrix.adoc
+++ b/docs/modules/ROOT/pages/reference/ops-status-matrix.adoc
@@ -1,7 +1,7 @@
 = Operator Coverage Matrix
 :description: Cross-backend status for every operator function in SKaiNET.
 
-Generated from `operators.json` version `0.23.0` on 2026-05-24.
+Generated from `operators.json` version `0.25.0` on 2026-05-25.
 
 Rows are `Operator.function` pairs. The `Validated` column shows whether the function's documentation has been DARC-validated by a reviewer (see xref:contributing/darc-workflow.adoc[DARC workflow]). Remaining columns are backends that appear in any function's `statusByBackend` map — a missing entry means the backend makes no claim about the function (treat it as "unknown", not "not supported").
 

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -46,7 +46,7 @@ The `skainet-bom` manages all SKaiNET module versions so you never have to keep 
 ----
 <project>
     <properties>
-        <skainet.version>0.23.1</skainet.version>
+        <skainet.version>0.25.0</skainet.version>
     </properties>
 
     <dependencyManagement>
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.23.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.23.0
+VERSION_NAME=0.25.0
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/


### PR DESCRIPTION
Bumps VERSION_NAME 0.23.0 → 0.25.0 and lands the matching CHANGELOG entry, README "What's New in 0.25.0" section, and sample-dependency version bumps across the how-to and tutorial pages.

The 0.25.0 release rolls up the BF16 and Q8_0 matmul end-to-end work (scalar/Panama/native kernels, dispatch chain, SafeTensors loader policy), autograd completeness for pow/log and conv/pool/upsample/split, the hybrid adaptive DSL with dtype constraints (RFC #615), the DARC validation flag for operator documentation (#627), and the SentencePiece special-token splitter, plus six dependency bumps and five documentation pushes (SIMD kernels deep-dive, arc42, the Using vs Contributing nav split, the canonical five-minute start path, and the README architecture-goal statement).

Operator docs were regenerated so the version stamp in reference/operators/generated/index.adoc and ops-status-matrix.adoc reads 0.25.0; validateOperatorSchema stays 4/4 valid; the Antora site rebuilds clean against the same Docker image the docs.yml workflow uses.