### PR TITLE
[BUILD]: Add commit hashes in verify-poms workflow to pin actions

### DIFF
--- a/.github/workflows/verify-poms.yml
+++ b/.github/workflows/verify-poms.yml
@@ -24,7 +24,7 @@ jobs:
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: 'zulu'
           java-version: 25

--- a/.github/workflows/verify-poms.yml
+++ b/.github/workflows/verify-poms.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties


### PR DESCRIPTION
This ``PR`` pins all actions in the ``verify-poms.yml`` workflow with their commit hash to increase security (#815).

The OpenSSF Score should increase after this ``PR`` has been merged.