### PR TITLE
Use current recording stop API internally

### DIFF
--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultGraphExecutionContext.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultGraphExecutionContext.kt
@@ -126,7 +126,7 @@ public class DefaultGraphExecutionContext(
         startRecording()
         return try {
             val result = this.block()
-            stopRecordingAndGet() to result
+            stopRecording() to result
         } finally {
             if (isRecording) stopRecording()
         }

--- a/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/EagerVsRecordingOnesAddTest.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonTest/kotlin/sk/ainet/compile/graph/EagerVsRecordingOnesAddTest.kt
@@ -46,10 +46,10 @@ class EagerVsRecordingOnesAddTest {
         val y = ctx.ops.add(a, b)
         assertEquals(Shape.Companion(5), y.shape)
 
-        val tape = ctx.stopRecordingAndGet()
+        val tape = ctx.stopRecording()
         assertNotNull(tape, "Recording should return a non-null tape")
 
         // Verify that at least one operation was recorded on the tape
-        kotlin.test.assertTrue(tape!!.operations.isNotEmpty(), "Tape should contain recorded operations in recording mode")
+        kotlin.test.assertTrue(tape.operations.isNotEmpty(), "Tape should contain recorded operations in recording mode")
     }
 }


### PR DESCRIPTION
Closes #639. Summary: replaces internal stopRecordingAndGet() usage with stopRecording(), which already returns the tape; removes an unnecessary non-null assertion in the eager-vs-recording test. Validation: ./gradlew :skainet-compile:skainet-compile-dag:jvmTest --no-daemon --stacktrace; ./gradlew :skainet-compile:skainet-compile-dag:compileTestKotlinIosArm64 --no-daemon --stacktrace.