### PR TITLE
docs(antora): fix version-currency + broken links across all pages

### DIFF
--- a/docs/modules/ROOT/pages/contributing/benchmarks.adoc
+++ b/docs/modules/ROOT/pages/contributing/benchmarks.adoc
@@ -1,5 +1,4 @@
 = Official Engine Benchmarks
-:url-prd: https://github.com/ainet-sk/SKaiNET/blob/main/bench-prd.md
 :url-pts: https://www.phoronix-test-suite.com/
 :url-obo: https://openbenchmarking.org/
 
@@ -72,8 +71,7 @@ records should be excluded from public leaderboards.
 
 The full lane currently runs on a Linux x86 host with an
 AVX2-capable CPU. macOS Arm64 and Linux Arm64 lanes are tracked as
-follow-ups in the
-{url-prd}[engine benchmark PRD].
+follow-ups.
 
 == Reproducing a public run locally
 
@@ -110,7 +108,7 @@ To register this machine as the official self-hosted runner:
 [source,bash]
 ----
 GH_RUNNER_TOKEN=<token from repo Settings -> Actions -> Runners> \
-  REPO=ainet-sk/SKaiNET \
+  REPO=SKaiNET-developers/SKaiNET \
   ./scripts/register_bench_runner.sh
 ----
 
@@ -136,7 +134,6 @@ comparisons don't silently break.
 
 == Related
 
-* {url-prd}[Engine + Transformers benchmark PRD]
 * {url-pts}[Phoronix Test Suite]
 * {url-obo}[OpenBenchmarking.org]
 * xref:explanation/perf/jvm-cpu.adoc[JVM CPU backend notes]

--- a/docs/modules/ROOT/pages/contributing/dtype-model.adoc
+++ b/docs/modules/ROOT/pages/contributing/dtype-model.adoc
@@ -4,9 +4,8 @@
 [NOTE]
 ====
 **Audience: SKaiNET maintainers and contributors.** This page maps
