### PR TITLE
[BUILD]: Add commit hashes to documentation workflow to pin actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -65,7 +65,7 @@ jobs:
           
       - name: Upload documentation preview (PR only)
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: documentation-preview-${{ github.event.number }}
           path: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -81,7 +81,7 @@ jobs:
     
     steps:
       - name: Download documentation artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: documentation-preview-${{ github.event.number }}
           path: ./docs-preview

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
           distribution: 'temurin'
           
       - name: Cache Gradle packages
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -87,7 +87,7 @@ jobs:
           path: ./docs-preview
           
       - name: Setup Node.js for preview server
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: '18'
           

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -102,7 +102,7 @@ jobs:
           echo "Preview server started at http://localhost:3000"
           
       - name: Create PR comment with preview link
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./gradlew generateDocs --stacktrace
         
       - name: Upload generated documentation
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: operator-documentation
           path: |


### PR DESCRIPTION
This ``PR`` pins all actions in the ``documentation.yml`` workflow with their commit hash to increase security (#815 ).

The OpenSSF Score should increase after this ``PR`` has been merged.