### PR TITLE
[CI]: Add OpenSSF workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2020 OpenSSF Scorecard Authors, 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This workflow generates an OpenSSF scorecard report, and uploads the report
+# (i) as an artifact to the actions tab, and (ii) to GitHub's code scanning dashboard
+# Note: This workflow file is a slightly adpated version of
+# https://github.com/ossf/scorecard/blob/99b664e5d18f6774ef63dd1e7acb9f255c6285de/.github/workflows/scorecard-analysis.yml
+
+
+name: OpenSSF Scorecard
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+      - develop
+
+  pull_request:
+    branches:
+      - develop
+      
+  schedule:
+    # Weekly on Saturdays at 1:30AM.
+    - cron:  '30 1 * * 6'
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: OpenSSF Scorecard
+
+    runs-on: ubuntu-24.04
+
+    permissions:
+      actions: read
+      artifact-metadata: read
+      attestations: read
+      checks: read
+      code-quality: read
+      contents: read
+      deployments: read
+      issues: read
+      models: read
+      discussions: read
+      packages: read
+      pages: read
+      pull-requests: read
+      statuses: read
+      vulnerability-alerts: read
+
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+      
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to our repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![GitHub Contributors](https://img.shields.io/github/contributors/SKaiNET-developers/SKaiNET)](https://github.com/SKaiNET-developers/SKaiNET/graphs/contributors)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-View%20Docs-blue?logo=readthedocs&logoColor=white)](https://deepwiki.com/SKaiNET-developers/SKaiNET)
 [![REUSE status](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)
+[![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/SKaiNET-developers/SKaiNET/badge)](https://scorecard.dev/viewer/?uri=github.com/SKaiNET-developers/SKaiNET)
+
 
 <img src="docs/modules/ROOT/images/SKaiNET-logo.png" alt="SKaiNET logo" width="150">
 


### PR DESCRIPTION
This `PR` adds the ``OpenSSF`` workflow to the ``CI`` (#813 ), and displays the reuslts in the ``README`` as a badge.

The ``OpenSSF`` workflow runs on all ``push`` and ``pull requests``, and also weekly on Saturdays. This ``PR`` adds an important best practise for **security** within the FOSS community.