### PR TITLE
refactor(storage): deprecate LogicalDType, fromDType/toLogicalDType, logicalType getters and overloads (SKEEP-003 P0, S0.2b)

### DIFF
--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/StorageIntegrationTest.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/StorageIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.io.gguf
 
 import org.junit.Test

--- a/skainet-io/skainet-io-safetensors/src/commonTest/kotlin/sk/ainet/io/safetensors/StorageAwareSafeTensorsLoaderTest.kt
+++ b/skainet-io/skainet-io-safetensors/src/commonTest/kotlin/sk/ainet/io/safetensors/StorageAwareSafeTensorsLoaderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.io.safetensors
 
 import sk.ainet.io.RandomAccessSource

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/LogicalDType.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/LogicalDType.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // this file *is* the deprecated type
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.types.BF16
@@ -23,6 +25,10 @@ import sk.ainet.lang.types.Ternary
  * values are physically stored. A tensor with logical type [FLOAT32] might
  * be encoded as [TensorEncoding.Dense], [TensorEncoding.Q4_K], etc.
  */
+@Deprecated(
+    message = "LogicalDType merges into DType (SKEEP-003 decision #13): use the DType objects (FP32, Int8, …) and the dtype-first constructors/overloads.",
+    replaceWith = ReplaceWith("DType", "sk.ainet.lang.types.DType"),
+)
 public enum class LogicalDType(
     public val sizeInBits: Int,
     public val isFloatingPoint: Boolean,
@@ -78,6 +84,10 @@ public enum class LogicalDType(
          * The [LogicalDType] for a [DType]. Inverse of [toDType]; prefer the extension
          * [sk.ainet.lang.tensor.storage.toLogicalDType] at call sites.
          */
+        @Deprecated(
+            message = "LogicalDType merges into DType (SKEEP-003 decision #13); the DType object itself is the logical type.",
+            replaceWith = ReplaceWith("dtype"),
+        )
         public fun fromDType(dtype: DType): LogicalDType = when (dtype) {
             is Ternary -> TERNARY
             is Int4 -> INT4

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/LogicalDTypeBridge.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/LogicalDTypeBridge.kt
@@ -1,4 +1,5 @@
 @file:JvmName("DTypeBridge")
+@file:Suppress("DEPRECATION") // the bridge exists to keep the deprecated type usable until removal
 
 package sk.ainet.lang.tensor.storage
 
@@ -19,4 +20,8 @@ import kotlin.jvm.JvmName
  * When `LogicalDType` is deprecated (decision #13, separate slice) its `ReplaceWith` targets
  * point at `DType` directly and this extension becomes a no-op shim.
  */
+@Deprecated(
+    message = "LogicalDType merges into DType (SKEEP-003 decision #13); keep the DType itself.",
+    replaceWith = ReplaceWith("this"),
+)
 public fun DType.toLogicalDType(): LogicalDType = LogicalDType.fromDType(this)

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/PackedBlockStorage.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/PackedBlockStorage.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape
@@ -63,6 +65,7 @@ public interface PackedBlockStorage {
     /**
      * Convert this packed storage to a [TensorStorage] descriptor.
      */
+    @Deprecated(message = "Use toTensorStorage(dtype, placement) (SKEEP-003 decision #13).", replaceWith = ReplaceWith("toTensorStorage(dtype, placement)"))
     public fun toTensorStorage(
         logicalType: LogicalDType = LogicalDType.FLOAT32,
         placement: Placement = Placement.CPU_HEAP

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/StorageMemoryReport.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/StorageMemoryReport.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape
@@ -10,6 +12,7 @@ import sk.ainet.lang.tensor.Shape
  */
 public data class StorageMemoryReport(
     val shape: Shape,
+    @Deprecated(message = "Use dtype (SKEEP-003 decision #13).", replaceWith = ReplaceWith("dtype"))
     val logicalType: LogicalDType,
     val encoding: TensorEncoding,
     val ownership: Ownership,

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/StorageSpec.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/StorageSpec.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // StorageSpec is itself deprecated and built on LogicalDType; both go at the next major
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.memory.AllocationSpec

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/TensorStorage.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/TensorStorage.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // keeps the LogicalDType primary constructor working until the next major
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape
@@ -22,6 +24,10 @@ import sk.ainet.lang.types.DType
  */
 public data class TensorStorage(
     val shape: Shape,
+    @Deprecated(
+        message = "Use dtype (SKEEP-003 decision #13); the LogicalDType view stays until the next major.",
+        replaceWith = ReplaceWith("dtype"),
+    )
     val logicalType: LogicalDType,
     val encoding: TensorEncoding,
     val buffer: BufferHandle,

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/TensorStorageFactory.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/TensorStorageFactory.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // the LogicalDType overloads stay as delegating shims until the next major
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape
@@ -72,6 +74,7 @@ public object TensorStorageFactory {
      * Create storage from raw bytes with explicit encoding.
      * The byte array is borrowed (not copied).
      */
+    @Deprecated(message = "Use the DType overload (SKEEP-003 decision #13).", replaceWith = ReplaceWith("fromRawBytes(shape, dtype, encoding, …)"))
     public fun fromRawBytes(
         shape: Shape,
         logicalType: LogicalDType,
@@ -98,6 +101,7 @@ public object TensorStorageFactory {
     /**
      * Create storage from raw bytes with explicit encoding (owned copy).
      */
+    @Deprecated(message = "Use the DType overload (SKEEP-003 decision #13).", replaceWith = ReplaceWith("fromRawBytesOwned(shape, dtype, encoding, …)"))
     public fun fromRawBytesOwned(
         shape: Shape,
         logicalType: LogicalDType,
@@ -124,6 +128,7 @@ public object TensorStorageFactory {
     /**
      * Create file-backed storage (for memory-mapped model weights).
      */
+    @Deprecated(message = "Use the DType overload (SKEEP-003 decision #13).", replaceWith = ReplaceWith("fileBacked(shape, dtype, encoding, …)"))
     public fun fileBacked(
         shape: Shape,
         logicalType: LogicalDType,

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/AcceptanceCriteriaTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/AcceptanceCriteriaTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/BufferHandleFactoryTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/BufferHandleFactoryTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/CompressedKvAttentionTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/CompressedKvAttentionTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import kotlin.test.Test

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/ExplicitCopyApiTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/ExplicitCopyApiTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/KvCacheStoreTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/KvCacheStoreTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import kotlin.test.Test

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/LogicalDTypeBridgeTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/LogicalDTypeBridgeTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape
@@ -25,7 +27,6 @@ import kotlin.test.assertSame
  * SKEEP-003 Phase 0, decision #13: the two-way `LogicalDType` <-> `DType` bridge must be total
  * and bijective so that `LogicalDType` can later be merged into `DType` without a semantic gap.
  */
-@Suppress("DEPRECATION") // StorageSpec is exercised on purpose: the bridge must keep the legacy descriptor working
 class LogicalDTypeBridgeTest {
 
     private val expectedPairs: List<Pair<LogicalDType, DType>> = listOf(

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/MemoryPlannerTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/MemoryPlannerTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/NarrowFloatStorageDecodeTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/NarrowFloatStorageDecodeTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/NonContiguousStorageTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/NonContiguousStorageTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/PackedBlockStorageTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/PackedBlockStorageTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/StorageToTensorDataTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/StorageToTensorDataTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/TensorStorageContractTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/TensorStorageContractTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/TransferOpsTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/tensor/storage/TransferOpsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.tensor.storage
 
 import sk.ainet.lang.tensor.Shape

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/types/DTypeWitnessTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/types/DTypeWitnessTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // LogicalDType legacy path kept under test until removal (SKEEP-003 #1014)
+
 package sk.ainet.lang.types
 
 import sk.ainet.lang.tensor.storage.LogicalDType


### PR DESCRIPTION
## Summary

SKEEP-003 slice S0.2b (milestone M0 #1001, decision #13), the last Phase-0 step: with the two-way bridge (#1045), the `DType` witness (#1050), `Format` (#1051) and `AllocationSpec` (#1053) in place, nothing new is written against `LogicalDType` — so it is now **deprecated**, additively.

- `@Deprecated(WARNING, ReplaceWith("DType"))` on `LogicalDType`, `LogicalDType.fromDType`, `DType.toLogicalDType()`, the `logicalType` properties of `TensorStorage` / `StorageMemoryReport`, the `LogicalDType` overloads of `TensorStorageFactory` (`fromRawBytes`, `fromRawBytesOwned`, `fileBacked`) and `PackedBlockStorage.toTensorStorage(logicalType, …)`.
- **Nothing removed**: the primary constructors keep `LogicalDType` (a data-class constructor cannot change compatibly) and every shim delegates to the dtype-first API; removal is scheduled for the next major (deprecate-don't-delete).
- The files that *implement* the legacy surface (`LogicalDType.kt`, `LogicalDTypeBridge.kt`, `TensorStorage.kt`, `StorageMemoryReport.kt`, `TensorStorageFactory.kt`, `PackedBlockStorage.kt`, `StorageSpec.kt`) and the 16 tests that keep it covered carry a file-level `@Suppress("DEPRECATION")` with the reason; the rest of the build is deprecation-warning-free for `LogicalDType` (checked on the JVM compile log).
- No BCV change (annotations are not part of the dumps); no CHANGELOG edit.

Re-opened against `develop` (the stacked PR #1058 was auto-closed when its base branch was deleted on merge); same single commit, gate results in #1058 and below.

## Test plan

Full local gate (`scripts/pr-gate.sh`, JDK 25); results in the first comment. Targeted: lang-core storage/types + io-gguf + io-safetensors jvmTest 503/503.

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)
