### PR TITLE
ci(publish): build & publish the skainet-backend-jni-cpu AAR on release (#946)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,12 @@ name: release
 #     resources.srcDir(nativeResourcesRoot) on jvmMain picks them all
 #     up into the published JAR.
 #
+# The publish job also builds and publishes the skainet-backend-jni-cpu AAR
+# (Android JNI kernel provider). Its native .so's are cross-compiled by the
+# NDK during `./gradlew publish`, so the publish runner sets up the Android
+# SDK + a pinned NDK (see the publish job) — independent of the build-native
+# matrix above, which only produces the FFM shared libs.
+#
 # Linux ARM64 is intentionally absent: Kotlin/Native plugin 2.3.21
 # doesn't support `linux aarch64` as a HOST target ("Unknown host
 # target" — see SKaiNET PR #577). Linux ARM64 consumers fall back
@@ -138,6 +144,22 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 25
+
+      # `./gradlew publish` now includes skainet-backend-jni-cpu (an Android
+      # library whose AAR carries NDK-built .so's). The publish runner therefore
+      # needs the Android SDK + a pinned NDK; without it the AAR's native build
+      # fails and the release ships no JNI artifact. The NDK version must match
+      # gradle/libs.versions.toml `android-ndk`.
+      - name: Set up Android SDK
+        # NOTE (maintainer): pin to a commit SHA per repo convention before merge —
+        # this tag is used only because the SHA can't be verified from the dev box.
+        uses: android-actions/setup-android@v3
+
+      - name: Install pinned NDK
+        run: |
+          NDK_VERSION="$(grep -E '^android-ndk[[:space:]]*=' gradle/libs.versions.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "Installing NDK ${NDK_VERSION}"
+          yes | sdkmanager "ndk;${NDK_VERSION}" >/dev/null
 
       - name: Validate signing configuration
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,9 +151,7 @@ jobs:
       # fails and the release ships no JNI artifact. The NDK version must match
       # gradle/libs.versions.toml `android-ndk`.
       - name: Set up Android SDK
-        # NOTE (maintainer): pin to a commit SHA per repo convention before merge —
-        # this tag is used only because the SHA can't be verified from the dev box.
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
       - name: Install pinned NDK
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### CI
+
+- **Release workflow publishes the `skainet-backend-jni-cpu` AAR.** `./gradlew publish` now
+  includes the Android JNI kernel module, whose AAR carries NDK-cross-built `.so`s; the publish
+  job gains Android SDK + a pinned NDK setup so the native build succeeds on the release runner
+  (previously the release would ship no JNI artifact, or fail). The NDK version is pinned in
+  `gradle/libs.versions.toml` (`android-ndk`) and referenced by the module's `ndkVersion` and the
+  workflow, so local and CI builds are reproducible. (#946)
+
 ### Added
 
 - **NEON body for the Q4_0 matmul kernel.** `skainet_q4_0_matmul` was the only priority

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,10 @@ kotlinxCoroutines = "1.11.0"
 kotlinBrowser = "0.5.0"
 android-minSdk = "24"
 android-compileSdk = "36"
+# NDK for skainet-backend-jni-cpu's externalNativeBuild. Pinned so the AAR's
+# .so's build reproducibly on dev machines and the release runner. r28+ links
+# 16 KB-page-aligned .so's by default (Android 15+ requirement).
+android-ndk = "28.2.13676358"
 kotlinxSerializationJson = "1.11.0"
 ktorClientCore = "3.5.2"
 ktorClientPlugins = "3.1.1"

--- a/skainet-backends/skainet-backend-jni-cpu/build.gradle.kts
+++ b/skainet-backends/skainet-backend-jni-cpu/build.gradle.kts
@@ -23,6 +23,9 @@ plugins {
 android {
     namespace = "sk.ainet.exec.kernel.jni"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
+    // Pinned NDK so the AAR's .so's build reproducibly locally and on the
+    // release runner (AGP provisions it via sdkmanager when absent).
+    ndkVersion = libs.versions.android.ndk.get()
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()


### PR DESCRIPTION
Closes the AAR-publishing gap from the 0.39.0 release checklist (#946). Since the JNI module merged to develop, `./gradlew publish` (macOS publish job) now includes an Android library whose AAR carries NDK-cross-built `.so`s — but the runner has no Android SDK/NDK, so a release would fail to build the AAR or ship no JNI artifact. That artifact is the whole Android NEON win (**~24 tok/s** SmolLM2-135M decode measured on a Pixel 8a vs 3.8 scalar), so it has to be in the release.

## Changes

- **Pin the NDK** in `gradle/libs.versions.toml` (`android-ndk = 28.2.13676358`) and reference it from the module's `ndkVersion` — reproducible `.so` builds on dev machines and CI. r28+ links 16 KB-page-aligned `.so`s (Android 15+).
- **publish.yml publish job**: set up the Android SDK and install the pinned NDK (version read from the catalog) before `./gradlew publish`. Independent of the `build-native` matrix (which only makes the FFM shared libs).

## Verified locally

`publishToMavenLocal` produces a complete artifact:
```
skainet-backend-jni-cpu-<v>.aar        (arm64-v8a + x86_64: libskainet_jni.so + libskainet_jni_v82.so)
  proguard.txt                          (consumer ServiceLoader/JNI keep rules)
skainet-backend-jni-cpu-<v>.pom         (groupId sk.ainet.core, dep skainet-backend-api)
  + sources.jar, javadoc.jar, .module
```
`assembleRelease` green with the pinned NDK; `publish.yml` passes `yaml.safe_load`.

## Needs a maintainer eye

1. **Pin `android-actions/setup-android` to a commit SHA** per repo convention — I left it as `@v3` with an inline note because I couldn't verify the SHA offline.
2. The workflow change itself is only fully exercised by a real tagged release (or a fork tag). The Gradle side is verified locally; the CI YAML is not.

Part of the #946 release checklist; prerequisite for the mobile NEON work to be consumable by SKaiNET-transformers apps.

Refs #946 #920