### PR TITLE
Clarify ignored tests and enable BatchNorm coverage

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/lang/nn/normalization/BatchNormalizationTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/lang/nn/normalization/BatchNormalizationTest.kt
@@ -4,8 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
-import kotlin.test.Ignore
 import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.Phase
 import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.types.FP32
 import sk.ainet.lang.tensor.Tensor
@@ -37,11 +37,11 @@ class BatchNormalizationTest {
         }
     }
 
-    @Ignore
     @Test
     fun train_then_eval_works_and_preserves_shape() {
-        val exec = DirectCpuExecutionContext()
-        val x = makeInput2x2(exec)
+        val trainExec = DirectCpuExecutionContext(phase = Phase.TRAIN)
+        val evalExec = DirectCpuExecutionContext(phase = Phase.EVAL)
+        val x = makeInput2x2(trainExec)
         val bn = BatchNormalization<FP32, Float>(
             numFeatures = 2,
             affine = false,
@@ -49,21 +49,20 @@ class BatchNormalizationTest {
         )
         // training pass initializes running stats
         bn.train()
-        val yTrain = bn.forward(x, exec)
+        val yTrain = bn.forward(x, trainExec)
         assertNotNull(yTrain)
         assertEquals(x.shape, yTrain.shape)
 
         // eval should now work using running stats
         bn.eval()
-        val yEval = bn.forward(x, exec)
+        val yEval = bn.forward(x, evalExec)
         assertNotNull(yEval)
         assertEquals(x.shape, yEval.shape)
     }
 
-    @Ignore
     @Test
     fun simple_2x2_batch_is_normalized_per_channel() {
-        val exec = DirectCpuExecutionContext()
+        val exec = DirectCpuExecutionContext(phase = Phase.TRAIN)
         val x = makeInput2x2(exec)
         val bn = BatchNormalization<FP32, Float>(
             numFeatures = 2,

--- a/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/DefaultExecutionContextTest.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/DefaultExecutionContextTest.kt
@@ -4,7 +4,7 @@ import kotlin.test.Test
 import kotlin.test.Ignore
 import kotlin.test.assertTrue
 
-@Ignore
+@Ignore("GraphExecution DSL tests are parked until the API drift is resolved")
 class GraphExecutionDSLTest {
     @Test
     fun placeholder() {

--- a/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/MnistMplGraphvizTest.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/MnistMplGraphvizTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
  * val graph = model.toGraph()
  * graph.toGraphviz()
  */
-@Ignore
+@Ignore("Graphviz snippet is parked until the MnistMpl graph API drift is resolved")
 class MnistMplGraphvizTest {
 
 

--- a/skainet-compile/skainet-compile-dag/src/jvmTest/kotlin/sk/ainet/graph/TapeToGraphUnitTests.kt
+++ b/skainet-compile/skainet-compile-dag/src/jvmTest/kotlin/sk/ainet/graph/TapeToGraphUnitTests.kt
@@ -4,7 +4,7 @@ import kotlin.test.Test
 import kotlin.test.Ignore
 import kotlin.test.assertTrue
 
-@Ignore
+@Ignore("Placeholder suite parked until the JVM-specific execution helper is migrated")
 class TapeToGraphUnitTests {
     @Test
     fun placeholder() {

--- a/skainet-io/skainet-io-onnx/src/jvmTest/kotlin/sk/ainet/io/onnx/OnnxResourceReadTest.kt
+++ b/skainet-io/skainet-io-onnx/src/jvmTest/kotlin/sk/ainet/io/onnx/OnnxResourceReadTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.Ignore
 
 class OnnxResourceReadTest {
 
-    @Ignore
+    @Ignore("Requires run14.onnx test fixture, which is not checked into the repository")
     @Test
     fun `read run14 onnx from resources and build graph view`() {
         val inputStream: InputStream = requireNotNull(javaClass.getResourceAsStream("/run14.onnx")) {
@@ -38,7 +38,7 @@ class OnnxResourceReadTest {
         )
     }
 
-    @Ignore
+    @Ignore("Requires run14.onnx test fixture, which is not checked into the repository")
     @Test
     fun `run14 onnx ops are covered by importer mapping`() {
         val bytes = loadResourceBytes("run14.onnx")


### PR DESCRIPTION
## Summary
- Re-enable two BatchNormalization tests by using explicit TRAIN/EVAL execution contexts.
- Add concrete reasons to ignored ONNX fixture and graph API drift tests.
- Leave download-heavy CIFAR integration skips untouched because they already document manual execution cost.

## Verification
- ./gradlew :skainet-backends:skainet-backend-cpu:jvmTest --no-daemon
- ./gradlew :skainet-compile:skainet-compile-dag:jvmTest --no-daemon
- ./gradlew :skainet-io:skainet-io-onnx:jvmTest --no-daemon