### PR TITLE
[FIX]: Change URLs in npm install command

### DIFF
--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -61,10 +61,8 @@ RUN npm init -y && npm i --save-exact \
 RUN git clone https://gitlab.com/antora/antora.git \
     && cd antora \
     && git checkout aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
-    && cd packages/cli \
-    && npm install --save-exact \
-    && cd ../packages/site-generator \
-    && npm install --save-exact
+    && npm install --save-exact packages/cli \
+    && npm install --save-exact packages/site-generator
 
 # Make installed modules resolvable even when the workdir is the mounted
 # project (which has no node_modules of its own).

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -56,7 +56,7 @@ RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
       https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
-      https://github.com/mermaid-js/mermaid-cli/tree/a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
+      https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
 

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -53,11 +53,18 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # asciidoctor-kroki: d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
-      https://gitlab.com/antora/antora.git#aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
+
+RUN git clone https://gitlab.com/antora/antora.git \
+    && cd antora \
+    && git checkout aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
+    && cd packages/cli \
+    && npm install --save-exact \
+    && cd ../packages/site-generator \
+    && npm install --save-exact
 
 # Make installed modules resolvable even when the workdir is the mounted
 # project (which has no node_modules of its own).

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
-      https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
+      https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -53,8 +53,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # asciidoctor-kroki: d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
-      https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
-      https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
+      https://gitlab.com/antora/antora.git#aa33c8283f9cbc76df93201bec5f8421e8f59a43 \
       https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \


### PR DESCRIPTION
This ``PR`` fixes the broken ``npms`` install by changing the URLs, the bug was introduced by ``PR`` #848.