### PR TITLE
[DOC]: Pin docker image with hash

### DIFF
--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -13,7 +13,7 @@
 #   3. Offline extras available but not forced: lunr full-text search,
 #      a pre-baked Antora UI bundle, and MathJax es5 for LaTeX.
 #   4. asciidoctor-kroki installed-but-unused as an escape hatch.
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 LABEL org.opencontainers.image.title="markup-antora" \
       org.opencontainers.image.description="Universal Antora site generator with offline Mermaid (mermaid-cli), offline search (lunr), pre-baked UI bundle + MathJax. No Kroki, no CDN." \


### PR DESCRIPTION
This ``PR`` pins the docker image used in ``docs`` with a hash to increase security.

The OpenSSF Score should increase after this ``PR`` has been merged.

The ``PR`` is linked to #594 and #814 and #815. I did not open an issue for this ``PR`` because the change is a little to small, and #815 is similar in spirit as it pins actions with the hash.