### PR TITLE
Fix Gradle build hygiene warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,6 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
-org.gradle.configureondemand=true
 #Kotlin
 kotlin.code.style=official
 #MPP

--- a/skainet-compile/skainet-compile-hlo/build.gradle.kts
+++ b/skainet-compile/skainet-compile-hlo/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     explicitApi()
 
     android {
-        namespace = "sk.ainet.compilie.core"
+        namespace = "sk.ainet.compile.hlo"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
         compilerOptions {


### PR DESCRIPTION
## Summary
- Remove Gradle configuration-on-demand from repo defaults because Kotlin Multiplatform targets do not support it reliably.
- Fix the Android namespace typo for skainet-compile-hlo.

## Verification
- ./gradlew projects --no-daemon
- ./gradlew :skainet-lang:skainet-lang-core:jvmTest --no-daemon

Fixes #632