### PR TITLE
[FIX]: Change URLs in npm install command

### DIFF
--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -56,7 +56,7 @@ RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
       https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
-      https://github.com/mermaid-js/mermaid-cli/tree/a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
+      https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force
 

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -54,7 +54,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
-      https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
+      @antora/site-generator@3.1 \
       https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -53,7 +53,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # asciidoctor-kroki: d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
-      https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
+      @antora/cli@3.1 \
       @antora/site-generator@3.1 \
       https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -53,7 +53,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 # asciidoctor-kroki: d02fbf06cdb837524f5e4e12537c05e0bb83c715 -> v0.18
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
-      @antora/cli@3.1 \
+      @antora/cli@3.1.15 \
       @antora/site-generator@3.1 \
       https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -55,7 +55,7 @@ WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/cli \
       https://gitlab.com/antora/antora/-/tree/aa33c8283f9cbc76df93201bec5f8421e8f59a43/packages/site-generator \
-      https://gitlab.com/antora/antora-lunr-extension/-/commit/41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
+      https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \
     && npm cache clean --force

--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -54,7 +54,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
 WORKDIR /opt/antora
 RUN npm init -y && npm i --save-exact \
       @antora/cli@3.1.15 \
-      @antora/site-generator@3.1 \
+      @antora/site-generator@3.1.15 \
       https://gitlab.com/antora/antora-lunr-extension.git#41975fc8f62cb2219a2de2f618de1ae1482bd0ce \
       https://github.com/mermaid-js/mermaid-cli.git#a85b11df7064498d5b6b97ee9b2d4a7c10cb42ae \
       https://github.com/asciidoctor/asciidoctor-kroki.git#d02fbf06cdb837524f5e4e12537c05e0bb83c715 \


### PR DESCRIPTION
This ``PR`` fixes the broken ``npms`` install by changing the URLs, the bug was introduced by ``PR`` #848.

This fix has the shortcoming of rolling back the install commands of antora ``cli`` and antora ``site-generator`` to installation from the npm package repository. The problem with these two is that they are part of a mono-repository, where a lot of packages are developed. I was unable to find a solution where we can pin the installs with a commit hash.

PR #857 is a failed attempt.