### PR TITLE
ci(docs): deploy on push to develop instead of a GitHub Release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,20 @@ name: Docs
 
 # Build the Antora site (with generated operator pages and the
 # cross-backend coverage matrix) on every PR and push, and publish to
-# GitHub Pages when a release is published, so the live site tracks the
-# last released version. Dokka API bundling is wired in commit 6 of the
+# GitHub Pages on every push to develop, so the live site tracks the
+# last merge. Dokka API bundling is wired in commit 6 of the
 # docs-to-Antora migration (see issue #494).
+#
+# Previously gated the deploy on `release: published`, matching the
+# stated intent of "canonical site = latest release" — but this repo's
+# actual release process only ever pushes a git tag, never a GitHub
+# Release object, so that trigger has never once fired (issue #975).
+# Deploying on every push to develop instead — same as
+# SKaiNET-transformers' docs.yml — guarantees the site is never more
+# than one merge behind, and is simpler than the release-gated version
+# nobody was exercising. Revisit this pairing with #976 (versioned
+# docs) if "canonical site = latest release" needs to come back as a
+# distinct, working thing rather than "whatever's latest on develop".
 
 on:
   push:
@@ -22,14 +33,6 @@ on:
       - 'build.gradle.kts'
       - 'build-logic/**'
       - 'skainet-lang/skainet-lang-core/**'
-  # Publish on release: the live site tracks the last released version.
-  # `release: published` is immune to the `paths:` filter above (so every
-  # release rebuilds docs) and checks out the released commit, where
-  # `generateDocs`/`dokkaGenerate` run live against the working tree — no
-  # need to commit generated pages. Single-version for now; a dedicated
-  # multi-repo aggregation site can come later (see issue #494).
-  release:
-    types: [ published ]
   workflow_dispatch:
 
 concurrency:
@@ -128,10 +131,11 @@ jobs:
           path: docs/build/site
 
   deploy-docs:
-    # Canonical site = latest release. Deploy only on a published release;
-    # develop/main pushes still run build-docs above for validation but no
-    # longer publish to Pages.
-    if: github.event_name == 'release'
+    # Deploy on every push to develop that touched docs-relevant paths (see
+    # the `on: push: paths:` filter above) — matches SKaiNET-transformers'
+    # docs.yml. PR builds and pushes to other branches still run build-docs
+    # for validation but don't publish.
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     needs: build-docs
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary

Fixes #975. `deploy-docs` was gated on `github.event_name == 'release'`, matching
the docs' stated intent that the canonical site tracks the latest release. But this
repo's release process only ever pushes a git tag (`0.40.1`, `0.39.1`, ...) — no
GitHub Release object is ever created (`gh release list` returns empty). Confirmed
via Actions history: every historical `docs.yml` run was a `push` or `pull_request`
event; `release` has never fired once. The live site
(https://skainet-developers.github.io/SKaiNET/skainet/) has been frozen since
whatever deployed it outside this workflow — missing content that's been on
`develop` for a while, e.g. SKEEP-002/SKEEP-003 (present in `nav.adoc`/`index.adoc`,
reachable from tag `0.40.1`, invisible on the live site).

## Fix

Deploy on every push to `develop` instead — matches how
`SKaiNET-transformers`' `docs.yml` already does it (`if: github.ref ==
'refs/heads/develop' && github.event_name == 'push'`), a pattern that's actually
proven to fire in that repo's Actions history. The existing `paths:` filter on the
`push` trigger already scopes rebuilds to docs-relevant changes
(`docs/**`, the workflow file, `build.gradle.kts`, `build-logic/**`,
`skainet-lang/skainet-lang-core/**`), so this doesn't change *when* the site
rebuilds for validation — only makes successful builds on `develop` actually
publish.

Dropped the now-dead `release: types: [published]` trigger entirely rather than
leaving it wired to nothing, to avoid the same "looks like it does something, does
nothing" confusion that caused this bug in the first place.

## Not in scope

- Versioning the docs site (multiple simultaneous versions) — tracked separately at
  #976, deliberately independent of this fix (this issue is "the single current
  version doesn't deploy at all"; #976 is "there's only ever one version to begin
  with").
- Restoring "canonical site = latest release" as a literal, working behavior (e.g.
  by having the release process create real GitHub Releases) — noted as an
  alternative fix option in #975 but not the one taken here; left as a future option
  if that framing turns out to matter more than "always current with develop".

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"` — valid YAML
- No other logic changed — `build-docs` job, Antora build steps, and Dokka bundling untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)