### PR TITLE
feat(nn): make Linear open for adapter subclasses

### DIFF
--- a/skainet-lang/skainet-lang-core/api/android/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/android/skainet-lang-core.api
@@ -754,7 +754,7 @@ public abstract class sk/ainet/lang/nn/InternalMixedPrecisionModule : sk/ainet/l
 	protected abstract fun forwardImpl (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 }
 
-public final class sk/ainet/lang/nn/Linear : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
+public class sk/ainet/lang/nn/Linear : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
 	public fun <init> (IILjava/lang/String;Lsk/ainet/lang/tensor/Tensor;)V
 	public fun <init> (IILjava/lang/String;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)V
 	public fun <init> (IILjava/lang/String;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Z)V
@@ -764,6 +764,7 @@ public final class sk/ainet/lang/nn/Linear : sk/ainet/lang/nn/Module, sk/ainet/l
 	public fun getName ()Ljava/lang/String;
 	public fun getParams ()Ljava/util/List;
 	public final fun getTrainable ()Z
+	protected fun onForward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/context/ExecutionContext;)Lsk/ainet/lang/tensor/Tensor;
 }
 
 public final class sk/ainet/lang/nn/MaxPool2d : sk/ainet/lang/nn/Module {

--- a/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
@@ -989,7 +989,7 @@ public final class sk/ainet/lang/nn/LayerScale : sk/ainet/lang/nn/Module, sk/ain
 	public fun getParams ()Ljava/util/List;
 }
 
-public final class sk/ainet/lang/nn/Linear : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
+public class sk/ainet/lang/nn/Linear : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {
 	public fun <init> (IILjava/lang/String;Lsk/ainet/lang/tensor/Tensor;)V
 	public fun <init> (IILjava/lang/String;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)V
 	public fun <init> (IILjava/lang/String;Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;Z)V
@@ -999,6 +999,7 @@ public final class sk/ainet/lang/nn/Linear : sk/ainet/lang/nn/Module, sk/ainet/l
 	public fun getName ()Ljava/lang/String;
 	public fun getParams ()Ljava/util/List;
 	public final fun getTrainable ()Z
+	protected fun onForward (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/context/ExecutionContext;)Lsk/ainet/lang/tensor/Tensor;
 }
 
 public final class sk/ainet/lang/nn/Lstm : sk/ainet/lang/nn/Module, sk/ainet/lang/nn/topology/ModuleParameters {

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/Linear.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/nn/Linear.kt
@@ -19,6 +19,9 @@ import sk.ainet.lang.nn.topology.weights
  * heads. A bias-less layer registers only the weight parameter, so parameter
  * counts and checkpoints match architectures defined without bias.
  *
+ * The class is `open` so adapter-style layers (e.g. LoRA) can subclass it and
+ * augment [onForward] or [params] while reusing the base projection.
+ *
  * @param inFeatures Number of input features
  * @param outFeatures Number of output features
  * @param name Name of the module
@@ -26,7 +29,7 @@ import sk.ainet.lang.nn.topology.weights
  * @param initBias Initial bias, or `null` for a layer without bias
  */
 
-public class Linear<T : DType, V> @kotlin.jvm.JvmOverloads constructor(
+public open class Linear<T : DType, V> @kotlin.jvm.JvmOverloads constructor(
     inFeatures: Int,
     outFeatures: Int,
     override val name: String = "Linear",


### PR DESCRIPTION
## What

Marks `Linear` as `open` so adapter-style layers can subclass it — the LoRA pattern (`class LinearWithLoRA : Linear`) that augments `onForward` with a low-rank update and `params` with the A/B matrices, while reusing the frozen base projection.

No behavioral change and no new members: the override points (`onForward`, `params`) were already open via `Module` / `ModuleParameters`; only the class itself was final. API dumps updated (the now-visible `protected onForward` surfaces in the dump because the class is subclassable).

## Motivation

Completes the toolkit for parameter-efficient finetuning on top of SKaiNET: with bias-less `Linear` (#870) and this change, an educational GPT port can express LoRA as a small subclass instead of reimplementing the layer. Follows the same from-scratch-then-upstream pattern as #866 (LR schedules), #867 (Dropout), #870 (bias-less Linear).
