### PR TITLE
docs(readme): add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-View%20Docs-blue?logo=readthedocs&logoColor=white)](https://deepwiki.com/SKaiNET-developers/SKaiNET)
 [![REUSE status](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)](https://api.reuse.software/badge/github.com/SKaiNET-developers/SKaiNET)
 [![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/SKaiNET-developers/SKaiNET/badge)](https://scorecard.dev/viewer/?uri=github.com/SKaiNET-developers/SKaiNET)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14004/badge)](https://www.bestpractices.dev/projects/14004)
 
 
 <img src="docs/modules/ROOT/images/SKaiNET-logo.png" alt="SKaiNET logo" width="150">


### PR DESCRIPTION
Adds the OpenSSF Best Practices badge for project [14004](https://www.bestpractices.dev/projects/14004) to the README badge row, next to the existing OpenSSF Scorecard badge.

```markdown
[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14004/badge)](https://www.bestpractices.dev/projects/14004)
```

## Heads-up: it currently renders "in progress 24%", not "passing"

The badge image is generated live from the project's current criteria state, and right now that is:

```json
{ "id": 14004, "name": "SKaiNET", "badge_level": "in_progress", "tiered_percentage": 24 }
```

so the SVG renders `openssf best practices: in progress 24%`. The `/en/projects/14004/passing` URL is the *passing-level criteria page* — the tab listing what passing requires — not a statement that the project has reached it.

Nothing to fix in this PR: the badge is dynamic and flips to `passing` on its own once the criteria are filled in at https://www.bestpractices.dev/en/projects/14004/passing. Merging now means the README tracks that progress rather than needing a follow-up edit. If you'd rather the row only ever show green badges, hold this until the percentage is up.

Also worth noting the badge is linked to the un-suffixed project URL (`/projects/14004`) rather than `/en/projects/14004/passing`, so it lands on the project overview in the reader's own language and does not go stale if the project later moves to silver or gold.

## Verification

- `https://www.bestpractices.dev/projects/14004/badge` → HTTP 200, valid SVG
- `repo_url` on the project record is `https://github.com/SKaiNET-developers/SKaiNET`, so the badge points at this repo
- README-only change; no build or CI impact
