### PR TITLE
Add gated OpenBenchmarking.org publish path for the engine benchmark suite

### DIFF
--- a/.github/workflows/engine-benchmarks.yml
+++ b/.github/workflows/engine-benchmarks.yml
@@ -27,6 +27,11 @@ on:
       - 'scripts/check_engine_json.sh'
       - '.github/workflows/engine-benchmarks.yml'
   workflow_dispatch:
+    inputs:
+      confirm_publish:
+        description: 'Publish this run to OpenBenchmarking.org (full-self-hosted lane only). Requires a one-time `phoronix-test-suite openbenchmarking-login` on the runner.'
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -94,8 +99,10 @@ jobs:
   full-self-hosted:
     # Full pack on the registered self-hosted runner. Only fires on release
     # publish or manual dispatch — never on PRs — so untrusted code cannot
-    # land on the maintainer machine. Results land as artifacts; this
-    # session does NOT upload to OpenBenchmarking.org (separate milestone).
+    # land on the maintainer machine. Results always land as artifacts;
+    # publishing to OpenBenchmarking.org is a separate, explicitly gated
+    # step below (workflow_dispatch with confirm_publish: true only — a
+    # release publish alone never auto-publishes to the public leaderboard).
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: [self-hosted, linux, x86_64, skainet-bench-linux-x86]
     timeout-minutes: 120
@@ -137,3 +144,15 @@ jobs:
           name: engine-full-records-${{ github.run_id }}
           path: out/engine/**/*.json
           retention-days: 90
+
+      - name: Publish to OpenBenchmarking.org
+        # Explicitly gated — only a manual workflow_dispatch with
+        # confirm_publish: true reaches this step. A release publish event
+        # alone runs the benchmarks and uploads artifacts above, but never
+        # this step, so a bad release tag can't silently publish public
+        # numbers. Requires a one-time `phoronix-test-suite
+        # openbenchmarking-login` on this runner — see
+        # docs/modules/ROOT/pages/contributing/benchmarks.adoc.
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.confirm_publish == 'true'
+        run: |
+          ./scripts/upload_openbenchmarking.sh "$(ls -td out/engine/*/ | head -1)" --confirm

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-bf16-matmul/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-bf16-matmul/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-bf16-matmul --out "$HERE/last-result.json" "$@"
+    run --scenario engine-bf16-matmul --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-bf16-matmul/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-bf16-matmul/test-definition.xml
@@ -11,16 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-bf16-matmul</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false --provider panama</Arguments>
+            <Arguments>--provider panama</Arguments>
         </Default>
         <Option>
             <DisplayName>Kernel Provider</DisplayName>
@@ -28,11 +27,11 @@
             <Menu>
                 <Entry>
                     <Name>Panama Vector</Name>
-                    <Value>--smoke false --provider panama</Value>
+                    <Value>--provider panama</Value>
                 </Entry>
                 <Entry>
                     <Name>Scalar</Name>
-                    <Value>--smoke false --provider scalar</Value>
+                    <Value>--provider scalar</Value>
                 </Entry>
             </Menu>
         </Option>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-elementwise-add/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-elementwise-add/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-elementwise-add --out "$HERE/last-result.json" "$@"
+    run --scenario engine-elementwise-add --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-elementwise-add/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-elementwise-add/test-definition.xml
@@ -11,30 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-elementwise-add</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false</Arguments>
+            <Arguments></Arguments>
         </Default>
-        <Option>
-            <DisplayName>Mode</DisplayName>
-            <Identifier>mode</Identifier>
-            <Menu>
-                <Entry>
-                    <Name>Full</Name>
-                    <Value>--smoke false</Value>
-                </Entry>
-                <Entry>
-                    <Name>Smoke</Name>
-                    <Value>--smoke</Value>
-                </Entry>
-            </Menu>
-        </Option>
     </TestSettings>
 </PhoronixTestSuite>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-fp32-gemm/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-fp32-gemm/install.sh
@@ -18,12 +18,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-fp32-gemm --out "$HERE/last-result.json" "$@"
+    run --scenario engine-fp32-gemm --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-fp32-gemm/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-fp32-gemm/test-definition.xml
@@ -11,30 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-fp32-gemm</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false</Arguments>
+            <Arguments></Arguments>
         </Default>
