### PR TITLE
Release 0.26.0 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,42 @@
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-05-30
+
 ### Added
 
 - **Q4_0 promoted to a first-class quantized format.** The older GGML 4-bit format (18 bytes / 32 elements) was previously a JVM/MemSegment-only, GGUF-only side-path; it is now wired across the full provider stack mirroring Q8_0 / Q4_K:
   - commonMain heap `Q4_0TensorData` / `Q4_0BlockTensorData` (+ `TensorEncoding.Q4_0`) so any loader can produce it and non-JVM targets can use it.
   - `Q4_0MatmulKernel` SPI + `KernelProvider.matmulQ4_0()`, with **scalar** (commonMain), **Panama Vector** (JVM SIMD), and **native FFM** (`skainet_q4_0_matmul`) implementations selected via `KernelRegistry.bestAvailable()` (native → Panama → scalar). `DefaultCpuOpsJvm.chooseQuantizedMatmul` gains an `is Q4_0TensorData` branch.
   - `Q4_0Quantizer` (FP32 → Q4_0) — the produce side was missing, so dense weights from any source (SafeTensors / JSON / in-memory) can now be quantized to canonical ggml Q4_0 without going through GGUF.
-- All Q4_0 paths use the canonical ggml **split** nibble layout (low nibbles → elements 0..15, high → 16..31, `(code - 8) * d`).
+  - All Q4_0 paths use the canonical ggml **split** nibble layout (low nibbles → elements 0..15, high → 16..31, `(code - 8) * d`). (PRs #648, #649, #650, #651)
+- **`tanh` as a first-class `TensorOps` activation primitive.** Promotes `tanh` from a default `NotImplementedError` stub to a fully wired `@Diff @ActivationDsl` primitive, eliminating the `2*sigmoid(2x)-1` polyfill that downstream consumers were forced to re-derive. Wires the standard six-layer pattern: `TensorOps` interface, `TanhOperation` class, `Tensor.tanh()` extension, CPU backend, recording decorator, and autograd backward (`1 - output^2`). A Karpathy micrograd `demo.ipynb` port lands as an end-to-end training test (moons dataset, `[2,16,16,1]` tanh-MLP, MSE + SGD, held-out accuracy) exercising the primitive through the full DSL + training stack. (Issue #630, PR #631)
+- **CPU tensor `convert` op.** Implements the dtype-conversion operation on the CPU backend. (PR #636)
+
+### Changed
+
+- **Recording decorator uses the current recording-stop API internally.** Aligns the internal call site with the current recording API surface. (PR #640)
 
 ### Fixed
 
-- **Q4_0 MemSegment matmul layout.** The pre-existing JVM MemSegment Q4_0 kernel (`JvmQuantizedVectorKernels.dotQ4_0BlockMemSeg`) and `Q4MemorySegmentTensorData` used an *interleaved* nibble layout that did not match real GGUF Q4_0 weights (a latent correctness bug; the path was unverified and had no in-repo callers). Reconciled to the canonical split layout so it now agrees with the heap type, the SPI kernels, and `DequantOps.dequantQ4_0FromBytes`.
+- **Q4_0 MemSegment matmul layout.** The pre-existing JVM MemSegment Q4_0 kernel (`JvmQuantizedVectorKernels.dotQ4_0BlockMemSeg`) and `Q4MemorySegmentTensorData` used an *interleaved* nibble layout that did not match real GGUF Q4_0 weights (a latent correctness bug; the path was unverified and had no in-repo callers). Reconciled to the canonical split layout so it now agrees with the heap type, the SPI kernels, and `DequantOps.dequantQ4_0FromBytes`. (PR #649)
+
+### Tests
+
+- **Ignored common tests made portable across KMP targets** via the shared `@Ignore` annotation, so the same skip applies consistently on every platform. (PR #638)
+- **Ignored-test clarity and BatchNorm coverage.** Clarifies why each ignored test is ignored and enables previously-disabled BatchNorm coverage. (PR #634)
+
+### Build
+
+- **Gradle build-hygiene warnings fixed.** (PR #633)
+
+### CI
+
+- **Feature-PR workflow trigger scope narrowed** to avoid duplicate workflow runs on feature PRs. (PR #645)
+
+### API
+
+- **Resynced binary-compatibility-validator baselines** to current source (the committed `.api` dumps had drifted). (PR #647)
 
 ## [0.25.0] - 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.26.0"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -193,16 +193,16 @@ deployment, the StableHLO path for native and edge targets.
 
 ---
 
-## What's New in 0.25.0
+## What's New in 0.26.0
 
-- **BF16 and Q8_0 matmul kernels across the provider stack.** End-to-end dtype paths for both formats: new `Bf16TensorData` / `Bf16DenseTensorData`, `Bf16MatmulKernel` and `Q8_0MatmulKernel` with scalar / Panama / native implementations, opt-in SafeTensors BF16-preserving loader policy, and `DefaultCpuOpsJvm.chooseQuantizedMatmul` routed through the `KernelRegistry` SPI so the best-available kernel wins automatically. (PRs #605, #606, #608, #610, #612, #614)
-- **Autograd completeness.** Backward formulas filled in for `pow` / `log` / `log2` / `log10`, the conv / pool / upsample / split family, with an end-to-end CNN training-step test pinning the contract. (PR #618)
-- **Hybrid adaptive DSL with optional dtype constraints (RFC implementation).** `DTypeConstraintResolutionPass` plus a `dtypePolicy(...)` extension on `DagBuilder`, an opt-in `StreamingGgufParametersLoader.withPolicy(...)`, and a typed `ResolvedComputeGraph` view that flows into `toStableHlo(...)`. (PR #616)
-- **DARC validation flag for operator documentation.** New `@DarcValidated` annotation read by the KSP processor and surfaced as a `✅ / ⚠ / ✖` badge on every generated operator page plus a `Validated` column on the coverage matrix. The Antora `Contributing` section gains a dedicated DARC workflow page. (Issue #627, PR #628)
-- **SentencePiece tokenizer: special-token-aware splitting.** New `SpecialTokenSplitter` decorator covering the HF JSON gaps that previously misrouted control tokens. (PR #595)
+- **Q4_0 is now a first-class quantized format.** The older GGML 4-bit format joins Q8_0 / Q4_K across the full provider stack: a heap `Q4_0TensorData` any loader can produce, a `Q4_0MatmulKernel` SPI with scalar / Panama-Vector / native-FFM implementations auto-selected by `KernelRegistry`, and a `Q4_0Quantizer` to pack dense FP32 weights into canonical ggml Q4_0 without going through GGUF. (PRs #648–#651)
+- **`tanh` is now a first-class activation primitive.** Promoted from a `NotImplementedError` stub to a fully wired `@Diff @ActivationDsl` op — `TensorOps` interface, `Tensor.tanh()` extension, CPU backend, recording decorator, and autograd backward (`1 - output^2`) — so downstream consumers no longer re-derive the `2*sigmoid(2x)-1` polyfill. Pinned end-to-end by a micrograd tanh-MLP training test on the moons dataset. (Issue #630, PR #631)
+- **CPU tensor `convert` op.** Dtype conversion now has a real CPU backend implementation. (PR #636)
+- Plus test, build, and CI hygiene: portable KMP `@Ignore` for common tests, restored BatchNorm coverage, Gradle build-warning cleanup, and narrower feature-PR CI triggers. (PRs #633, #634, #638, #640, #645)
 
 ### Recent releases
 
+- **0.25.0** — BF16 and Q8_0 matmul kernels end-to-end across the provider stack, autograd completeness for `pow`/`log` and the conv/pool/upsample/split family, the hybrid adaptive dtype-constraint DSL, the `@DarcValidated` operator-doc flag, and the SentencePiece special-token splitter. (PRs #595, #605–#628)
 - **0.23.0** — Real-model GGUFs no longer OOM at network construction (lazy `TensorDataFactory.placeholder(...)`); Kotlin/Native can finally load GGUFs over 2 GiB via the new POSIX-`pread`-backed `PosixPreadRandomAccessSource`. (Issues #587, #589; PRs #588, #591)
 - **0.22.2** — `sk.ainet:skainet-bom` now resolves from Maven Central (earlier versions shipped at the wrong coordinates). (Issue #584)
 - **0.22.1** — `StreamingShardedSafeTensorsReader.loadTensorStorageMapped` for zero-copy reads of multi-shard tensors above the 2 GB JVM `ByteArray` limit. (PR #582)

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.26.0"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.26.0"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/java-model-training.adoc
+++ b/docs/modules/ROOT/pages/how-to/java-model-training.adoc
@@ -23,7 +23,7 @@ This guide covers building neural networks, defining loss functions and optimize
         <dependency>
             <groupId>sk.ainet</groupId>
             <artifactId>skainet-bom</artifactId>
-            <version>0.25.0</version>
+            <version>0.26.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/modules/ROOT/pages/reference/architecture.adoc
+++ b/docs/modules/ROOT/pages/reference/architecture.adoc
@@ -135,6 +135,27 @@ designed but not yet built. For *how* the kernels are implemented, see
 xref:explanation/perf/simd-kernels.adoc[] (FP32) and
 xref:explanation/perf/quantized-simd-kernels.adoc[] (quantized).
 
+[NOTE]
+.Native (FFM) provider — design summary
+====
+The planned `NativeKernelProvider` registers at priority 100 so that on
+JDK 21+ it wins `KernelRegistry.bestAvailable()` over the Panama Vector
+provider whenever the native library loads, and transparently falls back
+to Panama (priority 50) or scalar (priority 0) when it doesn't — no code
+change above the registry. The first kernel target is a native Q4_K
+matmul taking `MemorySegment` input and packed weights (canonical ggml
+layout), numerically equivalent to `PanamaVectorQ4KMatmulKernel` within
+`1e-4`, clearing the M5 metric of `≥2.5×` over the scalar dequant
+baseline. It uses FFM, not JNI (near-zero call overhead, no global lock),
+ships in a new `skainet-backend-native-cpu` module, and the first PR
+covers a single host architecture (local build only) — cross-arch builds
+and Maven classifier JARs are deliberately out of scope. The kernel SPI
+this builds on shipped across the 0.21.0 release (PRs #554–#565); the
+in-process native-FFM groundwork landed in 0.22.0 (PR #571). The full
+design draft was kept out of the published docs as it read as a PRD; this
+summary supersedes it.
+====
+
 == 6. Runtime view — eager execution
 
 The eager pipeline for a single op:

--- a/docs/modules/ROOT/pages/reference/operators/generated/index.adoc
+++ b/docs/modules/ROOT/pages/reference/operators/generated/index.adoc
@@ -1,6 +1,6 @@
 = AI-NET Operators Reference
 
-Generated from version `0.25.0` on 2026-05-25
+Generated from version `0.26.0` on 2026-05-30
 
 == Operators by Modality
 

--- a/docs/modules/ROOT/pages/reference/operators/generated/tensorops.adoc
+++ b/docs/modules/ROOT/pages/reference/operators/generated/tensorops.adoc
@@ -691,6 +691,25 @@ fun sigmoid(tensor:Tensor): Tensor
 
 `Tensor`
 
+== tanh
+
+[.darc-none]#✖ Generated facts only (no human prose)#
+
+=== Signature
+
+[source,kotlin]
+----
+fun tanh(tensor:Tensor): Tensor
+----
+
+=== Parameters
+
+* `tensor: Tensor`
+
+=== Return Type
+
+`Tensor`
+
 == silu
 
 [.darc-none]#✖ Generated facts only (no human prose)#
@@ -1219,25 +1238,6 @@ fun sin(tensor:Tensor): Tensor
 [source,kotlin]
 ----
 fun cos(tensor:Tensor): Tensor
-----
-
-=== Parameters
-
-* `tensor: Tensor`
-
-=== Return Type
-
-`Tensor`
-
-== tanh
-
-[.darc-none]#✖ Generated facts only (no human prose)#
-
-=== Signature
-
-[source,kotlin]
-----
-fun tanh(tensor:Tensor): Tensor
 ----
 
 === Parameters

--- a/docs/modules/ROOT/pages/reference/ops-status-matrix.adoc
+++ b/docs/modules/ROOT/pages/reference/ops-status-matrix.adoc
@@ -1,7 +1,7 @@
 = Operator Coverage Matrix
 :description: Cross-backend status for every operator function in SKaiNET.
 
-Generated from `operators.json` version `0.25.0` on 2026-05-25.
+Generated from `operators.json` version `0.26.0` on 2026-05-30.
 
 Rows are `Operator.function` pairs. The `Validated` column shows whether the function's documentation has been DARC-validated by a reviewer (see xref:contributing/darc-workflow.adoc[DARC workflow]). Remaining columns are backends that appear in any function's `statusByBackend` map — a missing entry means the backend makes no claim about the function (treat it as "unknown", not "not supported").
 
@@ -41,6 +41,7 @@ Rows are `Operator.function` pairs. The `Validated` column shows whether the fun
 | `TensorOps.softmax` | ✖ | — | — | — 
 | `TensorOps.logSoftmax` | ✖ | — | — | — 
 | `TensorOps.sigmoid` | ✖ | — | — | — 
+| `TensorOps.tanh` | ✖ | — | — | — 
 | `TensorOps.silu` | ✖ | — | — | — 
 | `TensorOps.gelu` | ✖ | — | — | — 
 | `TensorOps.sum` | ✖ | — | — | — 
@@ -68,7 +69,6 @@ Rows are `Operator.function` pairs. The `Validated` column shows whether the fun
 | `TensorOps.expm1` | ✖ | — | — | — 
 | `TensorOps.sin` | ✖ | — | — | — 
 | `TensorOps.cos` | ✖ | — | — | — 
-| `TensorOps.tanh` | ✖ | — | — | — 
 | `TensorOps.scaledDotProductAttention` | ✖ | — | — | — 
 | `Similarity.cosineDistance` | ✖ | ✅ | ✅ | ✅ 
 

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -46,7 +46,7 @@ The `skainet-bom` manages all SKaiNET module versions so you never have to keep 
 ----
 <project>
     <properties>
-        <skainet.version>0.25.0</skainet.version>
+        <skainet.version>0.26.0</skainet.version>
     </properties>
 
     <dependencyManagement>
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.25.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.26.0"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.25.0
+VERSION_NAME=0.26.0
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/


### PR DESCRIPTION
Bumps VERSION_NAME 0.25.0 → 0.26.0 with the matching CHANGELOG entry, README "What's New in 0.26.0" section, and sample-dependency version bumps across the how-to and tutorial pages.

The 0.26.0 release rolls up the first-class tanh activation primitive (#630/#631), the CPU tensor convert op (#636), and test/build/CI hygiene (#633, #634, #638, #640, #645).

Operator docs regenerated so the version stamp reads 0.26.0. The native-FFM plan draft was removed from the repo root; a short design summary now lives in reference/architecture.adoc.