### PR TITLE
[BUILD]: Pin serve install with commit hash

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -92,7 +92,7 @@ jobs:
           node-version: '18'
           
       - name: Install serve package
-        run: npm install -g serve
+        run: npm install -g git+https://github.com/vercel/serve.git#f3c702c6bb312c6d6b05315721a6d3ea245d86b8 #v14.2.6
         
       - name: Start preview server
         run: |


### PR DESCRIPTION
This ``PR`` pins the ``npm install -g serve`` with it's commit hash in ``documentation.yml``, and hereby  increases the security of the project (#847).

This ``PR`` changes the ``npm`` install of serve such that the commit hash is used. We do this by installing the package from ``GitHub``. The ``OpenSSF`` score should improve after this ``PR`` has been merged.