### PR TITLE
release: prepare 0.29.1 (publish skainet-compile-minerva)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-06-09
+
+### Fixed
+
+- **`sk.ainet.core:skainet-compile-minerva` is now published to Maven Central.** The new Minerva export module (shipped in 0.29.0) applies the publish plugin and was auto-included in the BOM, but it lacked the per-module `gradle.properties` (`POM_ARTIFACT_ID` / `POM_NAME`) that every other published module carries, so its publication had no POM name and never made it to Maven Central. Added the module's `gradle.properties`; the artifact now publishes alongside the rest of the engine.
+
 ## [0.29.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.1"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -227,14 +227,13 @@ Runnable examples:
 
 ---
 
-## What's New in 0.29.0
+## What's New in 0.29.1
 
-- **Minerva secure-MCU export module.** A new end-to-end pipeline that lowers a SKaiNET model through shared graph-export contracts → Minerva IR → an `.npz` compiler input → a libminerva-packaged secure MCU project bundle, with host-side runtime verification and fingerprinted manifest artifacts. Ships with a runnable sample, secure-MCU export examples, an ONNX export workflow, and getting-started docs. (PRs #697–#726)
-- **Packed-quant matmul kernels with Kotlin/Native parity.** Q5_0, Q5_1, Q4_K, and Q6_K gain matmul across the full provider stack: commonMain scalar kernels + SPI (Native parity), packed-quant dispatch in `DefaultCpuOpsBase`, and Panama Vector (JVM SIMD) kernels for Q5_1/Q5_0 and Q6_K routed via the `KernelRegistry`. (PRs #709–#720)
-- **Auto-generated, CI-gated kernel × platform support matrix** rendered through the build-logic → Antora pipeline, so the docs can't drift from the code. (PRs #716, #724)
+- **`sk.ainet.core:skainet-compile-minerva` now publishes to Maven Central.** A packaging fix for the Minerva export module that shipped in 0.29.0 — it was missing the per-module POM metadata, so the artifact never made it to Maven Central. See the 0.29.0 highlights below for the module itself.
 
 ### Recent releases
 
+- **0.29.0** — **Minerva secure-MCU export module**: an end-to-end pipeline that lowers a SKaiNET model through shared graph-export contracts → Minerva IR → an `.npz` compiler input → a libminerva-packaged secure MCU project bundle, with host-side runtime verification and fingerprinted manifest artifacts (runnable sample, examples, ONNX workflow, getting-started docs). Plus **packed-quant matmul kernels with Kotlin/Native parity** (Q5_0/Q5_1/Q4_K/Q6_K — commonMain scalar + SPI, packed-quant dispatch in `DefaultCpuOpsBase`, Panama Vector for Q5_1/Q5_0 and Q6_K via the `KernelRegistry`), and an **auto-generated, CI-gated kernel × platform support matrix**. (PRs #697–#726)
 - **0.28.1** — Kotlin DSL → StableHLO → IREE is green end-to-end for the whole conformance suite (7/7 models, 27/27 ops compile to a `vmfb`): `inferDagOutputSpecs` now infers correct output shapes for shape-changing ops, and `reduce_window` (pooling) emits IREE's generic region form. (PRs #674, #676)
 - **0.28.0** — Four StableHLO export bugs fixed (reshape #666, concatenate #667, constants/reductions #663, `HloGenerator` tracing #668) plus non-JVM image runtime support (#671). (PRs #664, #670, #671)
 - **0.27.0** — A full gemma3 network lowers to StableHLO and compiles to an IREE `vmfb` (zero op gaps, verified by `GemmaTraceTest`): new `scaledDotProductAttention` (with causal + explicit additive mask), `permute`, `narrow`, and multi-output `split` converters, plus boxing-free `FloatArray` weight externalization for `.irpa` baking. (PRs #661 et al.)

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.1"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.1"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/minerva-export.adoc
+++ b/docs/modules/ROOT/pages/how-to/minerva-export.adoc
@@ -38,7 +38,7 @@ For a published application, use the SKaiNET BOM and the Minerva artifact:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.1"))
     implementation("sk.ainet.core:skainet-compile-minerva")
 }
 ----

--- a/docs/modules/ROOT/pages/reference/kernel-support-matrix.adoc
+++ b/docs/modules/ROOT/pages/reference/kernel-support-matrix.adoc
@@ -1,7 +1,7 @@
 = Kernel × platform support matrix
 :description: Which compute-kernel provider serves each weight format on each KMP target.
 
-Generated from `kernel-support.json` (version `0.29.0`) by `KernelSupportMatrixTest` — registry introspection of the registered `KernelProvider` implementations. Do not edit by hand; run `./gradlew generateKernelMatrix` to refresh.
+Generated from `kernel-support.json` (version `0.29.1`) by `KernelSupportMatrixTest` — registry introspection of the registered `KernelProvider` implementations. Do not edit by hand; run `./gradlew generateKernelMatrix` to refresh.
 
 Each cell is the best (highest-priority) provider that serves `Float32 × format` `matmul` on that platform: *native-ffm* (100) → *panama-vector* (50) → *scalar* (0). An empty cell (`—`) means no provider carries a kernel there (the format is dequant-to-FP32 only).
 

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.29.0"))
+    implementation(platform("sk.ainet:skainet-bom:0.29.1"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.29.0
+VERSION_NAME=0.29.1
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/

--- a/skainet-compile/skainet-compile-minerva/gradle.properties
+++ b/skainet-compile/skainet-compile-minerva/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=skainet-compile-minerva
+POM_NAME=skainet neural network Minerva secure-MCU export


### PR DESCRIPTION
## Summary

Patch release **0.29.1** that fixes publishing of the Minerva export module shipped in 0.29.0.

> **Stacked on `release/0.29.0` (#727).** Base is `release/0.29.0`, not `develop` — merge #727 into develop first, then this. This PR's diff is only the publishing fix + version/notes bump on top of 0.29.0.

### Root cause
`skainet-compile-minerva` applies the `vanniktech.mavenPublish` plugin and is auto-included in the BOM, but — unlike every other published module — it had **no per-module `gradle.properties`** (`POM_ARTIFACT_ID` / `POM_NAME`). Maven Central rejects a publication with no POM name, so the artifact never made it to Central.

### Fix
- Add `skainet-compile/skainet-compile-minerva/gradle.properties`:
  ```
  POM_ARTIFACT_ID=skainet-compile-minerva
  POM_NAME=skainet neural network Minerva secure-MCU export
  ```
- Bump `VERSION_NAME` `0.29.0` → `0.29.1`.
- **CHANGELOG** — add `[0.29.1] - 2026-06-09` Fixed entry.
- **README** — bump BOM coordinate, retitle "What's New", demote 0.29.0 highlights into Recent releases.
- **Docs** — bump `skainet-bom` coordinates to `0.29.1`; regenerate `kernel-support-matrix.adoc`.

### Audit
Scanned **all** modules applying the publish plugin for a missing `POM_ARTIFACT_ID`: `skainet-compile-minerva` was the only one (the root project declares the plugin `apply false` and does not publish). No other module is affected.

## Notes
- BOM inclusion is automatic (no BOM build edit needed) — minerva already applies the publish plugin and is not on `bomCoverage.excludePublished`.
- Release tag `0.29.1` to be cut after merge to publish to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)