-        <Option>
-            <DisplayName>Mode</DisplayName>
-            <Identifier>mode</Identifier>
-            <Menu>
-                <Entry>
-                    <Name>Full</Name>
-                    <Value>--smoke false</Value>
-                </Entry>
-                <Entry>
-                    <Name>Smoke</Name>
-                    <Value>--smoke</Value>
-                </Entry>
-            </Menu>
-        </Option>
     </TestSettings>
 </PhoronixTestSuite>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-kernel-matmul/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-kernel-matmul/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-kernel-matmul --out "$HERE/last-result.json" "$@"
+    run --scenario engine-kernel-matmul --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-kernel-matmul/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-kernel-matmul/test-definition.xml
@@ -11,16 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-kernel-matmul</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false --provider panama</Arguments>
+            <Arguments>--provider panama</Arguments>
         </Default>
         <Option>
             <DisplayName>Kernel Provider</DisplayName>
@@ -28,11 +27,11 @@
             <Menu>
                 <Entry>
                     <Name>Panama Vector</Name>
-                    <Value>--smoke false --provider panama</Value>
+                    <Value>--provider panama</Value>
                 </Entry>
                 <Entry>
                     <Name>Scalar</Name>
-                    <Value>--smoke false --provider scalar</Value>
+                    <Value>--provider scalar</Value>
                 </Entry>
             </Menu>
         </Option>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-q4-gemm/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-q4-gemm/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-q4-gemm --out "$HERE/last-result.json" "$@"
+    run --scenario engine-q4-gemm --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-q4-gemm/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-q4-gemm/test-definition.xml
@@ -11,30 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-q4-gemm</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false</Arguments>
+            <Arguments></Arguments>
         </Default>
-        <Option>
-            <DisplayName>Mode</DisplayName>
-            <Identifier>mode</Identifier>
-            <Menu>
-                <Entry>
-                    <Name>Full</Name>
-                    <Value>--smoke false</Value>
-                </Entry>
-                <Entry>
-                    <Name>Smoke</Name>
-                    <Value>--smoke</Value>
-                </Entry>
-            </Menu>
-        </Option>
     </TestSettings>
 </PhoronixTestSuite>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-q8-matmul/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-q8-matmul/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-q8-matmul --out "$HERE/last-result.json" "$@"
+    run --scenario engine-q8-matmul --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-q8-matmul/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-q8-matmul/test-definition.xml
@@ -11,16 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-q8-matmul</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false --provider panama</Arguments>
+            <Arguments>--provider panama</Arguments>
         </Default>
         <Option>
             <DisplayName>Kernel Provider</DisplayName>
@@ -28,11 +27,11 @@
             <Menu>
                 <Entry>
                     <Name>Panama Vector</Name>
-                    <Value>--smoke false --provider panama</Value>
+                    <Value>--provider panama</Value>
                 </Entry>
                 <Entry>
                     <Name>Scalar</Name>
-                    <Value>--smoke false --provider scalar</Value>
+                    <Value>--provider scalar</Value>
                 </Entry>
             </Menu>
         </Option>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-mean/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-mean/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-reductions-mean --out "$HERE/last-result.json" "$@"
+    run --scenario engine-reductions-mean --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-mean/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-mean/test-definition.xml
@@ -11,30 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-reductions-mean</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false</Arguments>
+            <Arguments></Arguments>
         </Default>
-        <Option>
-            <DisplayName>Mode</DisplayName>
-            <Identifier>mode</Identifier>
-            <Menu>
-                <Entry>
-                    <Name>Full</Name>
-                    <Value>--smoke false</Value>
-                </Entry>
-                <Entry>
-                    <Name>Smoke</Name>
-                    <Value>--smoke</Value>
-                </Entry>
-            </Menu>
-        </Option>
     </TestSettings>
 </PhoronixTestSuite>

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-sum/install.sh
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-sum/install.sh
@@ -16,12 +16,15 @@ fi
 
 cp "$SKAINET_PUBLISH_JAR" "$DEST/skainet-engine-publish.jar"
 
