### PR TITLE
fix(cpu-ops): lazy transpose for Q8_0 packed tensors

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
@@ -24,6 +24,7 @@ import sk.ainet.lang.tensor.data.Q5_1TensorData
 import sk.ainet.lang.tensor.data.Q5_1BlockTensorData
 import sk.ainet.lang.tensor.data.Q5_0TensorData
 import sk.ainet.lang.tensor.data.Q5_0BlockTensorData
+import sk.ainet.lang.tensor.data.Q8_0BlockTensorData
 import sk.ainet.lang.tensor.data.TensorData
 import sk.ainet.lang.tensor.data.TensorDataFactory
 import sk.ainet.lang.tensor.ops.UpsampleMode
@@ -606,6 +607,12 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
                 is Q6_KTensorData -> return newTensor(Q6_KBlockTensorData(Shape(cols, rows), d.packedData) as TensorData<T, V>, tensor.dtype, tensor)
                 is Q5_1TensorData -> return newTensor(Q5_1BlockTensorData(Shape(cols, rows), d.packedData) as TensorData<T, V>, tensor.dtype, tensor)
                 is Q5_0TensorData -> return newTensor(Q5_0BlockTensorData(Shape(cols, rows), d.packedData) as TensorData<T, V>, tensor.dtype, tensor)
+                // Q8_0 lazy transpose: rewrap the same input-block-major bytes with
+                // flipped shape (bytes are layout-agnostic to the [out,in] kernel
+                // convention) so a packed Q8_0 weight (e.g. gemma's tied lm_head)
+                // survives linearProject's transpose instead of hitting the generic
+                // FP32 path (Byte→Float ClassCastException). See transformers #178.
+                is Q8_0TensorData -> return newTensor(Q8_0BlockTensorData(Shape(cols, rows), d.packedData) as TensorData<T, V>, tensor.dtype, tensor)
                 else -> {}
             }
         }


### PR DESCRIPTION
## Problem
`DefaultCpuOps.transpose` rewraps packed bytes with a flipped shape for the K-series (Q4_K/Q5_K/Q6_K) and Q5_0/Q5_1, but **Q8_0 falls through to the generic FP32 `DenseTensorDataFactory` path**, which casts the Byte-backed buffer to Float and throws:

```
ClassCastException: class java.lang.Byte cannot be cast to class java.lang.Float
  at DenseTensorDataFactory.init → DefaultCpuOpsBase.transpose → linearProject
```

This blocks keeping a **Q8_0 matmul weight packed** through `linearProject` (`matmul(x, transpose(W))`).

## Fix
Add the analogous `is Q8_0TensorData -> Q8_0BlockTensorData(Shape(cols, rows), d.packedData)` case (one line + import). Bytes are layout-agnostic to the kernel's `[out, in]` block-major convention, so this is a metadata-only (lazy) transpose like the others.

## Why it matters
Unblocks FunctionGemma's tied **Q8_0 lm_head** staying packed in the eager `NATIVE_OPTIMIZED` path instead of dequanting to FP32 (~0.67 GB), which OOMs the 1.9 GB Astra Machina SL2610.

## Verification
SKaiNET-transformers `GemmaQ5KPackedParityTest` (composite `-PuseLocalSkainet=true`) now packs the lm_head as Q8_0 and decodes **byte-identically** to the FP32 baseline. See [SKaiNET-transformers #178](https://github.com/SKaiNET-developers/SKaiNET-transformers/issues/178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)