### PR TITLE
chore(bcv): refresh stale skainet-compile-hlo API dump (pre-existing apiCheck failure on develop)

### DIFF
--- a/skainet-compile/skainet-compile-hlo/api/jvm/skainet-compile-hlo.api
+++ b/skainet-compile/skainet-compile-hlo/api/jvm/skainet-compile-hlo.api
@@ -314,16 +314,22 @@ public final class sk/ainet/compile/hlo/StableHloTextWriter : sk/ainet/compile/e
 }
 
 public final class sk/ainet/compile/hlo/TypeMapper {
+	public static final field Companion Lsk/ainet/compile/hlo/TypeMapper$Companion;
+	public static final field DYNAMIC_DIM I
 	public fun <init> ()V
 	public final fun areTypesCompatible (Lsk/ainet/lang/tensor/ops/TensorSpec;Lsk/ainet/lang/tensor/ops/TensorSpec;)Z
 	public final fun createDynamicTensorType (ILjava/lang/String;)Ljava/lang/String;
 	public final fun createTensorType (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+	public final fun formatShape (Ljava/util/List;)Ljava/lang/String;
 	public final fun getScalarType (Ljava/lang/String;)Ljava/lang/String;
 	public final fun inferBroadcastType (Lsk/ainet/lang/tensor/ops/TensorSpec;Lsk/ainet/lang/tensor/ops/TensorSpec;)Lsk/ainet/lang/tensor/ops/TensorSpec;
 	public final fun mapDType (Ljava/lang/String;)Ljava/lang/String;
 	public final fun mapFunctionSignature (Ljava/util/List;Ljava/util/List;)Ljava/lang/String;
 	public final fun mapTensorType (Lsk/ainet/lang/tensor/ops/TensorSpec;)Ljava/lang/String;
 	public final fun negInfBits (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class sk/ainet/compile/hlo/TypeMapper$Companion {
 }
 
 public final class sk/ainet/compile/hlo/converters/ActivationOperationsConverter : sk/ainet/compile/hlo/StableHloOperationConverter {


### PR DESCRIPTION
## Summary

`./gradlew apiCheck` fails on `develop` for `:skainet-compile:skainet-compile-hlo`: `TypeMapper.DYNAMIC_DIM`, `TypeMapper.formatShape(...)` and the `TypeMapper.Companion` were added without regenerating `skainet-compile/skainet-compile-hlo/api/jvm/skainet-compile-hlo.api` (CI runs per-target `*Test` legs and never `apiCheck`, so it went unnoticed). Regenerated with `./gradlew apiDump` — **additions only, no source change**.

Split out of #1045 so that the memory-architecture slices (#932 → #1001) can keep `apiCheck` in their local PR gate; #1045 will be rebased onto `develop` once this is merged.

## Test plan

Full local gate (JDK 25): `jvmTest` ✔ (3m 53s) · `apiCheck` ✔ · `verifyNpmPins jsTest wasmJsTest wasmWasiTest` ✔ (2m 25s) · `linuxX64Test` ✔ · `assemble` ✔ · `:skainet-test:skainet-test-java:test` ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)