### PR TITLE
release: 0.32.2 — ExecutionContext.isRecording + docs audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [0.32.2] - 2026-06-24
+
+### Added
+
+- **`ExecutionContext.isRecording`.** A default-`false` `isRecording` on the lang-core
+  `ExecutionContext` interface, overridden by `GraphExecutionContext` (`currentTape?.isRecording`).
+  Lets modules with an eager fast-path that bypasses `ops.*` (e.g. RoPE's raw-array INTERLEAVED
+  rotation) detect tracing and emit a graph-traceable `ctx.ops.*` path — so they export to StableHLO
+  while keeping the fast path for eager inference — without depending on the compile-dag module.
+  Backward-compatible (existing `ExecutionContext` implementations inherit the default). (PR #757)
+
+### Changed
+
+- **Docs:** Antora docs version-currency (dependency snippets → current release) and broken-link
+  fixes across all pages (`.md` `link:` → `xref:`, dead `tensorflow.org/xla` → `openxla.org`, dead
+  `rfc.md`/`bench-prd.md` references, `ainet-sk` → `SKaiNET-developers`). (PR #758)
+- **Dependency:** `ch.qos.logback:logback-classic` 1.5.34 → 1.5.35. (PR #756)
+
 ## [0.32.1] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.2"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -241,6 +241,15 @@ Runnable examples:
 
 ---
 
+## What's New in 0.32.2
+
+- **`ExecutionContext.isRecording`.** A default-`false` flag (overridden by the graph/tape context)
+  so a module with an eager fast-path that bypasses `ops.*` — e.g. RoPE's raw-array INTERLEAVED
+  rotation — can detect tracing and emit a graph-traceable `ctx.ops.*` path instead, exporting to
+  StableHLO while keeping the eager fast path. Backward-compatible. (PR #757)
+- **Docs:** Antora version-currency + broken-link fixes across all pages (PR #758).
+- **Dependency:** `ch.qos.logback:logback-classic` → 1.5.35 (#756).
+
 ## What's New in 0.32.1
 
 - **GroupNorm compiles on stock IREE.** The 0.32.0 GroupNorm converter emitted `@reduce_mean` /
@@ -249,19 +258,9 @@ Runnable examples:
   the [`skainet-iree-conformance`](https://github.com/SKaiNET-developers/skainet-iree-conformance) harness
   (`iree-compile` + `iree-run-module` + numpy validate → PASS, `max_abs_err = 1.2e-7`). (PR #754)
 
-## What's New in 0.32.0
-
-- **GroupNorm StableHLO converter.** `groupNorm` now lowers to real `stablehlo.*` ops — reshape
-  `(N, C, *spatial)` into `(N, G, M)` groups → per-group `mean`/`variance` → normalize → reshape back →
-  optional per-channel `scale`/`offset`. Previously a `groupNorm` node fell through to the "operation
-  not supported" path. (PR #752)
-- **Docs:** a SKEEP proposals module (PR #750) and a quantization-process explanation —
-  weights, activations, calibration (PR #747).
-- **Dependencies:** `com.vanniktech.maven.publish` → 0.37.0 (#748),
-  `com.networknt:json-schema-validator` → 3.0.5 (#749), kotest → 6.2.1 (#744),
-  Gradle wrapper → 9.6.0 (#745), `actions/checkout` → 7 (#743).
-
 ### Recent releases
+
+- **0.32.0** — **GroupNorm StableHLO converter** (#752): `groupNorm` lowers to real `stablehlo.*` ops; plus a SKEEP proposals docs module (#750), a quantization-process explanation (#747), and dependency bumps.
 
 - **0.31.2** — `RowDequantSource` + `ops.gather` row-dequant: a packed/oversized embedding (a Q-quantised `token_embd`) stays packed and is looked up via `ops.gather`, dequantising only the touched rows. (PR #741)
 - **0.31.0** — `ops.transpose` lazily handles every packed matmul dtype (Q8_0/Q4_0 added, completing the Q4_K/Q5_K/Q6_K/Q5_0/Q5_1/Q8_0/Q4_0 set); `json-schema-validator` → 3.0.4. (PRs #736, #737, #733)

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.2"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.2"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/java-model-training.adoc
+++ b/docs/modules/ROOT/pages/how-to/java-model-training.adoc
@@ -23,7 +23,7 @@ This guide covers building neural networks, defining loss functions and optimize
         <dependency>
             <groupId>sk.ainet</groupId>
             <artifactId>skainet-bom</artifactId>
-            <version>0.32.1</version>
+            <version>0.32.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/modules/ROOT/pages/how-to/minerva-export.adoc
+++ b/docs/modules/ROOT/pages/how-to/minerva-export.adoc
@@ -38,7 +38,7 @@ For a published application, use the SKaiNET BOM and the Minerva artifact:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.2"))
     implementation("sk.ainet.core:skainet-compile-minerva")
 }
 ----

--- a/docs/modules/ROOT/pages/tutorials/image-data-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/image-data-getting-started.adoc
@@ -32,7 +32,7 @@ For a JVM project, add the image/data modules alongside the CPU backend:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.2"))
 
     implementation("sk.ainet:skainet-backend-cpu-jvm")
     implementation("sk.ainet:skainet-io-image-jvm")

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -46,7 +46,7 @@ The `skainet-bom` manages all SKaiNET module versions so you never have to keep 
 ----
 <project>
     <properties>
-        <skainet.version>0.32.1</skainet.version>
+        <skainet.version>0.32.2</skainet.version>
     </properties>
 
     <dependencyManagement>
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.32.1"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.2"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.32.1
+VERSION_NAME=0.32.2
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/


### PR DESCRIPTION
## Release 0.32.2 (patch)

`VERSION_NAME` 0.32.1 → **0.32.2**; CHANGELOG `[0.32.2]` + README "What's New". Ships `develop`'s unreleased changes:

- **feat: `ExecutionContext.isRecording`** (#757) — default-false flag (overridden by the graph/tape context) so modules with an eager fast-path that bypasses `ops.*` (e.g. RoPE's INTERLEAVED rotation) can detect tracing and emit a graph-traceable path. Backward-compatible. **This is the enabler for graph-exportable INTERLEAVED RoPE downstream.**
- **docs:** Antora version-currency + broken-link fixes across all pages (#758)
- **deps:** logback-classic 1.5.34 → 1.5.35 (#756)

Also bumps the README + Antora dependency snippets to 0.32.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)