-cat > "$DEST/$SCENARIO" <<'WRAPPER'
+cat > "$DEST/skainet-$SCENARIO" <<'WRAPPER'
 #!/usr/bin/env bash
+# PTS only parses results from the file at $LOG_FILE (set by the PTS client), never
+# from captured stdout directly — so the parseable result line must land there too.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
-exec java --enable-preview --add-modules jdk.incubator.vector \
+java --enable-preview --add-modules jdk.incubator.vector \
     -jar "$HERE/skainet-engine-publish.jar" \
-    run --scenario engine-reductions-sum --out "$HERE/last-result.json" "$@"
+    run --scenario engine-reductions-sum --out "$HERE/last-result.json" "$@" \
+    | tee -a "${LOG_FILE:-/dev/stdout}"
 WRAPPER
-chmod +x "$DEST/$SCENARIO"
+chmod +x "$DEST/skainet-$SCENARIO"

--- a/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-sum/test-definition.xml
+++ b/benchmarks/openbenchmarking/profiles/skainet-engine-reductions-sum/test-definition.xml
@@ -11,30 +11,15 @@
     <TestProfile>
         <Version>1.0.0</Version>
         <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
-        <SoftwareType>Library</SoftwareType>
+        <SoftwareType>Benchmark</SoftwareType>
         <TestType>Processor</TestType>
-        <License>MIT</License>
-        <Status>Testing</Status>
+        <License>Free</License>
+        <Status>Unverified</Status>
         <Maintainer>SKaiNET Developers</Maintainer>
-        <Executable>skainet-engine-reductions-sum</Executable>
     </TestProfile>
     <TestSettings>
         <Default>
-            <Arguments>--smoke false</Arguments>
+            <Arguments></Arguments>
         </Default>
-        <Option>
-            <DisplayName>Mode</DisplayName>
-            <Identifier>mode</Identifier>
-            <Menu>
-                <Entry>
-                    <Name>Full</Name>
-                    <Value>--smoke false</Value>
-                </Entry>
-                <Entry>
-                    <Name>Smoke</Name>
-                    <Value>--smoke</Value>
-                </Entry>
-            </Menu>
-        </Option>
     </TestSettings>
 </PhoronixTestSuite>

--- a/docs/modules/ROOT/pages/contributing/benchmarks.adoc
+++ b/docs/modules/ROOT/pages/contributing/benchmarks.adoc
@@ -73,6 +73,12 @@ The full lane currently runs on a Linux x86 host with an
 AVX2-capable CPU. macOS Arm64 and Linux Arm64 lanes are tracked as
 follow-ups.
 
