### PR TITLE
feat(lang): add log (natural logarithm) tensor op (DARC #882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`log` (natural logarithm) tensor op** (`Tensor.log()` / `TensorOps.log`, DARC #882): element-wise `ln(x)`,
+  `@Diff` (gradient `1/x`), lowering to `stablehlo.log`. Unblocks DSL-authoring of learned frontends that use
+  `asinh` compression (`asinh(x) = log(x + √(x²+1))`), e.g. Moonshine v2 — so such models stay fully
+  DSL NN → DAG → StableHLO → IREE. Eager (`DefaultCpuOps`), void, and tracing impls; covered by `LogOpHloTest`.
+
 ## [0.19.1] - 2026-04-21
 
 ### Fixed

--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
@@ -2330,6 +2330,15 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
         return newTensor(outData, tensor.dtype, tensor)
     }
 
+    override fun <T : DType, V> log(tensor: Tensor<T, V>): Tensor<T, V> {
+        val outData = dataFactory.init<T, V>(tensor.shape, tensor.dtype) { idx ->
+            val x = tensor.data.get(*idx) as Float
+            @Suppress("UNCHECKED_CAST")
+            kotlin.math.ln(x) as V
+        }
+        return newTensor(outData, tensor.dtype, tensor)
+    }
+
     override fun <T : DType, V> sin(tensor: Tensor<T, V>): Tensor<T, V> {
         val outData = dataFactory.init<T, V>(tensor.shape, tensor.dtype) { idx ->
             val x = tensor.data.get(*idx) as Float

--- a/skainet-compile/skainet-compile-core/src/commonMain/kotlin/sk/ainet/tape/RecordingExecution.kt
+++ b/skainet-compile/skainet-compile-core/src/commonMain/kotlin/sk/ainet/tape/RecordingExecution.kt
@@ -433,6 +433,7 @@ internal class RecordingTensorOpsDecorator(private val base: TensorOps) : Tensor
     override fun <T : DType, V> indexSelect(input: Tensor<T, V>, indices: Tensor<DType, *>, dim: Int): Tensor<T, V> = base.indexSelect(input, indices, dim)
     override fun <T : DType, V> exp(tensor: Tensor<T, V>): Tensor<T, V> = base.exp(tensor)
     override fun <T : DType, V> expm1(tensor: Tensor<T, V>): Tensor<T, V> = base.expm1(tensor)
+    override fun <T : DType, V> log(tensor: Tensor<T, V>): Tensor<T, V> = base.log(tensor)
     override fun <T : DType, V> scaledDotProductAttention(
         query: Tensor<T, V>, key: Tensor<T, V>, value: Tensor<T, V>,
         mask: Tensor<T, V>?, scale: Float, causal: Boolean

--- a/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultExecutionTape.kt
+++ b/skainet-compile/skainet-compile-dag/src/commonMain/kotlin/sk/ainet/lang/graph/DefaultExecutionTape.kt
@@ -844,6 +844,11 @@ public class DefaultGradientTape(
         return listOf(ops.multiply(upstream, expX))
     }
 
+    override fun logBackward(upstream: Tensor<DType, Any>, output: Tensor<DType, Any>, inputs: List<Tensor<DType, Any>>, attributes: Map<String, Any?>): List<Tensor<DType, Any>?> {
+        // d(ln(x))/dx = 1/x
+        return listOf(upstream.ops.divide(upstream, inputs[0]))
+    }
+
     override fun scaledDotProductAttentionBackward(upstream: Tensor<DType, Any>, output: Tensor<DType, Any>, inputs: List<Tensor<DType, Any>>, attributes: Map<String, Any?>): List<Tensor<DType, Any>?> {
         // SDPA backward is complex; stub returns null gradients (not differentiable through this path).
         // Full backward would require recomputing attention weights from Q,K,V.

--- a/skainet-compile/skainet-compile-hlo/src/commonTest/kotlin/sk/ainet/compile/hlo/LogOpHloTest.kt
+++ b/skainet-compile/skainet-compile-hlo/src/commonTest/kotlin/sk/ainet/compile/hlo/LogOpHloTest.kt
@@ -1,0 +1,47 @@
+package sk.ainet.compile.hlo
+
+import sk.ainet.context.ExecutionContext
+import sk.ainet.lang.graph.DefaultExecutionTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.VoidOpsTensor
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.log
+import sk.ainet.lang.tensor.operators.bind
+import sk.ainet.lang.tensor.ops.VoidTensorOps
+import sk.ainet.lang.types.FP32
+import sk.ainet.tape.Execution
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for the `log` (natural logarithm) tensor op — added so learned frontends (e.g. Moonshine v2's
+ * asinh compression, `asinh(x) = log(x + sqrt(x²+1))`) can be authored in the DSL. Confirms the extension
+ * `Tensor.log()` traces through to a `stablehlo.log` primitive (the [UnaryMathConverter] mapping).
+ */
+class LogOpHloTest {
+    @Test
+    fun logTracesToStableHloLog() {
+        val input = VoidOpsTensor(
+            object : TensorData<FP32, Float> {
+                override val shape = Shape(2, 3)
+                override fun get(vararg indices: Int): Float = 1.0f
+                override fun set(vararg indices: Int, value: Float) {}
+            },
+            FP32::class,
+        )
+        val ctx = DefaultGraphExecutionContext.tape(baseOps = VoidTensorOps())
+        val tape = ctx.record {
+            val ct = (this as DefaultGraphExecutionContext).currentTape ?: error("no tape")
+            Execution.tapeStack.pushTape(ct)
+            try {
+                input.bind(this as ExecutionContext).log()   // bind to the recording ctx so the op is traced
+            } finally {
+                Execution.tapeStack.popTape()
+            }
+        }.first
+        val graph = (tape as DefaultExecutionTape).toComputeGraph(synthesizeExternalInputs = true)
+        val mlir = sk.ainet.compile.hlo.toStableHlo(graph, "log_test").content
+        assertTrue(mlir.contains("stablehlo.log"), "Tensor.log() must lower to stablehlo.log; got:\n$mlir")
+    }
+}

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/TensorExtensions.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/TensorExtensions.kt
@@ -67,6 +67,8 @@ public fun <T : DType, V> Tensor<T, V>.silu(): Tensor<T, V> = ops.silu(this)
 public fun <T : DType, V> Tensor<T, V>.gelu(): Tensor<T, V> = ops.gelu(this)
 public fun <T : DType, V> Tensor<T, V>.exp(): Tensor<T, V> = ops.exp(this)
 public fun <T : DType, V> Tensor<T, V>.expm1(): Tensor<T, V> = ops.expm1(this)
+/** Element-wise natural logarithm: ln(x). */
+public fun <T : DType, V> Tensor<T, V>.log(): Tensor<T, V> = ops.log(this)
 public fun <T : DType, V> Tensor<T, V>.softmax(dim: Int = -1): Tensor<T, V> = ops.softmax(this, dim)
 public fun <T : DType, V> Tensor<T, V>.logSoftmax(dim: Int = -1): Tensor<T, V> = ops.logSoftmax(this, dim)
 public fun <T : DType, V> Tensor<T, V>.sum(dim: Int? = null): Tensor<T, V> = ops.sum(this, dim)

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/TensorOps.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/TensorOps.kt
@@ -249,6 +249,10 @@ public interface TensorOps {
     @ActivationDsl
     public fun <T : DType, V> expm1(tensor: Tensor<T, V>): Tensor<T, V>
 
+    /** Element-wise natural logarithm: ln(x). Differentiable (grad = 1/x). Lowers to `stablehlo.log`. */
+    @Diff
+    public fun <T : DType, V> log(tensor: Tensor<T, V>): Tensor<T, V>
+
     // Trigonometric operations
     public fun <T : DType, V> sin(tensor: Tensor<T, V>): Tensor<T, V> {
         throw NotImplementedError("sin not implemented by this TensorOps backend")

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/VoidTensorOps.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/ops/VoidTensorOps.kt
@@ -457,6 +457,11 @@ public class VoidTensorOps : TensorOps {
         return VoidOpsTensor(resultData, tensor.dtype)
     }
 
+    override fun <T : DType, V> log(tensor: Tensor<T, V>): Tensor<T, V> {
+        val resultData = dataFactory.zeros<T, V>(tensor.shape, tensor.dtype)
+        return VoidOpsTensor(resultData, tensor.dtype)
+    }
+
     override fun <T : DType, V> sin(tensor: Tensor<T, V>): Tensor<T, V> {
         val resultData = dataFactory.zeros<T, V>(tensor.shape, tensor.dtype)
         return VoidOpsTensor(resultData, tensor.dtype)


### PR DESCRIPTION
Implements #882 following DARC. Element-wise `ln(x)`, `@Diff` (grad 1/x), lowering to `stablehlo.log`.

**Why:** unblocks DSL-authoring of learned audio frontends that use `asinh` compression
(`asinh(x) = log(x + √(x²+1))`) — e.g. **Moonshine v2's frontend** — so such models stay fully
DSL NN → DAG → StableHLO → IREE (runnable on any IREE runtime) instead of falling back to a vendor ONNX graph.

**Changes:** `TensorOps.log` (abstract, `@Diff`, KDoc) + `Tensor.log()` extension; eager `DefaultCpuOps`
(`kotlin.math.ln`), `VoidTensorOps`, `RecordingExecution` delegation; `logBackward` (1/x) in
`DefaultGradientTape`. The `UnaryMathConverter` already mapped `log → stablehlo.log` and the KSP tracing
processor already listed `log`, so only the front + gradient were missing.

**Test:** `LogOpHloTest` — `Tensor.log()` traces to `stablehlo.log` (passes). Affected modules build.

Closes #882