### PR TITLE
[BUILD] Add workflow reuse-compliance to CI

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>, 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on:
+  push:
+    branches:
+      - master
+  
+  pull_request:
+    branches:
+      - master
+
+  schedule:
+    # Weekly on Saturdays at 1:30AM
+    - cron: '30 1 * * 6'
+
+# Set default permission for all jobs to none
+permissions: {}
+
+jobs:
+  test-reuse-compliance:
+    runs-on: ubuntu-22.04
+    
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: "Run REUSE Compliance Check"
+        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5.0.0

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -25,6 +25,9 @@ permissions: {}
 jobs:
   test-reuse-compliance:
     runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
     
     steps:
       - name: "Checkout Repository"

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -7,11 +7,13 @@ name: REUSE Compliance Check
 on:
   push:
     branches:
-      - master
+      - main
+      - develop
   
   pull_request:
     branches:
-      - master
+      - main
+      - develop
 
   schedule:
     # Weekly on Saturdays at 1:30AM

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/sk.ainet.core/skainet-lang-core.svg)](https://central.sonatype.com/artifact/sk.ainet.core/skainet-lang-core)
 [![GitHub Contributors](https://img.shields.io/github/contributors/SKaiNET-developers/SKaiNET)](https://github.com/SKaiNET-developers/SKaiNET/graphs/contributors)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-View%20Docs-blue?logo=readthedocs&logoColor=white)](https://deepwiki.com/SKaiNET-developers/SKaiNET)
-[![REUSE status](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)]
+[REUSE status](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)
 
 <img src="docs/modules/ROOT/images/SKaiNET-logo.png" alt="SKaiNET logo" width="150">
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/sk.ainet.core/skainet-lang-core.svg)](https://central.sonatype.com/artifact/sk.ainet.core/skainet-lang-core)
 [![GitHub Contributors](https://img.shields.io/github/contributors/SKaiNET-developers/SKaiNET)](https://github.com/SKaiNET-developers/SKaiNET/graphs/contributors)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-View%20Docs-blue?logo=readthedocs&logoColor=white)](https://deepwiki.com/SKaiNET-developers/SKaiNET)
+[![REUSE status](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)]
 
 <img src="docs/modules/ROOT/images/SKaiNET-logo.png" alt="SKaiNET logo" width="150">
 


### PR DESCRIPTION
This `PR` adds the workflow `reuse-compliance.yml` workflow to the `CI` pipeline (#805).

The ``REUSE`` compliance workflow runs on all ``push`` and ``pull requests``. This ``PR`` adds an important best practise for **compliance** within the FOSS community and is part of a larger effort to implement FOSS best practises (#594).