### PR TITLE
[BUILD]: Add commit hashes to engine-benchmarks workflow to pin actions

### DIFF
--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload full records
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: engine-full-records-${{ github.run_id }}
           path: out/engine/**/*.json

--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload smoke records
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: engine-smoke-records-${{ github.run_id }}
           path: out/engine/smoke/**/*.json

--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, skainet-bench-linux-x86]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Show runner identity
         run: |


### PR DESCRIPTION
This ``PR`` pins all actions in the ``engine-benchmarks.yml`` workflow with their commit hash to increase security (#815 ).

The OpenSSF Score should increase after this ``PR`` has been merged.