### PR TITLE
Implement CPU tensor convert op

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
@@ -9,14 +9,20 @@ import sk.ainet.lang.ops.Backend
 import sk.ainet.lang.ops.TensorOp
 import sk.ainet.lang.ops.InProgress
 import sk.ainet.lang.tensor.data.FloatArrayTensorData
+import sk.ainet.lang.tensor.data.IntArrayTensorData
+import sk.ainet.lang.tensor.data.TensorData
 import sk.ainet.lang.tensor.data.TensorDataFactory
 import sk.ainet.lang.tensor.ops.UpsampleMode
+import sk.ainet.lang.types.FP16
 import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Int32
+import sk.ainet.lang.types.Int8
 import kotlin.math.ln
 import kotlin.math.log10 as kmLog10
 import kotlin.math.log2 as kmLog2
 import kotlin.math.pow
 import kotlin.math.sqrt
+import kotlin.reflect.KClass
 
 @Backend(id = "cpu", displayName = "CPU")
 @InProgress("cpu", owner = "team:cpu", issue = "task-ops.md#defaultcpuops")
@@ -42,6 +48,56 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
         dtype: kotlin.reflect.KClass<T>,
         vararg inputs: Tensor<T, V>
     ): Tensor<T, V> = CpuTensor(data, this, dtype, gradStateFrom(*inputs))
