### PR TITLE
[BUILD]: Add commit hashes to docs workflow to pin actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,7 +78,7 @@ jobs:
       # cache. Transformers skipped caching here — this workflow
       # improves on that.
       - name: Build Antora image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.0.0
         with:
           context: docs/.docker
           tags: skainet-antora:local

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
         run: ./gradlew --no-daemon generateDocs dokkaGenerate
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # The Chromium layer makes the image ~400 MB. First build is
       # ~3–5 minutes; subsequent runs are sub-minute via the GHA

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -112,7 +112,7 @@ jobs:
         run: ./gradlew --no-daemon bundleDokkaIntoSite
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/build/site
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -127,4 +127,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           java-version: '25'
 
       - name: Cache Gradle
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       # container, so the Gradle wrapper cache works and generateDocs
       # / dokkaGenerate see the right JDK.
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           distribution: temurin
           java-version: '25'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # JDK 25 matches the version used by every other workflow in
       # this repo. Runs on the RUNNER, not inside the Docker


### PR DESCRIPTION
This ``PR`` pins all actions in the ``docs.yml`` workflow with their commit hash to increase security (#815 ).

The OpenSSF Score should increase after this ``PR`` has been merged.