### PR TITLE
io-safetensors: add androidNative targets (drop unused compile-core/-dag)

### DIFF
--- a/skainet-io/skainet-io-safetensors/build.gradle.kts
+++ b/skainet-io/skainet-io-safetensors/build.gradle.kts
@@ -32,6 +32,12 @@ kotlin {
     macosArm64()
     linuxX64()
     linuxArm64()
+    // androidNative (edge NPU / phone). io-safetensors has no posix in its own nativeMain —
+    // createRandomAccessSource / readTextFile are stubs and currentTimeMillis uses a monotonic
+    // TimeSource — so there is no bit-width metadata issue here (unlike io-core, whose posix pread
+    // needed the native64Main split). File-backed reads route through io-core's RandomAccessSource.
+    androidNativeArm32()
+    androidNativeArm64()
 
     js {
         browser()
@@ -54,8 +60,6 @@ kotlin {
                 implementation(libs.kotlinx.coroutines)
                 implementation(project(":skainet-lang:skainet-lang-core"))
                 implementation(project(":skainet-io:skainet-io-core"))
-                implementation(project(":skainet-compile:skainet-compile-core"))
-                implementation(project(":skainet-compile:skainet-compile-dag"))
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
Completes androidNative for the SafeTensors weight-loading path (follow-on to #836/#842 for io-core).

## What

Adds `androidNativeArm32()` / `androidNativeArm64()` to `skainet-io-safetensors` and removes its
two unused `skainet-compile-core` / `skainet-compile-dag` dependencies.

## Why it's clean

1. **The compile deps are dead.** There is no `sk.ainet.compile.*` reference anywhere in the
   module (any source set). They were the only commonMain deps lacking androidNative.
2. **No posix in its own nativeMain.** `createRandomAccessSource` and `readTextFile` are `null`
   stubs; `currentTimeMillis` uses `TimeSource.Monotonic`. So there is no bit-width metadata
   conflict here — unlike `io-core`, whose posix `pread` needed the `native64Main` split (#842).
   File-backed reads route through `io-core`'s `RandomAccessSource`.

After dropping the dead deps, `commonMain` depends only on `lang-core` + `io-core` (both
androidNative) + kotlinx, so the targets just needed declaring.

## Verification

`compileNativeMainKotlinMetadata`, `compileKotlinAndroidNativeArm32`, `compileKotlinAndroidNativeArm64`,
`compileKotlinJvm`, and `:skainet-io:skainet-io-safetensors:jvmTest` all green.

Unblocks on-device SafeTensors loading (the last io module that was jvm/linux-only) — e.g. an eager
on-device Moonshine ASR path on the 32-bit box / arm64 phones.
