### PR TITLE
feat(context): expose ExecutionContext.isRecording (eager-vs-trace routing)

### DIFF
--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/exec/GraphExecutionContext.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/exec/GraphExecutionContext.kt
@@ -28,9 +28,10 @@ public interface GraphExecutionContext : ExecutionContext, TrainingExecutionCont
     public val tapeStack: TapeStack
 
     /**
-     * Whether operations should be recorded
+     * Whether operations should be recorded. Overrides [ExecutionContext.isRecording] so modules
+     * can route eager-vs-trace without depending on the graph module.
      */
-    public val isRecording: Boolean get() = currentTape?.isRecording == true
+    override val isRecording: Boolean get() = currentTape?.isRecording == true
 
 
     /**

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/context/ExecutionContext.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/context/ExecutionContext.kt
@@ -23,6 +23,15 @@ public interface ExecutionContext {
     public val phase: Phase
     public val inTraining: Boolean get() = phase == Phase.TRAIN
 
+    /**
+     * Whether this context is currently *recording* a trace/graph (vs. plain eager execution).
+     * Defaults to `false` (eager); the graph/tape context overrides it. Modules with an eager
+     * fast-path that bypasses `ops.*` (e.g. RoPE's raw-array interleaved rotation) can check this
+     * to emit a graph-traceable `ctx.ops.*` path instead when recording, so they export to
+     * StableHLO while keeping the fast path for eager inference.
+     */
+    public val isRecording: Boolean get() = false
+
     public val tensorDataFactory: TensorDataFactory
 
     /**


### PR DESCRIPTION
## Why

Modules with an eager fast-path that bypasses `ops.*` can't currently be traced to a graph. The canonical case is **RoPE's INTERLEAVED rotation** (`transformer-core/.../RoPE.kt`), which uses raw `input.data.copyToFloatArray()` for stride-2 efficiency — it escapes the tape (traces to 0 nodes) and so can't export to StableHLO. `transformer-core` depends only on `lang-core`, so it can't reach `DefaultGraphExecutionContext.isRecording` to route.

## What

- `ExecutionContext` (lang-core): add `public val isRecording: Boolean get() = false`.
- `GraphExecutionContext` (compile-dag): `override val isRecording` (already had it as `currentTape?.isRecording`).

Now any module can do `if (ctx.isRecording) <ops.* graph path> else <eager fast path>` using only lang-core.

Backward-compatible (default false; existing impls inherit it). Compiles clean (lang-core + compile-dag).

## Follow-up

The transformers consumer (graph-traceable INTERLEAVED RoPE routed on `ctx.isRecording`) lands in a SKaiNET-transformers PR once this is released; downstream `skainet-iree-conformance` already validates SPLIT_HALF RoPE end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)