### PR TITLE
release: prepare 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-06-09
+
+### Added
+
+- **Minerva secure-MCU export module.** A new export pipeline that takes a SKaiNET model all the way to a secure microcontroller project bundle, built up in phases:
+  - **Shared graph-export contracts.** A backend-agnostic export contract layer (`feat(export)`), with a StableHLO graph-export adapter that exposes the existing HLO path through those contracts. (#697, #698, #702)
+  - **Module API scaffold.** The Minerva export module's public API surface. (#700)
+  - **Phase-one graph-compatibility validation.** Validates that a graph is exportable before any lowering work begins. (#701)
+  - **IR lowering + npz compiler input.** Compatible graphs lower to Minerva IR (#704) and emit an `.npz` compiler input (#706).
+  - **Compiler packager + host verification.** A packager flow that drives libminerva packaging, plus a host-verification flow and runtime-verification profile that prove the exported bundle on the host before it ships. (#706, #712, #714, #716, #717, #721, #725)
+  - **Manifest fingerprinting.** Generated manifest artifacts are fingerprinted so bundle contents are tamper-evident. (#724)
+  - **Runnable sample + examples + docs.** A runnable sample task and runner, secure MCU export examples, an ONNX export workflow, getting-started / explanation pages, and model-source guidance. (#707, #712, #719, #725)
+- **Packed-quant matmul kernels with Kotlin/Native parity.** Q5_0, Q5_1, Q4_K, and Q6_K gain matmul support across the provider stack:
+  - **commonMain scalar kernels + SPI** for Q5_1/Q5_0/Q4_K/Q6_K, giving Kotlin/Native parity with the JVM path. (#710, #711)
+  - **Packed-quant matmul dispatch in `DefaultCpuOpsBase`** so the packed-quant path is selected on Native, not just JVM. (#709, #711)
+  - **Panama Vector (JVM SIMD) kernels** for Q5_1/Q5_0 (#709) and Q6_K, with Q6_K routed via the `KernelRegistry`. (#715, #720)
+  - **Packed Q5_1/Q5_0 matmul kernels + lazy transpose** on the CPU backend. (#709)
+
+### Changed
+
+- **Kernel × platform support matrix is auto-generated and CI-gated.** The kernel/platform support matrix is now rendered through the build-logic → Antora pipeline (the same pipeline as the ops docs) from a CI-gated source, so it can't drift from the code. (#716, #724)
+
+### Docs
+
+- Refreshed the architecture kernel-provider section (native FFM ships; link matrix). (#726)
+- Eager-execution backends & kernels mindmap, refreshed after Panama Q6_K. (#720, #723)
+
+### Tests
+
+- Hardened CI browser tests against launch flakiness under `allTests` (Karma) and raised the Mocha timeout 10s → 60s for the micrograd demo. (#703, #705)
+
+### Dependencies
+
+- Bumped `io.github.optimumcode:json-schema-validator` to 0.5.5. (#713)
+
 ## [0.28.1] - 2026-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.28.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -227,14 +227,15 @@ Runnable examples:
 
 ---
 
-## What's New in 0.28.1
+## What's New in 0.29.0
 
-- **The Kotlin DSL → StableHLO → IREE path is green end-to-end for the whole conformance suite — 7/7 models and 27/27 ops `iree-compile` to a `vmfb`** (grayscale, tiny-mlp, whisper, mnist-cnn, yolo, leaf-embed, gemma3-260m). Shape-changing ops had been declaring a result/return type from operand-0 instead of their real output, so IREE rejected the modules. `inferDagOutputSpecs` now computes the correct output spec for `reshape`, `matmul`, `concatenate` (#673), and `conv1d`, `gather`, `maxpool2d`/`avgpool2d`, `flatten` (#675), and the corrected shapes flow to both the op result type and the `func.func` return.
-- **`reduce_window` (pooling) is emitted in IREE's generic region form** instead of the pretty `applies … over window` form IREE rejects; the `MlirValidator` now understands region block arguments. (#675, PR #676)
-- Verified end-to-end by publishing each candidate to mavenLocal and running the `skainet-iree-conformance` harness before release.
+- **Minerva secure-MCU export module.** A new end-to-end pipeline that lowers a SKaiNET model through shared graph-export contracts → Minerva IR → an `.npz` compiler input → a libminerva-packaged secure MCU project bundle, with host-side runtime verification and fingerprinted manifest artifacts. Ships with a runnable sample, secure-MCU export examples, an ONNX export workflow, and getting-started docs. (PRs #697–#726)
+- **Packed-quant matmul kernels with Kotlin/Native parity.** Q5_0, Q5_1, Q4_K, and Q6_K gain matmul across the full provider stack: commonMain scalar kernels + SPI (Native parity), packed-quant dispatch in `DefaultCpuOpsBase`, and Panama Vector (JVM SIMD) kernels for Q5_1/Q5_0 and Q6_K routed via the `KernelRegistry`. (PRs #709–#720)
+- **Auto-generated, CI-gated kernel × platform support matrix** rendered through the build-logic → Antora pipeline, so the docs can't drift from the code. (PRs #716, #724)
 
 ### Recent releases
 
+- **0.28.1** — Kotlin DSL → StableHLO → IREE is green end-to-end for the whole conformance suite (7/7 models, 27/27 ops compile to a `vmfb`): `inferDagOutputSpecs` now infers correct output shapes for shape-changing ops, and `reduce_window` (pooling) emits IREE's generic region form. (PRs #674, #676)
 - **0.28.0** — Four StableHLO export bugs fixed (reshape #666, concatenate #667, constants/reductions #663, `HloGenerator` tracing #668) plus non-JVM image runtime support (#671). (PRs #664, #670, #671)
 - **0.27.0** — A full gemma3 network lowers to StableHLO and compiles to an IREE `vmfb` (zero op gaps, verified by `GemmaTraceTest`): new `scaledDotProductAttention` (with causal + explicit additive mask), `permute`, `narrow`, and multi-output `split` converters, plus boxing-free `FloatArray` weight externalization for `.irpa` baking. (PRs #661 et al.)
 - **0.26.0** — Q4_0 promoted to a first-class quantized format across the provider stack, `tanh` as a first-class activation primitive, and a CPU tensor `convert` op, plus test/build/CI hygiene. (PRs #648–#651, #631, #636)

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.27.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.27.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/minerva-export.adoc
+++ b/docs/modules/ROOT/pages/how-to/minerva-export.adoc
@@ -38,7 +38,7 @@ For a published application, use the SKaiNET BOM and the Minerva artifact:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.28.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
     implementation("sk.ainet.core:skainet-compile-minerva")
 }
 ----

--- a/docs/modules/ROOT/pages/reference/kernel-support-matrix.adoc
+++ b/docs/modules/ROOT/pages/reference/kernel-support-matrix.adoc
@@ -1,7 +1,7 @@
 = Kernel × platform support matrix
 :description: Which compute-kernel provider serves each weight format on each KMP target.
 
-Generated from `kernel-support.json` (version `0.28.1`) by `KernelSupportMatrixTest` — registry introspection of the registered `KernelProvider` implementations. Do not edit by hand; run `./gradlew generateKernelMatrix` to refresh.
+Generated from `kernel-support.json` (version `0.29.0`) by `KernelSupportMatrixTest` — registry introspection of the registered `KernelProvider` implementations. Do not edit by hand; run `./gradlew generateKernelMatrix` to refresh.
 
 Each cell is the best (highest-priority) provider that serves `Float32 × format` `matmul` on that platform: *native-ffm* (100) → *panama-vector* (50) → *scalar* (0). An empty cell (`—`) means no provider carries a kernel there (the format is dequant-to-FP32 only).
 

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.27.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.28.1
+VERSION_NAME=0.29.0
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/


### PR DESCRIPTION
## Summary

Prepares the **0.29.0** release.

- **Version** — `VERSION_NAME` `0.28.1` → `0.29.0` in `gradle.properties`.
- **CHANGELOG** — new `[0.29.0] - 2026-06-09` section covering the work merged since the `0.28.1` tag (PRs #697–#726):
  - **Minerva secure-MCU export module** — end-to-end pipeline: shared graph-export contracts → Minerva IR → `.npz` compiler input → libminerva-packaged secure MCU bundle, with host-side runtime verification, fingerprinted manifests, a runnable sample, examples, ONNX workflow, and getting-started docs.
  - **Packed-quant matmul kernels** — Q5_0/Q5_1/Q4_K/Q6_K across the provider stack: commonMain scalar kernels + SPI (Kotlin/Native parity), packed-quant dispatch in `DefaultCpuOpsBase`, Panama Vector (JVM SIMD) for Q5_1/Q5_0 and Q6_K via the `KernelRegistry`.
  - Auto-generated, CI-gated kernel × platform support matrix; architecture & mindmap doc refreshes; CI browser-test hardening; `json-schema-validator` bump.
- **README** — bumped BOM coordinate, rewrote "What's New" for 0.29.0, demoted 0.28.1 into Recent releases.
- **Docs** — bumped `skainet-bom` coordinates to `0.29.0` (`io-readers`, `minerva-export`, `java-getting-started`); regenerated `kernel-support-matrix.adoc` via `./gradlew generateKernelMatrix`.

## Notes

- CHANGELOG/regen date is `2026-06-09`; adjust if tagged on a different day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)