### PR TITLE
ci: give every workflow a least-privilege GITHUB_TOKEN

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,15 +36,17 @@ concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Set default permission for all jobs to none. The Pages write grants live on
+# deploy-docs alone — build-docs only reads the repo and uploads an artifact.
+permissions: {}
 
 jobs:
   build-docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -135,6 +137,12 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+
+    # actions/deploy-pages needs pages:write to publish and id-token:write for
+    # the OIDC token it exchanges. It does not check the repository out.
+    permissions:
+      pages: write
+      id-token: write
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,15 +16,18 @@ on:
       - 'docs/**'
       - '.github/workflows/documentation.yml'
 
-permissions:
-  contents: read
-  pull-requests: write
+# Set default permission for all jobs to none. Only preview-documentation posts
+# the PR comment, so pull-requests:write lives there rather than build-wide.
+permissions: {}
 
 jobs:
   build-documentation:
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    
+
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,7 +81,13 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: build-documentation
     runs-on: ubuntu-latest
-    
+
+    # Posts the preview comment via actions/github-script. PR comments are issue
+    # comments, so pull-requests:write is what listComments/createComment need.
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Download documentation artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -34,6 +34,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Set default permission for all jobs to none
+permissions: {}
+
 jobs:
   smoke-ubuntu-latest:
     # Smoke pack on the default GitHub runner. Goal: prove the harness +
@@ -42,6 +45,10 @@ jobs:
     # runner, shared tenancy, no warmup steady-state.
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -92,6 +99,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: [self-hosted, linux, x86_64, skainet-bench-linux-x86]
     timeout-minutes: 120
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -10,10 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Set default permission for all jobs to none
+permissions: {}
+
 jobs:
   java-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/native-cpu-multiarch.yml
+++ b/.github/workflows/native-cpu-multiarch.yml
@@ -30,6 +30,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Set default permission for all jobs to none
+permissions: {}
+
 jobs:
   native-build-test:
     name: ${{ matrix.arch_label }}
@@ -52,6 +55,9 @@ jobs:
             lib_name: skainet_kernels.dll
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,11 @@ on:
     tags:
       - '**'
 
+# Set default permission for all jobs to none. Publishing authenticates to Maven
+# Central and signs with GPG through repository secrets, which are independent of
+# GITHUB_TOKEN — nothing here needs write access to the repository itself.
+permissions: {}
+
 jobs:
   build-native:
     name: native ${{ matrix.arch_label }}
@@ -49,6 +54,10 @@ jobs:
             lib_name: skainet_kernels.dll
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -91,6 +100,10 @@ jobs:
     name: Release build and publish
     needs: build-native
     runs-on: macOS-latest
+
+    permissions:
+      contents: read
+
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -9,9 +9,15 @@ on:
       - 'skainet-lang/**'
       - '.github/workflows/schema-validation.yml'
 
+# Set default permission for all jobs to none
+permissions: {}
+
 jobs:
   validate-schema:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code

--- a/.github/workflows/verify-poms.yml
+++ b/.github/workflows/verify-poms.yml
@@ -10,11 +10,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Set default permission for all jobs to none
+permissions: {}
+
 jobs:
   verify-poms:
     name: Publish to Maven local and validate POM coordinates
     runs-on: ubuntu-latest
     timeout-minutes: 45
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes the OpenSSF Scorecard **Token-Permissions** check (currently scoring **0/10**, severity high), and the matching `TokenPermissionsID` code-scanning alerts.

## The reported problem

Six workflows declared no top-level `permissions`, so they inherited whatever the repository default grants — historically read/write on everything:

```
Warn: no topLevel permission defined: .github/workflows/engine-benchmarks.yml:1
Warn: no topLevel permission defined: .github/workflows/java-tests.yml:1
Warn: no topLevel permission defined: .github/workflows/native-cpu-multiarch.yml:1
Warn: no topLevel permission defined: .github/workflows/publish.yml:1
Warn: no topLevel permission defined: .github/workflows/schema-validation.yml:1
Warn: no topLevel permission defined: .github/workflows/verify-poms.yml:1
```

All six now follow the pattern `build.yml` and `reuse-compliance.yml` already used — top-level `permissions: {}` with per-job grants — so this introduces no new convention.

## What each workflow actually needs

Every one of the six is read-only CI: `checkout`, `setup-java`, `cache`, `upload-artifact`. `contents: read` is the entire requirement.

Two cases that look like they need more but do not:

- **`upload-artifact` / `download-artifact`** authenticate with the Actions runtime token (`ACTIONS_RUNTIME_TOKEN`), not `GITHUB_TOKEN`. Restricting `permissions` does not affect them.
- **`publish.yml`** reaches Maven Central and GPG through `secrets.MAVEN_CENTRAL_*` / `secrets.GPG_PRIVATE_KEY` / `secrets.SIGNING_PASSWORD`. Repository secrets are independent of `GITHUB_TOKEN` permissions, and the workflow creates no GitHub Release, so it needs no write access to the repository itself.

## Also: two top-level write grants moved down

This is the other half of what the check penalises — a top-level write reaches *every* job in the file, not just the one that needs it.

| Workflow | Was | Now |
|---|---|---|
| `docs.yml` | top-level `pages: write` + `id-token: write`, reaching `build-docs` too | on `deploy-docs` only; `build-docs` gets `contents: read` |
| `documentation.yml` | top-level `pull-requests: write`, reaching `build-documentation` too | on `preview-documentation` only; `build-documentation` gets `contents: read` |

`build-docs` only checks out and uploads a Pages artifact — `actions/upload-pages-artifact` does not need `pages: write` (there is no `configure-pages` step in this workflow). `deploy-docs` runs `actions/deploy-pages`, which needs `pages: write` to publish and `id-token: write` for the OIDC exchange, and never checks the repository out.

## Result

Every workflow now has a top-level permission block, none holds a write at top level, and no job holds a permission it does not exercise:

| Workflow | Top | Job grants |
|---|---|---|
| build.yml | `{}` | test / assemble `contents: read`; build-job none |
| docs.yml | `{}` | build-docs `contents: read`; deploy-docs `pages: write`, `id-token: write` |
| documentation.yml | `{}` | build `contents: read`; preview `contents: read`, `pull-requests: write` |
| engine-benchmarks.yml | `{}` | both jobs `contents: read` |
| java-tests.yml | `{}` | `contents: read` |
| native-cpu-multiarch.yml | `{}` | `contents: read` |
| openssf-scorecard.yml | `{}` | unchanged (needs `security-events: write`) |
| publish.yml | `{}` | both jobs `contents: read` |
| reuse-compliance.yml | `{}` | `contents: read` |
| schema-validation.yml | `{}` | `contents: read` |
| verify-poms.yml | `{}` | `contents: read` |

## Verification and its limits

All 11 files parse, and a script asserts every workflow has a top-level block, no top-level write, and every job's grants are declared.

**Two paths this PR's CI cannot exercise, and a reviewer should know that:**

- `publish.yml` only triggers on tag push. The reasoning above (secrets are independent of `GITHUB_TOKEN`; no Release is created) is sound, but it is unproven until the next release tag.
- `docs.yml`'s `deploy-docs` only triggers on a published release, so the Pages deploy is likewise untested here.

Everything else — build, java-tests, verify-poms, schema-validation, native-cpu-multiarch, reuse-compliance, documentation — runs on this PR and is proven by its own checks.
