### PR TITLE
Fix Kotlin/Native ignored test annotations

### DIFF
--- a/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/DefaultExecutionContextTest.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/DefaultExecutionContextTest.kt
@@ -4,7 +4,8 @@ import kotlin.test.Test
 import kotlin.test.Ignore
 import kotlin.test.assertTrue
 
-@Ignore("GraphExecution DSL tests are parked until the API drift is resolved")
+// Ignored while the GraphExecution DSL tests are parked until the API drift is resolved.
+@Ignore
 class GraphExecutionDSLTest {
     @Test
     fun placeholder() {

--- a/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/MnistMplGraphvizTest.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/MnistMplGraphvizTest.kt
@@ -19,7 +19,8 @@ import kotlin.test.assertTrue
  * val graph = model.toGraph()
  * graph.toGraphviz()
  */
-@Ignore("Graphviz snippet is parked until the MnistMpl graph API drift is resolved")
+// Ignored while the Graphviz snippet is parked until the MnistMpl graph API drift is resolved.
+@Ignore
 class MnistMplGraphvizTest {
 
 


### PR DESCRIPTION
Closes #637. Summary: replaces commonTest @Ignore message arguments with no-arg @Ignore and keeps the reasons as comments, so Kotlin/Native can compile the shared test classes. Validation: ./gradlew :skainet-compile:skainet-compile-dag:compileTestKotlinIosArm64 --no-daemon --stacktrace; ./gradlew :skainet-compile:skainet-compile-dag:jvmTest --no-daemon --stacktrace.