### PR TITLE
publish: align data-module POM coordinates and names with module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (coordinates): `skainet-data-simple` now publishes under its module name.** The artifactId
+  changes from the mismatched `sk.ainet.core:skainet-data-basic` to `sk.ainet.core:skainet-data-simple`;
+  update your dependency declarations when upgrading past 0.34.0 (BOM consumers only need the new
+  artifactId). `skainet-data-transform` also gets a distinct POM name ("skainet data transforms" — it
+  previously duplicated the datasets module's name); its coordinates are unchanged.
+
 ## [0.34.0] - 2026-07-05
 
 ### Added

--- a/skainet-data/skainet-data-simple/gradle.properties
+++ b/skainet-data/skainet-data-simple/gradle.properties
@@ -1,2 +1,2 @@
-POM_ARTIFACT_ID=skainet-data-basic
-POM_NAME=skainet neural basic datasets
+POM_ARTIFACT_ID=skainet-data-simple
+POM_NAME=skainet simple datasets

--- a/skainet-data/skainet-data-transform/gradle.properties
+++ b/skainet-data/skainet-data-transform/gradle.properties
@@ -1,2 +1,2 @@
 POM_ARTIFACT_ID=skainet-data-transform
-POM_NAME=skainet neural basic datasets
+POM_NAME=skainet data transforms


### PR DESCRIPTION
## Summary

Post-0.34.0 publishing cleanup of the two POM quirks in the data modules (0.34.0 itself shipped with the old coordinates; this takes effect with the next release):

- **`skainet-data-simple`** — artifactId aligned to the module name: publishes as `sk.ainet.core:skainet-data-simple` (was the mismatched `sk.ainet.core:skainet-data-basic`). **BREAKING coordinate change** for direct consumers when upgrading past 0.34.0; BOM consumers only need the new artifactId. Documented under `[Unreleased]` in the CHANGELOG.
- **`skainet-data-transform`** — coordinates unchanged, but gets a distinct POM name ("skainet data transforms"); it previously duplicated the datasets module's "skainet neural basic datasets".

## Verification

Regenerated both modules' POMs via `generatePomFileForKotlinMultiplatformPublication` — artifactId/name come out as intended, all other metadata (license, SCM, developers) unchanged. Nothing else in the repo references the old `skainet-data-basic` artifactId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)