+Both triggers (`release`, `workflow_dispatch`) run the full lane and
+upload its JSON records as a build artifact — that alone never
+touches OpenBenchmarking.org. Actually publishing to the public
+leaderboard is a separate, explicitly gated step; see
+<<publishing-to-openbenchmarking-org>>.
+
 == Reproducing a public run locally
 
 Prerequisites: JDK 21 or newer, Phoronix Test Suite (required to
@@ -113,10 +119,19 @@ GH_RUNNER_TOKEN=<token from repo Settings -> Actions -> Runners> \
   ./scripts/register_bench_runner.sh
 ----
 
+[#publishing-to-openbenchmarking-org]
 == Publishing to OpenBenchmarking.org
 
-One-time setup on the self-hosted bench host (not automated — this
-script never sees or handles OpenBenchmarking.org credentials):
+Publishing is deliberately a separate, human-confirmed step from
+running the benchmarks — the full lane runs (and uploads its JSON
+artifact) on every `release` and `workflow_dispatch`, but nothing
+reaches the public leaderboard without an explicit opt-in each time.
+See <<why-manual-login>> for why the OpenBenchmarking.org login itself
+can't be automated either.
+
+One-time setup on the self-hosted bench host (also covered in
+xref:contributing/register-bench-runner.adoc[Register a self-hosted
+bench runner]):
 
 [source,bash]
 ----
@@ -148,6 +163,20 @@ manual `workflow_dispatch` run with `confirm_publish: true`. A
 JSON artifact, but never triggers a publish to OpenBenchmarking.org —
 that always requires an explicit, separate dispatch.
 
+[#why-manual-login]
+[TIP]
+.Why the OpenBenchmarking.org login stays manual
+====
+`phoronix-test-suite openbenchmarking-login` does a live
+username/password handshake against OpenBenchmarking.org and stores
+the resulting session locally — there's no static API key or token to
+hand the runner as a secret. Re-implementing that handshake in CI
+would mean the workflow handling account credentials directly; a
+one-time interactive login on a box only maintainers can reach is the
+safer trade. The login persists across runs, so this is genuinely
+one-time per bench host, not per publish.
+====
+
 == Result record schema
 
 Every scenario emits a `BenchmarkRecord` JSON (schema version `1.0.0`)
@@ -172,5 +201,6 @@ comparisons don't silently break.
 
 * {url-pts}[Phoronix Test Suite]
 * {url-obo}[OpenBenchmarking.org]
+* xref:contributing/register-bench-runner.adoc[Register a self-hosted bench runner] — one-time host setup, including OpenBenchmarking.org login
 * xref:explanation/perf/jvm-cpu.adoc[JVM CPU backend notes]
 * xref:explanation/perf/simd-kernels.adoc[How SIMD kernels are built]

--- a/docs/modules/ROOT/pages/contributing/benchmarks.adoc
+++ b/docs/modules/ROOT/pages/contributing/benchmarks.adoc
@@ -75,8 +75,9 @@ follow-ups.
 
 == Reproducing a public run locally
 
-Prerequisites: JDK 21 or newer, Phoronix Test Suite (optional, only
-required to validate the local PTS profiles).
+Prerequisites: JDK 21 or newer, Phoronix Test Suite (required to
+actually publish a run — see below; optional if you only want the raw
+JSON records).
 
 [source,bash]
 ----
@@ -111,6 +112,41 @@ GH_RUNNER_TOKEN=<token from repo Settings -> Actions -> Runners> \
   REPO=SKaiNET-developers/SKaiNET \
   ./scripts/register_bench_runner.sh
 ----
+
+== Publishing to OpenBenchmarking.org
+
+One-time setup on the self-hosted bench host (not automated — this
+script never sees or handles OpenBenchmarking.org credentials):
+
+[source,bash]
+----
+./scripts/install_pts.sh
+phoronix-test-suite openbenchmarking-login   # interactive; stores the account session locally
+----
+
+To publish a full-mode run:
+
+[source,bash]
+----
+./scripts/run_engine_benchmarks.sh
+./scripts/upload_openbenchmarking.sh out/engine/<TIMESTAMP>          # dry run — prints what it would do
+./scripts/upload_openbenchmarking.sh out/engine/<TIMESTAMP> --confirm # actually publishes
+----
+
+`upload_openbenchmarking.sh` validates the JSON records against the
+schema, refuses to proceed if any record is `"unstable": true` (CoV
+over `stability.cov_limit_percent`), re-runs the suite through PTS
+itself (PTS needs its own native result file to upload — the JSON
+harness output is a parallel, richer record, not a PTS result), then
+uploads. It only performs the actual upload with `--confirm` (or
+`CONFIRM_PUBLISH=yes`) — publishing is public and effectively
+irreversible, so it's opt-in every time.
+
+In CI, this is the `full-self-hosted` job's last step, gated on a
+manual `workflow_dispatch` run with `confirm_publish: true`. A
+`release` publish event alone runs the benchmarks and uploads the
+JSON artifact, but never triggers a publish to OpenBenchmarking.org —
+that always requires an explicit, separate dispatch.
 
 == Result record schema
 

--- a/docs/modules/ROOT/pages/contributing/index.adoc
+++ b/docs/modules/ROOT/pages/contributing/index.adoc
@@ -31,7 +31,7 @@ Concretely:
 |===
 | Page | What it answers
 | xref:contributing/build-from-source.adoc[Build from source] | How to clone, build, and run the test suite locally.
-| xref:contributing/benchmarks.adoc[Engine benchmark program] | The Phoronix Test Suite / OpenBenchmarking publication path: methodology, manifest, lanes, CI workflow, replay.
+| xref:contributing/benchmarks.adoc[Engine benchmark program] | The Phoronix Test Suite / OpenBenchmarking publication path: methodology, manifest, lanes, CI workflow, replay, and the gated steps to actually publish a run to OpenBenchmarking.org.
 | xref:contributing/matmul-kernels.adoc[Reading the matmul benchmark] | What the published numbers mean — scalar vs. Panama vs. quantized regimes, roofline reasoning, and a checklist for interpreting any new measurement.
 | xref:contributing/register-bench-runner.adoc[Register a self-hosted bench runner] | The one-time operator setup that lights up the full-publish CI lane on a Linux x86 box.
 | xref:skeep:index.adoc[SKEEP proposal track] | How SKaiNET records long-lived API, DSL, runtime, compiler, storage, and compatibility proposals.

--- a/docs/modules/ROOT/pages/contributing/register-bench-runner.adoc
+++ b/docs/modules/ROOT/pages/contributing/register-bench-runner.adoc
@@ -38,6 +38,10 @@ workflow's `runs-on:` clause can route the job to it.
 * Optional but recommended: Phoronix Test Suite, installed via
   `./scripts/install_pts.sh`. The benchmark workflow installs it
   itself if missing, but pre-installing avoids a per-run download.
+* Only if this box will publish to OpenBenchmarking.org: a free
+  OpenBenchmarking.org account, and `phoronix-test-suite
+  openbenchmarking-login` run once, interactively, on this host (see
+  <<openbenchmarking-login>>).
 
 [#nat-firewall]
 == Running behind NAT — what you don't need to configure
@@ -159,6 +163,37 @@ button on the workflow's page in the GitHub UI.)
 Within ~30 seconds the runner journal should pick up the job. The
 full lane completes in 10–20 minutes; the published artifacts land
 at `engine-full-records-<run-id>` on the workflow run page.
+
+[#openbenchmarking-login]
+=== 5. (Optional) Enable OpenBenchmarking.org publishing
+
+The full lane above always runs benchmarks and uploads a JSON
+artifact — it never touches OpenBenchmarking.org by itself. Actually
+publishing to the public leaderboard needs one more, separate
+one-time step on this host, since the workflow itself is never
+handed OpenBenchmarking.org credentials (see
+xref:contributing/benchmarks.adoc#why-manual-login[why the login
+stays manual]):
+
+[source,bash]
+----
+phoronix-test-suite openbenchmarking-login
+----
+
+This prompts for your OpenBenchmarking.org username and password
+once and stores the resulting session under
+`~/.phoronix-test-suite/`. After that, publishing is a per-run
+opt-in — trigger the workflow with `confirm_publish: true`:
+
+[source,bash]
+----
+gh workflow run engine-benchmarks.yml --ref develop -f confirm_publish=true
+----
+
+Full details, including the local (non-CI) publish path via
+`scripts/upload_openbenchmarking.sh`, are in
+xref:contributing/benchmarks.adoc#publishing-to-openbenchmarking-org[Publishing
+to OpenBenchmarking.org].
 
 == Optional hardening
 

--- a/scripts/upload_openbenchmarking.sh
+++ b/scripts/upload_openbenchmarking.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Publish a full-mode engine benchmark run to OpenBenchmarking.org via Phoronix Test Suite.
+#
+# One-time setup per bench host (not handled by this script — see
+# docs/modules/ROOT/pages/contributing/benchmarks.adoc):
+#   1. ./scripts/install_pts.sh
+#   2. phoronix-test-suite openbenchmarking-login
+#      (interactive; stores the account session locally — this script never sees or
+#      handles OpenBenchmarking.org credentials)
+#
+# What this script does:
+#   1. Validates a full-mode JSON run (from scripts/run_engine_benchmarks.sh) against the
+#      BenchmarkRecord schema and refuses to proceed if any record is "unstable": true
+#      (CoV > benchmarks/manifests/engine-release.yml's stability.cov_limit_percent).
+#      Re-run on a quiet, dedicated host if this gate fails.
+#   2. Syncs + statically validates the local PTS profiles/suite (scripts/validate_pts_profiles.sh).
+#   3. Re-runs the suite through PTS itself (`phoronix-test-suite batch-benchmark`) — PTS needs
+#      to produce its own native result to upload; the JSON from step 1 is a parallel, richer
+#      record kept for schema validation and historical diffing, not a PTS result file. Batch
+#      mode is configured here (non-interactively, upload OFF) rather than depending on a
+#      prior `phoronix-test-suite batch-setup` on the host.
+#   4. Uploads the resulting PTS result to OpenBenchmarking.org — a public, essentially
+#      irreversible action, so it only runs with --confirm (or CONFIRM_PUBLISH=yes); without
+#      it, this prints what it would do and exits.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+    sed -n '2,25p' "$0"
+    echo
+    echo "Usage: $0 <path to a full-mode out/engine/<TIMESTAMP> dir> [--confirm]"
+}
+
+JSON_DIR="${1:-}"
+if [ -z "$JSON_DIR" ] || [ "$JSON_DIR" = "-h" ] || [ "$JSON_DIR" = "--help" ]; then
+    usage
+    exit "$([ -z "$JSON_DIR" ] && echo 2 || echo 0)"
+fi
+
+CONFIRM="${CONFIRM_PUBLISH:-no}"
+[ "${2:-}" = "--confirm" ] && CONFIRM="yes"
+
+RESULT_IDENTIFIER="${RESULT_IDENTIFIER:-skainet-engine-$(basename "$JSON_DIR")}"
+
+if ! command -v phoronix-test-suite >/dev/null 2>&1; then
+    echo "ERROR: phoronix-test-suite not installed. Run ./scripts/install_pts.sh first." >&2
+    exit 2
+fi
+
+echo "== Stage 1: validate the JSON harness run at $JSON_DIR =="
+"$REPO_ROOT/scripts/check_engine_json.sh" "$JSON_DIR"
+
+UNSTABLE="$(python3 - "$JSON_DIR" <<'PY'
+import glob, json, os, sys
+d = sys.argv[1]
+bad = [p for p in sorted(glob.glob(os.path.join(d, "*.json"))) if json.load(open(p)).get("unstable")]
+print("\n".join(bad))
+PY
+)"
+if [ -n "$UNSTABLE" ]; then
+    echo "ERROR: unstable records present (CoV over the manifest's stability limit) —" >&2
+    echo "       re-run on a quiet, dedicated bench host before publishing:" >&2
+    echo "$UNSTABLE" >&2
+    exit 1
+fi
+echo "Stability gate: OK — no unstable records."
+
+echo
+echo "== Stage 2: sync + validate local PTS profiles and suite =="
+"$REPO_ROOT/scripts/validate_pts_profiles.sh"
+
+echo
+echo "== Stage 3: configure PTS batch mode (non-interactive, upload OFF for this stage) =="
+python3 - <<'PY'
+import os
+import xml.etree.ElementTree as ET
+
+path = os.path.expanduser("~/.phoronix-test-suite/user-config.xml")
+os.makedirs(os.path.dirname(path), exist_ok=True)
+
+if os.path.isfile(path):
+    tree = ET.parse(path)
+    root = tree.getroot()
+else:
+    root = ET.Element("PhoronixTestSuite")
+    tree = ET.ElementTree(root)
+
+def ensure_path(parent, *tags):
+    for tag in tags:
+        child = parent.find(tag)
+        if child is None:
+            child = ET.SubElement(parent, tag)
+        parent = child
+    return parent
+
+batch = ensure_path(root, "Options", "BatchMode")
+values = {
+    "Configured": "TRUE",
+    "SaveResults": "TRUE",
+    "OpenBrowser": "FALSE",
+    "UploadResults": "FALSE",  # upload is Stage 4, explicit and gated — never a side effect here
+    "PromptForTestIdentifier": "FALSE",
+    "PromptForTestDescription": "FALSE",
+    "PromptSaveName": "FALSE",
+    "RunAllTestCombinations": "TRUE",  # runs both panama/scalar for the 3 provider-optioned profiles
+}
+for tag, value in values.items():
+    ensure_path(batch, tag).text = value
+
+tree.write(path, encoding="unicode", xml_declaration=False)
+print(f"BatchMode configured in {path}")
+PY
+
+echo
+echo "== Stage 4: run the suite through PTS (produces the native result PTS can upload) =="
+echo "Result identifier: $RESULT_IDENTIFIER"
+if [ "$CONFIRM" != "yes" ]; then
+    echo
+    echo "DRY RUN — not executing. This would run:"
+    echo "  TEST_RESULTS_NAME=$RESULT_IDENTIFIER phoronix-test-suite batch-benchmark local/skainet-engine-suite"
+    echo "  phoronix-test-suite upload-result $RESULT_IDENTIFIER"
+    echo
+    echo "Re-run with --confirm (or CONFIRM_PUBLISH=yes) to actually publish to OpenBenchmarking.org."
+    exit 0
+fi
+
+TEST_RESULTS_NAME="$RESULT_IDENTIFIER" \
+TEST_RESULTS_DESCRIPTION="SKaiNET engine suite — full mode, published from $JSON_DIR" \
+    phoronix-test-suite batch-benchmark local/skainet-engine-suite < /dev/null
+
+echo
+echo "== Stage 5: upload to OpenBenchmarking.org =="
+echo "Requires a one-time 'phoronix-test-suite openbenchmarking-login' on this host."
+phoronix-test-suite upload-result "$RESULT_IDENTIFIER"
+
+echo
+echo "Published: $RESULT_IDENTIFIER"


### PR DESCRIPTION
## Summary
- Fixes 3 previously-undetected bugs in the 8 `skainet-engine-*` PTS test profiles (unresolvable install executable, invalid `test-profile.xsd` metadata, a `--smoke false` arg the harness CLI can't parse, missing `$LOG_FILE` output) — none of these profiles had ever actually been executed by real Phoronix Test Suite before this branch; CI only validated XML shape or ran the jar directly.
- Adds `scripts/upload_openbenchmarking.sh`: validates a full-mode JSON run against the `BenchmarkRecord` schema, blocks on any `"unstable": true` record, runs the suite through PTS's own batch mode, then uploads — the actual upload only fires with `--confirm`/`CONFIRM_PUBLISH=yes`.
- Wires this as a new, explicitly gated step on the `full-self-hosted` CI job (`workflow_dispatch` with `confirm_publish: true`) — a `release` event alone still runs benchmarks and uploads the JSON artifact, but never publishes to the public leaderboard on its own.
- Expands the Antora contributor docs (`benchmarks.adoc`, `register-bench-runner.adoc`, `contributing/index.adoc`) to document the one-time OpenBenchmarking.org login and the publish steps.

Note: the `<License>MIT</License>` → `<License>Free</License>` change in each `test-definition.xml` is a PTS test-profile metadata field fix, not a change to SKaiNET's project license (still MIT) — `MIT` isn't a valid value in PTS's own `{Free, Non-Free, Retail, Restricted}` enum.

## Test plan
- [x] Rebuilt `:skainet-backends:benchmarks:jvm-cpu-publish:shadowJar` and ran the full engine suite locally (11/11 scenarios produced valid `BenchmarkRecord` JSON)
- [x] `scripts/validate_pts_profiles.sh` passes with zero schema errors (previously 32 silent errors across the 8 profiles)
- [x] Installed and ran each fixed profile through real `phoronix-test-suite benchmark` / `batch-benchmark` (not just the JSON harness) — confirmed results are now correctly parsed and saved
- [x] `scripts/upload_openbenchmarking.sh` exercised end-to-end locally through the PTS batch-run stage (schema/stability gate, non-interactive batch config, saved result ready for `upload-result`) — stopped short of the live upload, which needs real OpenBenchmarking.org credentials on the actual self-hosted bench host
- [ ] Live publish from the self-hosted Linux runner, once `phoronix-test-suite openbenchmarking-login` is configured there

🤖 Generated with [Claude Code](https://claude.com/claude-code)