### PR TITLE
[DOCS]: Pin npm packages with their commit hash in Dockerfile

### DIFF
--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -50,14 +50,14 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # antora/site-generator: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # antora/lunr-extension: 41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
 # mermaid-js/mermaid-cli: a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
-# asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
+# asciidoctor-kroki: d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
       https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli/tree/a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
-      asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
+      https://github.com/asciidoctor/asciidoctor-kroki/tree/d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
 
 # Make installed modules resolvable even when the workdir is the mounted

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -57,7 +57,7 @@ RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
       https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli/tree/a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
-      https://github.com/asciidoctor/asciidoctor-kroki/tree/d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
+      https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
 
 # Make installed modules resolvable even when the workdir is the mounted

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -50,13 +50,14 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
 # @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
+# asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
-      asciidoctor-kroki@0.18 \
+      asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
 
 # Make installed modules resolvable even when the workdir is the mounted

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -49,14 +49,14 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # antora/cli: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # antora/site-generator: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # antora/lunr-extension: 41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
-# @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
+# mermaid-js/mermaid-cli: a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
 # asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
       https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
-      @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
+      https://github.com/mermaid-js/mermaid-cli/tree/a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
 

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -46,14 +46,14 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 #   - @antora/lunr-extension   : offline full-text search
 #   - asciidoctor-kroki        : escape hatch only; the playbook should
 #                                use the local mermaid extension instead.
-# @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
+# antora/cli: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
 # @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
 # asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
-      @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
+      https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -49,12 +49,13 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
+# @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
-      @mermaid-js/mermaid-cli@11 \
+      @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       asciidoctor-kroki@0.18 \
     && npm cache clean --force
 

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -46,9 +46,10 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 #   - @antora/lunr-extension   : offline full-text search
 #   - asciidoctor-kroki        : escape hatch only; the playbook should
 #                                use the local mermaid extension instead.
+# @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
-      @antora/cli@3.1 \
+      @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/site-generator@3.1 \
       @antora/lunr-extension@1.0.0-alpha.8 \
       @mermaid-js/mermaid-cli@11 \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -47,10 +47,11 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 #   - asciidoctor-kroki        : escape hatch only; the playbook should
 #                                use the local mermaid extension instead.
 # @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
+# @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
-      @antora/site-generator@3.1 \
+      @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/lunr-extension@1.0.0-alpha.8 \
       @mermaid-js/mermaid-cli@11 \
       asciidoctor-kroki@0.18 \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -47,14 +47,14 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 #   - asciidoctor-kroki        : escape hatch only; the playbook should
 #                                use the local mermaid extension instead.
 # antora/cli: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
-# @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
+# antora/site-generator: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
 # @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
 # asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
-      @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
+      https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
       @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -48,11 +48,12 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 #                                use the local mermaid extension instead.
 # @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
+# @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       @antora/cli@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       @antora/site-generator@aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
-      @antora/lunr-extension@1.0.0-alpha.8 \
+      @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       @mermaid-js/mermaid-cli@11 \
       asciidoctor-kroki@0.18 \
     && npm cache clean --force

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -48,14 +48,14 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 #                                use the local mermaid extension instead.
 # antora/cli: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
 # antora/site-generator: aa33c8283f9cbc76df93201bec5f8421e8f59a43 -> v3.1.15
-# @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
+# antora/lunr-extension: 41975fc8f62cb2219a2de2f618de1ae1482bd0ce -> v1.0.0-alpha.8
 # @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae -> v11.16.0
 # asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
-      @antora/lunr-extension@41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
+      https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       @mermaid-js/mermaid-cli@a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       asciidoctor-kroki@d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force


### PR DESCRIPTION
This ``PR`` pins all ``npm`` package installations in the ``Dockerfile`` used in the ``docs`` directory with their commit hash to increase security (#847).

The OpenSSF Score should increase after this ``PR`` has been merged.