### PR TITLE
[BUILD]: Add commit hashes in schema-validation workflow to pin actions

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       
     - name: Set up JDK 25
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       
     - name: Set up JDK 25
       uses: actions/setup-java@v5

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -14,40 +14,40 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      
-    - name: Set up JDK 25
-      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-      with:
-        java-version: '25'
-        distribution: 'temurin'
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         
-    - name: Cache Gradle packages
-      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      - name: Set up JDK 25
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
           
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      
-    - name: Generate operator documentation (KSP)
-      run: ./gradlew :skainet-lang:skainet-lang-core:kspCommonMainKotlinMetadata
-      
-    - name: Validate JSON schema via Gradle plugin
-      run: ./gradlew validateOperatorSchema
-      
-    - name: Upload validation artifacts
-      if: failure()
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: validation-logs
-        path: |
-          **/build/generated/**/*.json
-          **/build/logs/
-        retention-days: 7
+      - name: Cache Gradle packages
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+            
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        
+      - name: Generate operator documentation (KSP)
+        run: ./gradlew :skainet-lang:skainet-lang-core:kspCommonMainKotlinMetadata
+        
+      - name: Validate JSON schema via Gradle plugin
+        run: ./gradlew validateOperatorSchema
+        
+      - name: Upload validation artifacts
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: validation-logs
+          path: |
+            **/build/generated/**/*.json
+            **/build/logs/
+          retention-days: 7

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -44,7 +44,7 @@ jobs:
       
     - name: Upload validation artifacts
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: validation-logs
         path: |

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -24,7 +24,7 @@ jobs:
         distribution: 'temurin'
         
     - name: Cache Gradle packages
-      uses: actions/cache@v6
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: |
           ~/.gradle/caches


### PR DESCRIPTION
This ``PR`` pins all actions in the ``schema-validation.yml`` workflow with their commit hash to increase security (#815).

The OpenSSF Score should increase after this ``PR`` has been merged.