### PR TITLE
test(ci): harden Karma browser tests against launch flakiness under allTests

### DIFF
--- a/skainet-backends/skainet-backend-api/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-backends/skainet-backend-api/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-backends/skainet-backend-cpu/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-backends/skainet-backend-cpu/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-compile/skainet-compile-core/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-compile/skainet-compile-core/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-compile/skainet-compile-dag/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-compile/skainet-compile-dag/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-compile/skainet-compile-hlo/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-compile/skainet-compile-hlo/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-compile/skainet-compile-json/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-compile/skainet-compile-json/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-compile/skainet-compile-opt/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-compile/skainet-compile-opt/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-data/skainet-data-api/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-data/skainet-data-api/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-data/skainet-data-media/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-data/skainet-data-media/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-data/skainet-data-simple/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-data/skainet-data-simple/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-data/skainet-data-transform/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-data/skainet-data-transform/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-io/skainet-io-core/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-io/skainet-io-core/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-io/skainet-io-gguf/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-io/skainet-io-gguf/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-io/skainet-io-image/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-io/skainet-io-image/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-io/skainet-io-iree-params/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-io/skainet-io-iree-params/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-io/skainet-io-onnx/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-io/skainet-io-onnx/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-io/skainet-io-safetensors/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-io/skainet-io-safetensors/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-lang/skainet-lang-core/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-lang/skainet-lang-core/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-lang/skainet-lang-dag/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-lang/skainet-lang-dag/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-lang/skainet-lang-ksp-annotations/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-lang/skainet-lang-ksp-annotations/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-lang/skainet-lang-models/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-lang/skainet-lang-models/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-models/skainet-model-yolo/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-models/skainet-model-yolo/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});

--- a/skainet-pipeline/karma.config.d/skainet-browser-resilience.js
+++ b/skainet-pipeline/karma.config.d/skainet-browser-resilience.js
@@ -1,0 +1,20 @@
+// SKaiNET: harden Karma browser tests against launch/capture flakiness.
+//
+// During `./gradlew allTests` many wasmJs/js browser test tasks start a
+// ChromeHeadless instance at the same time. On a loaded machine the browser
+// can take longer than Karma's defaults to capture or to emit progress, so
+// Karma disconnects it ("Disconnected, no message in 30000 ms" /
+// "ChromeHeadless was not killed"), ends up discovering zero tests and the
+// build fails on Gradle's `failOnNoDiscoveredTests` check — even though the
+// tests pass fine when the task runs in isolation.
+//
+// Generous capture/disconnect/no-activity timeouts plus a few disconnect
+// retries make the run wait patiently for a starved browser instead of
+// giving up. Kotlin's Gradle plugin merges every *.js here into karma.conf.js.
+config.set({
+    captureTimeout: 120000,
+    browserDisconnectTimeout: 30000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 120000,
+    pingTimeout: 120000,
+});


### PR DESCRIPTION
## Problem

`allTests` (run on every CI PR/push, and locally) intermittently fails a browser test with:

```
Errors occurred during launch of browser for testing. - ChromeHeadless
> ...the test task did not discover any tests to execute.
```

This surfaced as `:skainet-data:skainet-data-api:wasmJsBrowserTest` failing during a full `allTests` run, while the **same task passes every time in isolation**.

## Root cause

Not a test bug — a **flaky browser launch under concurrency**. `allTests` starts ~20 `wasmJs`/`js` `*BrowserTest` tasks at once, each spinning up its own ChromeHeadless. On a loaded machine a browser exceeds Karma's default capture/activity timeouts (`Disconnected, no message in 30000 ms` / `ChromeHeadless was not killed`), Karma drops it, reports **zero** discovered tests, and Gradle fails the build on its `failOnNoDiscoveredTests` check. CI is the worst case for this: `ubuntu-latest`, `-Xmx4g`, and PRs run `clean assemble allTests` so every browser test re-executes from scratch.

## Fix

Add a `karma.config.d/skainet-browser-resilience.js` to every browser-test module (the Kotlin Gradle plugin merges these into the generated `karma.conf.js`). It raises the capture/disconnect/no-activity timeouts and adds disconnect tolerance, so a CPU-starved browser is waited on instead of abandoned:

```js
config.set({
    captureTimeout: 120000,
    browserDisconnectTimeout: 30000,
    browserDisconnectTolerance: 3,
    browserNoActivityTimeout: 120000,
    pingTimeout: 120000,
});
```

These knobs are **not exposed by Kotlin's `useKarma {}` Gradle DSL**, so a `karma.config.d/*.js` file is the supported way to set them. Applied across **all** browser modules (23 files) so the flakiness can't simply hop to a different module on the next run.

## Verification

`./gradlew allTests --rerun-tasks` — forced every test task (incl. all browser tasks) to actually re-execute concurrently rather than hit the cache. **BUILD SUCCESSFUL in 2m41s**, no failures, no "did not discover any tests", no browser launch errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)