### PR TITLE
test(lang-models): raise browser Mocha timeout to 60s for the micrograd demo

### DIFF
--- a/skainet-lang/skainet-lang-models/build.gradle.kts
+++ b/skainet-lang/skainet-lang-models/build.gradle.kts
@@ -34,7 +34,10 @@ kotlin {
         browser {
             testTask {
                 useMocha {
-                    timeout = "10s"
+                    // Generous timeout: the micrograd moons demo trains a 200-epoch MLP,
+                    // which is slow in a browser engine (especially wasmJs under CI/parallel
+                    // load) and can exceed Mocha's 2s default before the computation finishes.
+                    timeout = "60s"
                 }
             }
         }
@@ -45,7 +48,10 @@ kotlin {
         browser {
             testTask {
                 useMocha {
-                    timeout = "10s"
+                    // Generous timeout: the micrograd moons demo trains a 200-epoch MLP,
+                    // which is slow in a browser engine (especially wasmJs under CI/parallel
+                    // load) and can exceed Mocha's 2s default before the computation finishes.
+                    timeout = "60s"
                 }
             }
         }


### PR DESCRIPTION
`MicrogradMoonsDemoTest.micrograd_moons_demo_trains_and_classifies` flaked on the **wasmJs-browser** target under `allTests` (parallel load) with Mocha's default `Timeout of 2000ms exceeded`. The test isn't broken — its system-out shows it trained all 200 epochs (`loss=0.082`) and hit `accuracy 0.85 (17/20)`, identical to jvm / native / jsBrowser / wasmWasi. It just ran slower than the harness allowed under contention.

The module already set `useMocha { timeout = "10s" }` (since 0.19.0), but that wasn't always enough — this raises it to **60s** for both `js` and `wasmJs` browser test tasks.

Surfaced now because browser tests only run when `CHROME_BIN` is set; without it they skip/fail-to-launch, so this slow test was never actually executed in the browser before.

Verified: `:skainet-lang-models:wasmJsBrowserTest` + `jsBrowserTest` green (1/1 each) with the bump.