### PR TITLE
[BUILD]: Add least privilege principle to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
     permissions:
       contents: read
-      
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,6 +108,10 @@ jobs:
     name: assemble
     runs-on: ubuntu-latest
     timeout-minutes: 40
+
+    permissions:
+      contents: read
+      
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Set all permissions to none
+permissions: {}
+
 jobs:
   # `allTests` used to run in a single job alongside `assemble`. On a 7 GB
   # ubuntu-latest runner the combined peak RSS (Gradle JVM + Kotlin daemon +

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
             tasks: jsTest wasmJsTest wasmWasiTest
           - name: native
             tasks: linuxX64Test
+
+    permissions:
+      contents: read
+      
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
This ``PR`` adds the least privilege principle to the ``build.yml`` workflow by setting all permissions to ``none`` at the workflow level, and then adding the permission for ``contents`` to ``read`` for the ``test´` job (#898).

The OpenSSF Score should increase after this ``PR`` has been merged.