### PR TITLE
[BUILD]: Add commit hashes to java-tests workflow to pin actions

### DIFF
--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: java-test-reports
           path: |

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set up JDK 22
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: 'zulu'
           java-version: 22


### PR DESCRIPTION
This ``PR`` pins all actions in the ``java-tests.yml`` workflow with their commit hash to increase security (#815 ).

The OpenSSF Score should increase after this ``PR`` has been merged.