### PR TITLE
docs(readme): point LLM users to SKaiNET-transformers (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- **README points LLM users to SKaiNET-transformers**
+  ([#923](https://github.com/SKaiNET-developers/SKaiNET/issues/923)): a callout under
+  "Start in 5 minutes" says plainly that LLM inference lives in the
+  SKaiNET-transformers repository — this repo is the engine underneath — and names
+  the `sk.ainet.transformers` artifacts and BOM to depend on.
+
 ## [0.39.0] - 2026-08-10
 
 Headline: **on-device AI on Android becomes real.** A JNI NEON kernel backend

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ matches what you want to try first.
 Working in Java? SKaiNET ships first-class Java support — see the
 [Java getting-started guide](docs/modules/ROOT/pages/tutorials/java-getting-started.adoc).
 
+> [!NOTE]
+> **Looking for LLM inference?** Llama, Qwen, Gemma, Apertus, BERT embeddings and
+> GGUF chat models live in
+> [**SKaiNET-transformers**](https://github.com/SKaiNET-developers/SKaiNET-transformers) —
+> this repository is the engine underneath it (tensors, NN DSL, compiler, CPU/native
+> backends, GGUF/SafeTensors IO). Depend on the `sk.ainet.transformers` artifacts,
+> pinned together by the
+> [transformers BOM](https://central.sonatype.com/artifact/sk.ainet.transformers/skainet-transformers-bom).
+
 Use the version shown in this README as the source of truth for first-run snippets.
 If another page shows a different version, please open an issue or PR.
 


### PR DESCRIPTION
Closes #923.

Adds a `> [!NOTE]` callout right under the "Start in 5 minutes" table (the existing transformers-starter table row is easy to skim past when arriving from search): LLM inference — Llama, Qwen, Gemma, Apertus, BERT embeddings, GGUF chat models — lives in [SKaiNET-transformers](https://github.com/SKaiNET-developers/SKaiNET-transformers); this repository is the engine underneath it. Names the `sk.ainet.transformers` artifacts and the transformers BOM to depend on.

Docs-only (README + CHANGELOG). Ride-along candidate for the 0.39.1 patch release alongside #950.