### PR TITLE
docs(readme): embed clickable compiler architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 
 <img src="docs/modules/ROOT/images/SKaiNET-logo.png" alt="SKaiNET logo" width="150">
 
-> For architecture details see [ARCHITECTURE.md](ARCHITECTURE.md).
+<a href="https://skainet-developers.github.io/SKaiNET/skainet/reference/architecture.html" title="Open the full architecture reference">
+  <img src="docs/modules/ROOT/images/SKaiNET-compiler.png" alt="SKaiNET compiler architecture — click for the full architecture reference" width="640">
+</a>
+
+_Click the diagram for the full [architecture reference](https://skainet-developers.github.io/SKaiNET/skainet/reference/architecture.html), or read the short [ARCHITECTURE.md](ARCHITECTURE.md)._
 
 ---
 


### PR DESCRIPTION
Replace the plain-text `ARCHITECTURE.md` link in the README with the `SKaiNET-compiler.png` diagram, sized to a readable `width="640"` (scaled from the native 1672×941) and made clickable.

Clicking the diagram opens the published Antora architecture reference at `https://skainet-developers.github.io/SKaiNET/skainet/reference/architecture.html`. A short caption keeps direct links to both the Antora page and the local `ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)