-the vocabulary used in the
-https://github.com/SKaiNET-developers/SKaiNET/blob/develop/rfc.md[dtype-policy
-RFC] (issue #615) onto the existing SKaiNET implementations.
+the vocabulary used in the dtype-policy RFC (issue
+https://github.com/SKaiNET-developers/SKaiNET/issues/615[#615]) onto the existing SKaiNET implementations.
 Library consumers don't need to read this — they call
 `tensor<FP32, Float>(ctx, FP32::class) { … }` and the engine does
 the rest.
@@ -133,8 +132,7 @@ avoid; SKaiNET already prevents all three.
 
 == Related
 
-* `rfc.md` (repo root) — the design document this page implements.
-* Issue https://github.com/SKaiNET-developers/SKaiNET/issues/615[#615] — implementation tracker.
+* Issue https://github.com/SKaiNET-developers/SKaiNET/issues/615[#615] — the dtype-policy design + implementation tracker this page describes.
 * xref:how-to/build-tensors.adoc[Build tensors with the data DSL] — the user-facing entry points that produce the `Tensor<T, V>` values whose dtype this page describes.
 * xref:contributing/benchmarks.adoc[Engine benchmark program] — runtime numbers that the kernel SPI produces.
 * xref:contributing/matmul-kernels.adoc[Reading the matmul benchmark] — how the kernel SPI's dispatch actually shows up in measurements.

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.31.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.31.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/java-model-training.adoc
+++ b/docs/modules/ROOT/pages/how-to/java-model-training.adoc
@@ -12,7 +12,7 @@ This guide covers building neural networks, defining loss functions and optimize
 === Prerequisites
 
 * JDK 21{plus} (CI builds on JDK 25); Gradle passes `--enable-preview --add-modules jdk.incubator.vector` automatically
-* See link:java-getting-started.md[Java Getting Started] for project setup
+* See xref:tutorials/java-getting-started.adoc[Java Getting Started] for project setup
 
 ==== Maven Dependencies
 
@@ -23,7 +23,7 @@ This guide covers building neural networks, defining loss functions and optimize
         <dependency>
             <groupId>sk.ainet</groupId>
             <artifactId>skainet-bom</artifactId>
-            <version>0.27.0</version>
+            <version>0.32.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -454,5 +454,5 @@ future.thenAccept(result -> {
 
 === Next Steps
 
-* link:java-getting-started.md[Java Getting Started] -- tensor operations, project setup, and dependency management.
-* link:java-llm-inference.md[LLM Inference Guide] -- load GGUF/SafeTensors models, generate text, and build agents.
+* xref:tutorials/java-getting-started.adoc[Java Getting Started] -- tensor operations, project setup, and dependency management.
+* xref:how-to/java-llm-inference.adoc[LLM Inference Guide] -- load GGUF/SafeTensors models, generate text, and build agents.

--- a/docs/modules/ROOT/pages/how-to/minerva-export.adoc
+++ b/docs/modules/ROOT/pages/how-to/minerva-export.adoc
@@ -38,7 +38,7 @@ For a published application, use the SKaiNET BOM and the Minerva artifact:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.31.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
     implementation("sk.ainet.core:skainet-compile-minerva")
 }
 ----

--- a/docs/modules/ROOT/pages/tutorials/hlo-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/hlo-getting-started.adoc
@@ -221,7 +221,7 @@ SKaiNET uses the MLIR/XLA compilation pipeline to target different hardware plat
 ==== Prerequisites for GPU Compilation
 
 [arabic]
-. *XLA with GPU support*: https://www.tensorflow.org/xla/tutorials/compile[Installation guide]
+. *XLA with GPU support*: https://openxla.org/xla[Installation guide]
 . *NVIDIA CUDA Toolkit* (for NVIDIA GPUs): https://developer.nvidia.com/cuda-downloads[Download here]
 . *ROCm* (for AMD GPUs): https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html[Installation guide]
 
@@ -343,9 +343,9 @@ optimizer.dumpGraphviz("rgb2gray.dot")
 
 * https://github.com/openxla/stablehlo/blob/main/docs/spec.md[StableHLO Specification]
 * https://mlir.llvm.org/docs/[MLIR Documentation]
-* https://www.tensorflow.org/xla[XLA Compilation Guide]
+* https://openxla.org/xla[XLA Compilation Guide]
 * https://docs.nvidia.com/jetson/[NVIDIA Jetson Documentation]
-* link:./examples/hlo/[SKaiNET HLO Examples]
+* https://github.com/SKaiNET-developers/SKaiNET/tree/develop/skainet-compile/skainet-compile-hlo/src/commonMain/kotlin/sk/ainet/compile/hlo/examples[SKaiNET HLO Examples]
 
 === Next Steps
 
@@ -355,4 +355,4 @@ optimizer.dumpGraphviz("rgb2gray.dot")
 . *Contribute*: Add new HLO converters for missing operations
 . *Optimize*: Profile and optimize your models using HLO tools
 
-For more detailed information, see the link:./OPTIMIZATION.md[HLO Optimization Guide] and https://docs.skainet.sk/hlo/[API Documentation].
+For more detailed information, see the https://github.com/SKaiNET-developers/SKaiNET/blob/develop/skainet-compile/skainet-compile-hlo/OPTIMIZATION.md[HLO Optimization Guide] and xref:reference/api.adoc[API reference].

--- a/docs/modules/ROOT/pages/tutorials/image-data-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/image-data-getting-started.adoc
@@ -32,7 +32,7 @@ For a JVM project, add the image/data modules alongside the CPU backend:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.31.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
 
     implementation("sk.ainet:skainet-backend-cpu-jvm")
     implementation("sk.ainet:skainet-io-image-jvm")

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -46,7 +46,7 @@ The `skainet-bom` manages all SKaiNET module versions so you never have to keep 
 ----
 <project>
     <properties>
-        <skainet.version>0.27.0</skainet.version>
+        <skainet.version>0.32.1</skainet.version>
     </properties>
 
     <dependencyManagement>
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.31.2"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")
@@ -325,5 +325,5 @@ var usq  = TensorJavaOps.unsqueeze(a, 0);
 
 === Next Steps
 
-* link:java-llm-inference.md[LLM Inference Guide] -- load GGUF/SafeTensors models, generate text, run BERT embeddings, and build tool-calling agents.
-* link:java-model-training.md[Model Training Guide] -- build sequential models, train on MNIST, and run async training loops.
+* xref:how-to/java-llm-inference.adoc[LLM Inference Guide] -- load GGUF/SafeTensors models, generate text, run BERT embeddings, and build tool-calling agents.
+* xref:how-to/java-model-training.adoc[Model Training Guide] -- build sequential models, train on MNIST, and run async training loops.


### PR DESCRIPTION
Audited **every Antora page** (50 `.adoc` across ROOT + skeep) for version-currency and link validity.

## Version-currency
Bumped dependency snippets to the current release **0.32.1** (BOM + Maven version) in `io-readers`, `minerva-export`, `image-data-getting-started`, `java-getting-started` (×2), `java-model-training`. Left historical "introduced in 0.21/0.22" references intact.

## Links
All `xref:`/`image::`/`include::` targets already resolve (0 broken). Fixed broken `link:`/macros — mostly README-port artifacts:
- `.md` `link:` → Antora `xref:` (java tutorials cross-links)
- `link:./OPTIMIZATION.md`, `link:./examples/hlo/` → GitHub blob/tree URLs
- dead `docs.skainet.sk/hlo/` → `xref:reference/api.adoc`
- `tensorflow.org/xla` (moved) → `openxla.org/xla`
- dead repo-root `rfc.md` → the tracking issue #615
- dropped dead `bench-prd.md` PRD link; fixed `ainet-sk/SKaiNET` → `SKaiNET-developers/SKaiNET` in the runner example

## Flagged, not touched
The **generated** docs are stamped at old versions — `ops-status-matrix` + `operators/generated/*` (0.27.0) and `kernel-support-matrix` (0.31.2). They're marked "do not edit by hand"; refresh via `./gradlew generateOperatorDocs generateKernelMatrix` once a build regenerates their source JSON (a release-pipeline step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)