+
+    private fun rowMajorStrides(shape: Shape): IntArray {
+        val strides = IntArray(shape.rank)
+        var stride = 1
+        for (i in shape.rank - 1 downTo 0) {
+            strides[i] = stride
+            stride *= shape[i]
+        }
+        return strides
+    }
+
+    private fun flatIndexToIndices(flatIndex: Int, strides: IntArray): IntArray {
+        val indices = IntArray(strides.size)
+        var remaining = flatIndex
+        for (i in strides.indices) {
+            indices[i] = remaining / strides[i]
+            remaining %= strides[i]
+        }
+        return indices
+    }
+
+    private fun <T : DType, V> copyTensorValuesAsFloatArray(tensor: Tensor<T, V>): FloatArray {
+        val data = tensor.data
+        return when (data) {
+            is FloatArrayTensorData<*> -> data.buffer.copyOf()
+            is IntArrayTensorData<*> -> FloatArray(data.buffer.size) { data.buffer[it].toFloat() }
+            else -> {
+                val strides = rowMajorStrides(tensor.shape)
+                FloatArray(tensor.shape.volume) { flatIndex ->
+                    val indices = flatIndexToIndices(flatIndex, strides)
+                    (data.get(*indices) as Number).toFloat()
+                }
+            }
+        }
+    }
+
+    private fun <T : DType, V> copyTensorValuesAsIntArray(tensor: Tensor<T, V>): IntArray {
+        val data = tensor.data
+        return when (data) {
+            is IntArrayTensorData<*> -> data.buffer.copyOf()
+            is FloatArrayTensorData<*> -> IntArray(data.buffer.size) { data.buffer[it].toInt() }
+            else -> {
+                val strides = rowMajorStrides(tensor.shape)
+                IntArray(tensor.shape.volume) { flatIndex ->
+                    val indices = flatIndexToIndices(flatIndex, strides)
+                    (data.get(*indices) as Number).toInt()
+                }
+            }
+        }
+    }
 
     protected fun broadcastShapes(a: Shape, b: Shape): Shape {
         val ad = a.dimensions
@@ -2427,7 +2483,30 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
         tensor: Tensor<TFrom, V>,
         targetType: TTo
     ): Tensor<TTo, V> {
-        TODO("Not yet implemented")
+        @Suppress("UNCHECKED_CAST")
+        val targetClass = targetType::class as KClass<TTo>
+        if (tensor.dtype == targetClass) {
+            @Suppress("UNCHECKED_CAST")
+            return tensor as Tensor<TTo, V>
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val outData = when (targetClass) {
+            FP32::class, FP16::class -> dataFactory.fromFloatArray<TTo, Float>(
+                tensor.shape,
+                targetClass,
+                copyTensorValuesAsFloatArray(tensor)
+            ) as TensorData<TTo, V>
+            Int32::class, Int8::class -> dataFactory.fromIntArray<TTo, Int>(
+                tensor.shape,
+                targetClass,
+                copyTensorValuesAsIntArray(tensor)
+            ) as TensorData<TTo, V>
+            else -> throw IllegalArgumentException(
+                "convert supports FP32, FP16, Int32, and Int8 targets, got ${targetType.name}"
+            )
+        }
+        return CpuTensor(outData, this, targetClass, GradState(requiresGrad = tensor.requiresGrad))
     }
 
     override fun <T : DType, V> gather(input: Tensor<T, V>, indices: Tensor<DType, *>, dim: Int): Tensor<T, V> {

--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOpsConvertTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOpsConvertTest.kt
@@ -1,0 +1,99 @@
+package sk.ainet.exec.tensor.ops
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import sk.ainet.lang.tensor.GradState
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.DenseTensorDataFactory
+import sk.ainet.lang.tensor.data.FloatArrayTensorData
+import sk.ainet.lang.tensor.data.IntArrayTensorData
+import sk.ainet.lang.types.FP16
+import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Int16
+import sk.ainet.lang.types.Int32
+
+class DefaultCpuOpsConvertTest {
+    private val dataFactory = DenseTensorDataFactory()
+    private val ops = DefaultCpuOps(dataFactory)
+
+    private fun fp32Tensor(
+        shape: Shape,
+        values: FloatArray,
+        requiresGrad: Boolean = false
+    ): VoidOpsTensor<FP32, Float> {
+        val data = dataFactory.fromFloatArray<FP32, Float>(shape, FP32::class, values)
+        return VoidOpsTensor(data, FP32::class, GradState(requiresGrad = requiresGrad))
+    }
+
+    private fun int32Tensor(shape: Shape, values: IntArray): VoidOpsTensor<Int32, Int> {
+        val data = dataFactory.fromIntArray<Int32, Int>(shape, Int32::class, values)
+        return VoidOpsTensor(data, Int32::class)
+    }
+
+    @Test
+    fun convertFp32ToFp16PreservesShapeValuesAndGradRequirement() {
+        val input = fp32Tensor(
+            Shape(2, 2),
+            floatArrayOf(1.25f, -2.5f, 3.75f, 4.5f),
+            requiresGrad = true
+        )
+
+        val result = ops.convert(input, FP16)
+
+        assertEquals(Shape(2, 2), result.shape)
+        assertEquals(FP16::class, result.dtype)
+        assertTrue(result.requiresGrad)
+        assertContentEquals(
+            floatArrayOf(1.25f, -2.5f, 3.75f, 4.5f),
+            (result.data as FloatArrayTensorData<*>).buffer
+        )
+    }
+
+    @Test
+    fun convertInt32ToFp32CastsValuesToFloat() {
+        val input = int32Tensor(Shape(2, 2), intArrayOf(1, -2, 3, 4))
+
+        val result = ops.convert(input, FP32)
+
+        assertEquals(Shape(2, 2), result.shape)
+        assertEquals(FP32::class, result.dtype)
+        assertContentEquals(
+            floatArrayOf(1f, -2f, 3f, 4f),
+            (result.data as FloatArrayTensorData<*>).buffer
+        )
+    }
+
+    @Test
+    fun convertFp32ToInt32CastsValuesToInt() {
+        val input = fp32Tensor(Shape(4), floatArrayOf(1.9f, -2.1f, 3.0f, 4.8f))
+
+        val result = ops.convert(input, Int32)
+
+        assertEquals(Shape(4), result.shape)
+        assertEquals(Int32::class, result.dtype)
+        assertContentEquals(intArrayOf(1, -2, 3, 4), (result.data as IntArrayTensorData<*>).buffer)
+    }
+
+    @Test
+    fun convertToSameDtypeReturnsInputTensor() {
+        val input = fp32Tensor(Shape(2), floatArrayOf(1f, 2f))
+
+        val result = ops.convert(input, FP32)
+
+        assertSame(input, result)
+    }
+
+    @Test
+    fun convertRejectsUnsupportedTargetDtype() {
+        val input = fp32Tensor(Shape(2), floatArrayOf(1f, 2f))
+
+        assertFailsWith<IllegalArgumentException> {
+            ops.convert(input, Int16)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DefaultCpuOps.convert` for dense FP32, FP16, Int32, and Int8 targets
- preserve shape and gradient participation when converting
- add CPU backend coverage for same-dtype, float-to-float, int-to-float, float-to-int, and unsupported targets

## Validation
- `./gradlew :skainet-backends:skainet-backend-cpu:jvmTest --no-daemon`

Fixes #635