### PR TITLE
release: 0.32.4 — streaming detokenization preserves word spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.32.4] - 2026-06-26
+
+### Fixed
+
+- **Streaming detokenization preserves word-boundary spaces (`Tokenizer.decodeToken`).** A generation
+  loop that decodes one token at a time (`decode(tokenId)`) ran words together (`"the process"` →
+  `"theprocess"`): the single-token path delegated to the sequence-level
+  `SentencePieceTokenizer.decode(IntArray)`, whose `addSpacePrefix` leading-space strip is only
+  correct once per sequence. Adds `Tokenizer.decodeToken(id)` (default = `decode(intArrayOf(id))`) and
+  a `SentencePieceTokenizer` override that decodes a single token without the leading strip (llama.cpp
+  `token_to_piece` semantics), plus a `decode(ids, stripLeadingSpace)` overload. Every streaming
+  consumer now reconstructs spacing correctly.
+
 ## [0.32.3] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the core dependencies (Gradle Kotlin DSL):
 ```kotlin
 dependencies {
     // Recommended: import the umbrella BOM and drop versions on the engine modules.
-    implementation(platform("sk.ainet:skainet-bom:0.32.3"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.4"))
 
     implementation("sk.ainet.core:skainet-lang-core")
     implementation("sk.ainet.core:skainet-backend-cpu")
@@ -240,6 +240,13 @@ Runnable examples:
 - Use **Minerva export** when you need a secure MCU project bundle that goes through libminerva packaging and host verification.
 
 ---
+
+## What's New in 0.32.4
+
+- **Streaming detokenization keeps word spaces (`Tokenizer.decodeToken`).** Decoding generated tokens
+  one at a time no longer runs words together (`"the process"` → `"theprocess"`). The new
+  `decodeToken(id)` keeps each SentencePiece piece's leading space (llama.cpp `token_to_piece`
+  semantics); `decode(IntArray)` still strips the single sequence-leading space as before.
 
 ## What's New in 0.32.3
 

--- a/docs/modules/ROOT/pages/how-to/io-readers.adoc
+++ b/docs/modules/ROOT/pages/how-to/io-readers.adoc
@@ -20,7 +20,7 @@ Add the following dependencies to your `build.gradle.kts`:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.3"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.4"))
 
     implementation("sk.ainet.core:skainet-io-gguf")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")
@@ -32,7 +32,7 @@ dependencies {
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.3"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.4"))
 
     implementation("sk.ainet.core:skainet-io-onnx")
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.8.2")

--- a/docs/modules/ROOT/pages/how-to/java-model-training.adoc
+++ b/docs/modules/ROOT/pages/how-to/java-model-training.adoc
@@ -23,7 +23,7 @@ This guide covers building neural networks, defining loss functions and optimize
         <dependency>
             <groupId>sk.ainet</groupId>
             <artifactId>skainet-bom</artifactId>
-            <version>0.32.3</version>
+            <version>0.32.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/modules/ROOT/pages/how-to/minerva-export.adoc
+++ b/docs/modules/ROOT/pages/how-to/minerva-export.adoc
@@ -38,7 +38,7 @@ For a published application, use the SKaiNET BOM and the Minerva artifact:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.3"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.4"))
     implementation("sk.ainet.core:skainet-compile-minerva")
 }
 ----

--- a/docs/modules/ROOT/pages/tutorials/image-data-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/image-data-getting-started.adoc
@@ -32,7 +32,7 @@ For a JVM project, add the image/data modules alongside the CPU backend:
 [source,kotlin]
 ----
 dependencies {
-    implementation(platform("sk.ainet:skainet-bom:0.32.3"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.4"))
 
     implementation("sk.ainet:skainet-backend-cpu-jvm")
     implementation("sk.ainet:skainet-io-image-jvm")

--- a/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/java-getting-started.adoc
@@ -46,7 +46,7 @@ The `skainet-bom` manages all SKaiNET module versions so you never have to keep 
 ----
 <project>
     <properties>
-        <skainet.version>0.32.3</skainet.version>
+        <skainet.version>0.32.4</skainet.version>
     </properties>
 
     <dependencyManagement>
@@ -144,7 +144,7 @@ repositories {
 
 dependencies {
     // Import BOM for version alignment
-    implementation(platform("sk.ainet:skainet-bom:0.32.3"))
+    implementation(platform("sk.ainet:skainet-bom:0.32.4"))
 
     // Core tensor library
     implementation("sk.ainet:skainet-lang-core-jvm")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=sk.ainet.core
-VERSION_NAME=0.32.3
+VERSION_NAME=0.32.4
 POM_DESCRIPTION=SKaiNET
 
 POM_URL=https://github.com/SKaiNET-developers/skainet/

--- a/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/tokenizer/SentencePieceTokenizer.kt
+++ b/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/tokenizer/SentencePieceTokenizer.kt
@@ -86,7 +86,22 @@ public class SentencePieceTokenizer(
         return IntArray(out.size) { out[it] }
     }
 
-    override fun decode(ids: IntArray): String {
+    override fun decode(ids: IntArray): String = decode(ids, stripLeadingSpace = addSpacePrefix)
+
+    /**
+     * Decode a single token to its surface piece without stripping the leading
+     * word-boundary space — see [Tokenizer.decodeToken]. Required for correct
+     * spacing when a caller decodes generated tokens one at a time.
+     */
+    override fun decodeToken(id: Int): String = decode(intArrayOf(id), stripLeadingSpace = false)
+
+    /**
+     * Decode [ids] to text. When [stripLeadingSpace] is true a single leading
+     * space (the artefact of SentencePiece's `addSpacePrefix` at encode time) is
+     * removed — correct for a whole sequence, but NOT for an individual streaming
+     * token, which must keep its leading space.
+     */
+    public fun decode(ids: IntArray, stripLeadingSpace: Boolean): String {
         val sb = StringBuilder()
         val byteBuf = ArrayList<Byte>()
         for (id in ids) {
@@ -104,11 +119,8 @@ public class SentencePieceTokenizer(
         }
         if (byteBuf.isNotEmpty()) sb.append(flushBytes(byteBuf))
 
-        var result = sb.toString().replace(WHITESPACE_ESCAPE, ' ')
-        if (addSpacePrefix && result.startsWith(' ')) {
-            result = result.substring(1)
-        }
-        return result
+        val result = sb.toString().replace(WHITESPACE_ESCAPE, ' ')
+        return if (stripLeadingSpace && result.startsWith(' ')) result.substring(1) else result
     }
 
     // ------------------------------------------------------------------

--- a/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/tokenizer/Tokenizer.kt
+++ b/skainet-io/skainet-io-core/src/commonMain/kotlin/sk/ainet/io/tokenizer/Tokenizer.kt
@@ -15,4 +15,20 @@ public interface Tokenizer {
 
     public fun encode(text: String): IntArray
     public fun decode(ids: IntArray): String
+
+    /**
+     * Decode a single token to its surface piece for **streaming** generation.
+     *
+     * Unlike [decode], this must NOT apply any sequence-level leading-space
+     * normalisation: each piece keeps its own leading word-boundary space, so
+     * concatenating a stream of per-token pieces reconstructs spacing (llama.cpp
+     * `token_to_piece` semantics). Decoding tokens one at a time through [decode]
+     * would strip every word's leading space and run the words together
+     * (`"the process"` → `"theprocess"`).
+     *
+     * The default decodes the 1-element array; implementations whose [decode]
+     * strips a leading space (e.g. SentencePiece with `addSpacePrefix`) override
+     * this to skip that strip.
+     */
+    public fun decodeToken(id: Int): String = decode(intArrayOf(id))
 }

--- a/skainet-io/skainet-io-core/src/commonTest/kotlin/sk/ainet/io/tokenizer/SentencePieceTokenizerCoreTest.kt
+++ b/skainet-io/skainet-io-core/src/commonTest/kotlin/sk/ainet/io/tokenizer/SentencePieceTokenizerCoreTest.kt
@@ -128,6 +128,31 @@ class SentencePieceTokenizerCoreTest {
     }
 
     @Test
+    fun `streaming decodeToken keeps each word-boundary space`() {
+        val tok = buildToyTokenizer()
+        val ids = tok.encode("Hello world") // -> [▁Hello, ▁world]
+
+        // Streaming: each per-token piece keeps its own leading space, so a
+        // consumer that appends piece-by-piece reconstructs the spacing.
+        val streamed = ids.joinToString("") { tok.decodeToken(it) }
+        assertEquals(" Hello world", streamed)
+        assertEquals(tok.decode(ids), streamed.trimStart())
+
+        // Regression guard: decoding each token through the sequence-level
+        // decode() strips every leading space and runs the words together.
+        val buggy = ids.joinToString("") { tok.decode(intArrayOf(it)) }
+        assertEquals("Helloworld", buggy)
+    }
+
+    @Test
+    fun `decode with stripLeadingSpace=false keeps the leading space`() {
+        val tok = buildToyTokenizer()
+        val ids = tok.encode("Hello")
+        assertEquals("Hello", tok.decode(ids)) // default strips
+        assertEquals(" Hello", tok.decode(ids, stripLeadingSpace = false))
+    }
+
+    @Test
     fun `bos and eos ids are exposed`() {
         val tok = buildToyTokenizer()
         assertEquals(1, tok.bosTokenId)


### PR DESCRIPTION
Merges the **0.32.4** release back into develop. The tag `0.32.4` is published to Maven Central (deployment succeeded); this brings the release commit onto develop so the version (`0.32.4`) and CHANGELOG/docs reflect the release.

## What 0.32.4 ships
**Fix: streaming detokenization preserves word-boundary spaces.** A generation loop that decodes one token at a time (`decode(tokenId)`) ran words together (`"the process"` → `"theprocess"`) because the single-token path delegated to the sequence-level `SentencePieceTokenizer.decode(IntArray)`, whose `addSpacePrefix` leading-space strip is only correct once per sequence.

- `Tokenizer.decodeToken(id)` — new interface method, default `= decode(intArrayOf(id))` (backward-compatible); gives the upstream tokenizer the streaming single-token decode it lacked.
- `SentencePieceTokenizer` overrides `decodeToken` to decode without the leading strip (llama.cpp `token_to_piece` semantics); adds `decode(ids, stripLeadingSpace)`. `decode(IntArray)` behaviour unchanged.
- Tests: streaming decode keeps spaces; batch still strips once; regression guard for the old `"Helloworld"` behaviour.

Fixes correct-but-spaceless output in every streaming consumer (kllama, agent loops, any `decode(Int)` caller).

## Notes
- `skainet-io-core` is not API-tracked, so no `.api` dump change is needed.
- antora.yml is `version: ~` (branch-tracked).