### PR TITLE
io-core: add androidNativeArm64 target

### DIFF
--- a/skainet-io/skainet-io-core/build.gradle.kts
+++ b/skainet-io/skainet-io-core/build.gradle.kts
@@ -39,6 +39,12 @@ kotlin {
     macosArm64 ()
     linuxX64 ()
     linuxArm64 ()
+    // androidNativeArm64 joins the existing 64-bit native targets in the shared nativeMain
+    // (PosixPreadRandomAccessSource uses posix pread, whose ssize_t/size_t are Long on all of
+    // them). androidNativeArm32 is intentionally NOT added here: those posix types are Int on
+    // 32-bit, and mixing widths in the shared nativeMain metadata is illegal — arm32 needs the
+    // posix source moved to a 64-bit-only source set (tracked as a follow-up).
+    androidNativeArm64()
 
     js {
         browser()


### PR DESCRIPTION
Fixes #835 (arm64 portion).

Adds `androidNativeArm64()` to `skainet-io-core`. It already builds all other native targets (ios/macos/linux, all 64-bit) from a shared `nativeMain` whose `RandomAccessSource` actual is posix `pread`; arm64 is 64-bit so it joins that source set cleanly. Deps are only `lang-core` (androidNative) + kotlinx (all androidNative-capable).

Unblocks 64-bit on-device (arm64 phone) consumers needing the engine tokenizer (Moonshine ASR cartridge).

**Verification:** `:skainet-io:skainet-io-core:compileNativeMainKotlinMetadata` and `compileKotlinAndroidNativeArm64` compile clean.

## Not androidNativeArm32 (deliberately)

posix `ssize_t`/`size_t` are `Int` on 32-bit vs `Long` on the existing 64-bit targets; mixing widths in the shared `nativeMain` metadata is illegal (`compileNativeMainKotlinMetadata` fails). Arm32 needs `PosixPreadRandomAccessSource` moved to a 64-bit-only source set — a small source-set refactor tracked as a follow-up. `skainet-io-safetensors` also stays jvm/linux (additionally depends on `compile-core`/`-dag`).