### PR TITLE
Avoid duplicate feature PR workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Feature Branch Libraries build
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/verify-poms.yml
+++ b/.github/workflows/verify-poms.yml
@@ -1,6 +1,10 @@
 name: Verify published POMs
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #644. Summary: scopes build.yml and verify-poms.yml push triggers to main/develop while retaining pull_request validation for PRs into main/develop. This keeps post-merge validation but avoids launching duplicate expensive jobs for feature PR commits. Validation: git diff --check; ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/build.yml .github/workflows/verify-poms.yml.