### PR TITLE
[BUILD]: Add commit hashes to native-cpu-multiarch workflow to pin actions

### DIFF
--- a/.github/workflows/native-cpu-multiarch.yml
+++ b/.github/workflows/native-cpu-multiarch.yml
@@ -71,7 +71,7 @@ jobs:
           Copy-Item .github\ci-gradle.properties "$HOME\.gradle\gradle.properties"
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: 'zulu'
           java-version: 25

--- a/.github/workflows/native-cpu-multiarch.yml
+++ b/.github/workflows/native-cpu-multiarch.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload native library
         if: success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: libskainet_kernels-${{ matrix.arch_label }}
           path: skainet-backends/skainet-backend-native-cpu/build/native/resources/native/${{ matrix.arch_label }}/${{ matrix.lib_name }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: native-cpu-test-reports-${{ matrix.arch_label }}
           path: |

--- a/.github/workflows/native-cpu-multiarch.yml
+++ b/.github/workflows/native-cpu-multiarch.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Copy CI gradle.properties (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
This ``PR`` pins all actions in the ``native-cpu-multiarch.yml`` workflow with their commit hash to increase security (#815 ).

The OpenSSF Score should increase after this ``PR`` has been merged.