### PR TITLE
feat(memory): ternary encodings TQ1_0, TQ2_0 and BitNet b1.58 — block descriptor + reference codec (SKEEP-003 P6, S2.7)

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/goldenTest/kotlin/sk/ainet/exec/golden/Goldens.kt
+++ b/skainet-backends/skainet-backend-cpu/src/goldenTest/kotlin/sk/ainet/exec/golden/Goldens.kt
@@ -9,6 +9,17 @@ package sk.ainet.exec.golden
  */
 internal object Goldens {
     val expected: Map<String, String> = mapOf(
+        // #1033 — the ternary encodings, encoded and decoded by TernaryCodec (the GGML layout,
+        // interleave included). TQ1_0 and TQ2_0 share a decode digest on purpose: the same ternary
+        // values in two different byte layouts must come back identical.
+        "decode/BITNET_B1_58" to "n=768 fnv=42c65c028e7afe7e head=3ead0000,00000000,00000000,00000000",
+        "decode/TQ1_0" to "n=768 fnv=1a9dbfa9435ab9d8 head=3f000000,00000000,00000000,00000000",
+        "decode/TQ2_0" to "n=768 fnv=1a9dbfa9435ab9d8 head=3f000000,00000000,00000000,00000000",
+        "packed/BITNET_B1_58" to "n=196 fnv=f3e967d46c75c048 head=5646021586982468",
+        "packed/TQ1_0" to "n=162 fnv=202d7437bd7e9cd7 head=c7927ca5c36f235f",
+        "packed/TQ2_0" to "n=198 fnv=b72a1ac914b84809 head=a249156962a18411",
+        "view/TQ1_0" to "n=512 fnv=a315d19d84ba1325 head=3f000000,3f000000,00000000,bf000000",
+        "view/TQ2_0" to "n=512 fnv=a315d19d84ba1325 head=3f000000,3f000000,00000000,bf000000",
         "decode/Q4_0" to "n=384 fnv=d6bc5d718cd98a58 head=bdb0dc00,3d979800,00000000,3d4a2000",
         "decode/Q4_K" to "n=3072 fnv=fa096e860a45191e head=4049e820,408a0210,409c8910,40c19710",
         "decode/Q5_0" to "n=384 fnv=6a72d36758b74185 head=3dc3e000,bdc3e000,bef4d800,be74d800",
@@ -16,7 +27,9 @@ internal object Goldens {
         "decode/Q5_K" to "n=3072 fnv=3381529c397a361d head=4125da40,416af240,41980520,41980520",
         "decode/Q6_K" to "n=3072 fnv=3c3d7fa00c48faa9 head=c2606550,40ef5b00,41fe50b0,42606550",
         "decode/Q8_0" to "n=384 fnv=334c03e32df05c28 head=3f6a1700,bf6ede00,3ee55000,bf786c00",
-        "decode/TERNARY_tq2_0" to "n=256 fnv=48409a8f0eeaba6e head=bd000000,bd000000,bd000000,bd000000",
+        // Re-baselined by #1033: Ternary2BitTensorData.fromTQ2_0Block used to adopt the TQ2_0
+        // payload bytes verbatim, which silently mis-ordered the elements (TQ2_0 interleaves by 32).
+        "decode/TERNARY_tq2_0" to "n=256 fnv=7aa8775d0e1c591e head=bd000000,00000000,3d800000,bd000000",
         "decode/TERNARY_values" to "n=384 fnv=e455e2a9df6acf48 head=00000000,bf500000,bf500000,3f500000",
         "scalar-matmul/Q4_0" to "n=12 fnv=0aaee3d77e3619f6 head=3f15be82,3f0f4b4e,3e49fb8e,be220b31",
         "scalar-matmul/Q4_K" to "n=12 fnv=1c27f69421ebce94 head=c29e9232,c3116957,c3a2cb4f,c2da54e5",

--- a/skainet-backends/skainet-backend-cpu/src/goldenTest/kotlin/sk/ainet/exec/golden/PackedDecodeGoldenTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/goldenTest/kotlin/sk/ainet/exec/golden/PackedDecodeGoldenTest.kt
@@ -10,7 +10,13 @@ import sk.ainet.lang.tensor.data.Q5_KBlockTensorData
 import sk.ainet.lang.tensor.data.Q6_KBlockTensorData
 import sk.ainet.lang.tensor.data.Q8_0BlockTensorData
 import sk.ainet.lang.tensor.data.Ternary2BitTensorData
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.Storage
+import sk.ainet.lang.memory.TensorView
+import sk.ainet.lang.memory.TernaryBlockDecoder
+import sk.ainet.lang.memory.TernaryCodec
 import sk.ainet.lang.tensor.storage.PackedBlockStorage
+import sk.ainet.lang.tensor.storage.TensorEncoding
 import kotlin.test.Test
 
 /**
@@ -18,6 +24,7 @@ import kotlin.test.Test
  * bit-identical floats for the same bytes. Guards the TensorData → TensorView façade migration
  * (M1) and every later refactor of the packed storage types.
  */
+@OptIn(ExperimentalMemoryApi::class)
 class PackedDecodeGoldenTest {
 
     private companion object {
@@ -64,6 +71,35 @@ class PackedDecodeGoldenTest {
         val decoded = decodeAll(t, n, t.blockSize)
         GoldenSupport.check("decode/TERNARY_values", GoldenSupport.digest(decoded))
         GoldenSupport.check("packed/TERNARY_values", GoldenSupport.digest(t.packedData))
+    }
+
+    /**
+     * #1033: the ternary encodings decode through [TernaryCodec], whose layout is the GGML one
+     * (`dequantize_row_tq{1,2}_0`, interleave included). Golden over *encoded* ternary values, so a
+     * change to either half of the codec — the packer or the unpacker — moves the digest.
+     */
+    private fun ternaryGolden(encoding: TensorEncoding, name: String, elements: Int) {
+        val rng = GoldenSupport.Rng(SEED + 23)
+        val values = FloatArray(elements) { (((rng.nextLong() ushr 40).toInt() and 0xFFFF) % 3 - 1) * 0.5f }
+        val bytes = TernaryCodec.encode(encoding, values)
+        GoldenSupport.check("packed/$name", GoldenSupport.digest(bytes))
+        GoldenSupport.check("decode/$name", GoldenSupport.digest(TernaryCodec.decode(encoding, bytes, elements)))
+    }
+
+    @Test fun tq1_0() = ternaryGolden(TensorEncoding.TQ1_0, "TQ1_0", 256 * 3)
+    @Test fun tq2_0() = ternaryGolden(TensorEncoding.TQ2_0, "TQ2_0", 256 * 3)
+    @Test fun bitnet() = ternaryGolden(TensorEncoding.BITNET_B1_58, "BITNET_B1_58", 256 * 3)
+
+    /** A ternary view decodes exactly like the codec it is driven by — the M2 kernel entry path. */
+    @Test
+    fun ternaryThroughATensorView() {
+        val rng = GoldenSupport.Rng(SEED + 29)
+        val values = FloatArray(512) { (((rng.nextLong() ushr 40).toInt() and 0xFFFF) % 3 - 1) * 0.5f }
+        for (encoding in listOf(TensorEncoding.TQ1_0, TensorEncoding.TQ2_0)) {
+            val bytes = TernaryCodec.encode(encoding, values)
+            val view = TensorView.packed(Storage.Heap.wrap(bytes), Shape(2, 256), encoding, TernaryBlockDecoder(encoding))
+            GoldenSupport.check("view/${encoding.name}", GoldenSupport.digest(view.toFloatArray()))
+        }
     }
 
     @Test

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/GgufMemoryPlan.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/GgufMemoryPlan.kt
@@ -79,6 +79,7 @@ public fun ggufFormat(type: GGMLQuantizationType, nBytes: Long): Format {
         GGMLQuantizationType.Q4_0 -> TensorEncoding.Q4_0; GGMLQuantizationType.Q5_0 -> TensorEncoding.Q5_0; GGMLQuantizationType.Q5_1 -> TensorEncoding.Q5_1
         GGMLQuantizationType.Q8_0 -> TensorEncoding.Q8_0; GGMLQuantizationType.Q4_K -> TensorEncoding.Q4_K; GGMLQuantizationType.Q5_K -> TensorEncoding.Q5_K
         GGMLQuantizationType.Q6_K -> TensorEncoding.Q6_K
+        GGMLQuantizationType.TQ1_0 -> TensorEncoding.TQ1_0; GGMLQuantizationType.TQ2_0 -> TensorEncoding.TQ2_0
         else -> TensorEncoding.Opaque(type.name, nBytes)
     }
     return Format(dtype, encoding)

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGGUFReader.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGGUFReader.kt
@@ -189,6 +189,8 @@ public class StreamingGGUFReader private constructor(
         GGMLQuantizationType.Q4_K -> TensorEncoding.Q4_K
         GGMLQuantizationType.Q5_K -> TensorEncoding.Q5_K
         GGMLQuantizationType.Q6_K -> TensorEncoding.Q6_K
+        GGMLQuantizationType.TQ1_0 -> TensorEncoding.TQ1_0
+        GGMLQuantizationType.TQ2_0 -> TensorEncoding.TQ2_0
         // Types without a dedicated TensorEncoding carry their real byte count,
         // so TensorStorage.physicalBytes (which prefers encoding.physicalBytes
         // over buffer.sizeInBytes) stays truthful. The previous Opaque(name, 0)

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGgufParametersLoader.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGgufParametersLoader.kt
@@ -146,7 +146,9 @@ public class StreamingGgufParametersLoader(
                     GGMLQuantizationType.Q8_0,
                     GGMLQuantizationType.Q4_0,
                     GGMLQuantizationType.Q5_0,
-                    GGMLQuantizationType.Q5_1 -> quantizedTensor(ctx, dtype, shape, tensorInfo, rawBytes)
+                    GGMLQuantizationType.Q5_1,
+                    GGMLQuantizationType.TQ1_0,
+                    GGMLQuantizationType.TQ2_0 -> quantizedTensor(ctx, dtype, shape, tensorInfo, rawBytes)
 
                     else -> throw IllegalStateException(
                         "StreamingGgufParametersLoader: tensor '${tensorInfo.name}' of type " +
@@ -190,6 +192,18 @@ public class StreamingGgufParametersLoader(
             (dtype == FP32::class || dtype == FP16::class)
         ) {
             val dest = DequantOps.dequantFromBytes(rawBytes, tensorInfo.tensorType, tensorInfo.nElements.toInt())
+            return ctx.wrapFloatArray<T, Float>(shape, dtype, dest) as Tensor<T, V>
+        }
+        if (tensorInfo.tensorType == GGMLQuantizationType.TQ1_0 || tensorInfo.tensorType == GGMLQuantizationType.TQ2_0) {
+            // #1033: ternary tensors decode correctly, but there is no packed ternary `TensorData`
+            // with per-block scales yet — it arrives with the ternary kernels (#1040/#1041). Until
+            // then every policy widens them to FP32: right values, no memory saving.
+            require(dtype == FP32::class || dtype == FP16::class) {
+                "tensor '${tensorInfo.name}' is ${tensorInfo.tensorType}; ternary tensors currently " +
+                    "load as FP32, so the requested dtype $dtype is not supported"
+            }
+            val dest = DequantOps.dequantFromBytes(rawBytes, tensorInfo.tensorType, tensorInfo.nElements.toInt())
+            @Suppress("UNCHECKED_CAST")
             return ctx.wrapFloatArray<T, Float>(shape, dtype, dest) as Tensor<T, V>
         }
         val packed = when (tensorInfo.tensorType) {
@@ -270,6 +284,11 @@ public class StreamingGgufParametersLoader(
             GGMLQuantizationType.Q5_K,
             GGMLQuantizationType.Q6_K,
             GGMLQuantizationType.Q8_0,
+            // #1033: ternary. Decoded through the reference codec next to their
+            // TensorEncoding descriptor, so the loader and the ternary kernels
+            // cannot read the same bytes differently.
+            GGMLQuantizationType.TQ1_0,
+            GGMLQuantizationType.TQ2_0,
         )
 
         private const val MAX_LISTED_TENSORS = 8

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/dequant/DequantOps.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/dequant/DequantOps.kt
@@ -799,88 +799,24 @@ public object DequantOps {
     }
 
     @Suppress("UNUSED_PARAMETER")
+    /**
+     * `TQ2_0` → floats through the shared reference codec (#1033).
+     *
+     * The layout — including the interleave, where one byte holds four elements **32 apart** — is
+     * defined once by [sk.ainet.lang.memory.TernaryCodec], next to the `TensorEncoding.TQ2_0`
+     * descriptor, so the loader and the ternary kernels cannot decode the same bytes differently.
+     */
+    @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
     private fun dequantTQ2_0FromBytes(bytes: ByteArray, nElems: Int): FloatArray {
-        val blockSize = 256
-        val bytesPerBlock = 66
-        val blockCount = bytes.size / bytesPerBlock
-        val out = FloatArray(blockCount * blockSize)
-        var offset = 0
-        var outOff = 0
-
-        repeat(blockCount) {
-            val qs = bytes.copyOfRange(offset, offset + 64)
-            offset += 64
-
-            val scale = halfToFloat(
-                (bytes[offset + 1].toInt() and 0xFF shl 8) or (bytes[offset].toInt() and 0xFF)
-            )
-            offset += 2
-
-            for (i in 0 until 64) {
-                val b = qs[i].toInt() and 0xFF
-                val v0 = (b and 0x03) - 1
-                val v1 = ((b shr 2) and 0x03) - 1
-                val v2 = ((b shr 4) and 0x03) - 1
-                val v3 = ((b shr 6) and 0x03) - 1
-
-                out[outOff + i * 4 + 0] = v0 * scale
-                out[outOff + i * 4 + 1] = v1 * scale
-                out[outOff + i * 4 + 2] = v2 * scale
-                out[outOff + i * 4 + 3] = v3 * scale
-            }
-            outOff += blockSize
-        }
-        return out
+        val blocks = bytes.size / sk.ainet.lang.tensor.storage.TensorEncoding.TQ2_0.BYTES_PER_BLOCK
+        return sk.ainet.lang.memory.TernaryCodec.decodeTq2_0(bytes, blocks * 256)
     }
 
-    @Suppress("UNUSED_PARAMETER")
+    /** `TQ1_0` → floats through the shared reference codec (#1033); see [dequantTQ2_0FromBytes]. */
+    @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
     private fun dequantTQ1_0FromBytes(bytes: ByteArray, nElems: Int): FloatArray {
-        val blockSize = 256
-        val bytesPerBlock = 54
-        val blockCount = bytes.size / bytesPerBlock
-        val out = FloatArray(blockCount * blockSize)
-        var offset = 0
-        var outOff = 0
-
-        repeat(blockCount) {
-            val qsBase3 = bytes.copyOfRange(offset, offset + 48)
-            offset += 48
-
-            val qs2bit = bytes.copyOfRange(offset, offset + 4)
-            offset += 4
-
-            val scale = halfToFloat(
-                (bytes[offset + 1].toInt() and 0xFF shl 8) or (bytes[offset].toInt() and 0xFF)
-            )
-            offset += 2
-
-            var outIdx = 0
-            for (i in 0 until 48) {
-                var b = qsBase3[i].toInt() and 0xFF
-                repeat(5) {
-                    val v = (b % 3) - 1
-                    out[outOff + outIdx] = v * scale
-                    outIdx++
-                    b /= 3
-                }
-            }
-
-            for (i in 0 until 4) {
-                val b = qs2bit[i].toInt() and 0xFF
-                val v0 = (b and 0x03) - 1
-                val v1 = ((b shr 2) and 0x03) - 1
-                val v2 = ((b shr 4) and 0x03) - 1
-                val v3 = ((b shr 6) and 0x03) - 1
-
-                out[outOff + 240 + i * 4 + 0] = v0 * scale
-                out[outOff + 240 + i * 4 + 1] = v1 * scale
-                out[outOff + 240 + i * 4 + 2] = v2 * scale
-                out[outOff + 240 + i * 4 + 3] = v3 * scale
-            }
-
-            outOff += blockSize
-        }
-        return out
+        val blocks = bytes.size / sk.ainet.lang.tensor.storage.TensorEncoding.TQ1_0.BYTES_PER_BLOCK
+        return sk.ainet.lang.memory.TernaryCodec.decodeTq1_0(bytes, blocks * 256)
     }
 
     private fun typeName(value: Any?): String =

--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/GgufMemoryPlanTest.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/GgufMemoryPlanTest.kt
@@ -47,7 +47,14 @@ class GgufMemoryPlanTest {
         assertEquals(TensorEncoding.Q6_K, ggufFormat(GGMLQuantizationType.Q6_K, 0).encoding)
         assertEquals(FP32, ggufFormat(GGMLQuantizationType.Q6_K, 0).dtype)
         assertEquals(TensorEncoding.Dense(2), ggufFormat(GGMLQuantizationType.BF16, 0).encoding)
-        assertTrue(ggufFormat(GGMLQuantizationType.TQ1_0, 123).encoding is TensorEncoding.Opaque)
+        // #1033: the ternary types are described, not opaque — a TQ1_0 tensor plans at 54 B per
+        // 256 elements instead of falling back to "whatever the header said the bytes were".
+        assertEquals(TensorEncoding.TQ1_0, ggufFormat(GGMLQuantizationType.TQ1_0, 123).encoding)
+        assertEquals(TensorEncoding.TQ2_0, ggufFormat(GGMLQuantizationType.TQ2_0, 123).encoding)
+        assertEquals(FP32, ggufFormat(GGMLQuantizationType.TQ1_0, 123).dtype)
+        assertEquals(54L, ggufFormat(GGMLQuantizationType.TQ1_0, 0).physicalBytes(256))
+        assertEquals(66L, ggufFormat(GGMLQuantizationType.TQ2_0, 0).physicalBytes(256))
+        assertTrue(ggufFormat(GGMLQuantizationType.IQ2_XS, 123).encoding is TensorEncoding.Opaque, "still unmapped")
     }
 
     /** Real file, fixture-gated (see GgufNameMapFixtureTest): the plan must be consistent with the header. */

--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/GgufTernaryLoadTest.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/GgufTernaryLoadTest.kt
@@ -1,0 +1,95 @@
+package sk.ainet.io.gguf
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DefaultDataExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.io.model.QuantPolicy
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.TernaryCodec
+import sk.ainet.lang.memory.blockSpec
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.FloatArrayTensorData
+import sk.ainet.lang.tensor.storage.TensorEncoding
+import sk.ainet.lang.types.FP32
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * #1033 (M2-F1): a GGUF holding `TQ1_0` / `TQ2_0` tensors loads, and the values that come out are
+ * the values that went in — the end-to-end half of the ternary-encoding slice.
+ *
+ * Before this slice both types decoded through a hand-written routine whose element order did not
+ * match `dequantize_row_tq{1,2}_0` (four *consecutive* elements per byte instead of four 32 apart),
+ * and the loader described them as `Opaque`, so nothing downstream knew their geometry.
+ */
+@OptIn(ExperimentalMemoryApi::class)
+class GgufTernaryLoadTest {
+
+    @Test
+    fun ternaryTensorsLoadWithTheirValuesIntact() {
+        val (tq1, _, tq1Values) = SyntheticGguf.ternary("w_tq1", GGMLQuantizationType.TQ1_0, elements = 512)
+        val (tq2, _, tq2Values) = SyntheticGguf.ternary("w_tq2", GGMLQuantizationType.TQ2_0, elements = 512)
+        val file = SyntheticGguf.write(tq1, tq2)
+        try {
+            val loaded = load(file, QuantPolicy.DEQUANTIZE_TO_FP32)
+            assertEquals(setOf("w_tq1", "w_tq2"), loaded.keys)
+            for ((name, expected) in listOf("w_tq1" to tq1Values, "w_tq2" to tq2Values)) {
+                val data = loaded.getValue(name).data
+                val actual = (data as FloatArrayTensorData<*>).buffer
+                assertContentEquals(expected, actual.copyOf(expected.size), "$name: decoded values")
+            }
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun theHeaderDescribesTheTernaryGeometryInsteadOfCallingItOpaque() {
+        val (tq1, _, _) = SyntheticGguf.ternary("w_tq1", GGMLQuantizationType.TQ1_0, elements = 512)
+        val file = SyntheticGguf.write(tq1)
+        try {
+            JvmRandomAccessSource.open(file).use { src ->
+                val reader = StreamingGGUFReader.open(src)
+                val storage = reader.loadTensorStorage("w_tq1")
+                assertEquals(TensorEncoding.TQ1_0, storage.encoding)
+                assertEquals(FP32, storage.dtype, "ternary weights are logically FP32 (SKEEP-003 rule 3)")
+                assertEquals(54L * 2, storage.encoding.physicalBytes(512), "two 54-byte blocks")
+                assertEquals(1.625, storage.encoding.blockSpec!!.bitsPerElement)
+
+                // the plan sees the same geometry the file has
+                val input = reader.planInput(ctx = 128)
+                assertEquals(54L * 2, input.weights.single { it.name == "w_tq1" }.bytes)
+            }
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun theLoaderAndTheCodecDecodeTheSameBytesIdentically() {
+        val (tq2, bytes, values) = SyntheticGguf.ternary("w", GGMLQuantizationType.TQ2_0, elements = 256 * 3)
+        val file = SyntheticGguf.write(tq2)
+        try {
+            val loaded = load(file, QuantPolicy.DEQUANTIZE_TO_FP32).getValue("w").data
+            val actual = (loaded as FloatArrayTensorData<*>).buffer.copyOf(values.size)
+            assertContentEquals(TernaryCodec.decodeTq2_0(bytes, values.size), actual, "loader vs reference codec")
+            assertContentEquals(values, actual)
+        } finally {
+            file.delete()
+        }
+    }
+
+    private fun load(file: File, policy: QuantPolicy): Map<String, Tensor<FP32, Float>> {
+        val ctx = DefaultDataExecutionContext()
+        val loaded = mutableMapOf<String, Tensor<FP32, Float>>()
+        runBlocking {
+            StreamingGgufParametersLoader(
+                sourceProvider = { JvmRandomAccessSource.open(file) },
+                quantPolicy = policy,
+            ).load<FP32, Float>(ctx, FP32::class) { name, tensor -> loaded[name] = tensor }
+        }
+        return loaded
+    }
+}

--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/SyntheticGguf.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/SyntheticGguf.kt
@@ -1,5 +1,7 @@
 package sk.ainet.io.gguf
 
+import sk.ainet.lang.memory.TernaryCodec
+import sk.ainet.lang.tensor.storage.TensorEncoding
 import java.io.File
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
@@ -60,6 +62,7 @@ object SyntheticGguf {
                 }
                 buf.array()
             }
+            GGMLQuantizationType.TQ1_0, GGMLQuantizationType.TQ2_0 -> ternary(name, type, elements, seed).second
             else -> {
                 val (blockBytes, blockElems) = blockLayout(type)
                 require(elements % blockElems == 0) {
@@ -72,6 +75,32 @@ object SyntheticGguf {
             }
         }
         return TestTensor(name, type, elements.toLong(), bytes)
+    }
+
+    /**
+     * A ternary tensor (`TQ1_0` / `TQ2_0`) and the exact values it encodes (#1033).
+     *
+     * Values are drawn from `{-0.5, 0, +0.5}`, so every block's absmax is 0.5 — exactly
+     * representable in FP16 — and the file round-trips to the values bit for bit. The bytes come
+     * from [TernaryCodec], the same reference encoder the decoder is defined against, so this
+     * fixture exercises the real GGML layout (interleave included) rather than a plausible one.
+     */
+    @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
+    fun ternary(
+        name: String,
+        type: GGMLQuantizationType,
+        elements: Int,
+        seed: Int = name.hashCode(),
+    ): Triple<TestTensor, ByteArray, FloatArray> {
+        val encoding = when (type) {
+            GGMLQuantizationType.TQ1_0 -> TensorEncoding.TQ1_0
+            GGMLQuantizationType.TQ2_0 -> TensorEncoding.TQ2_0
+            else -> error("$type is not a ternary GGML type")
+        }
+        val rnd = Random(seed)
+        val values = FloatArray(elements) { (rnd.nextInt(3) - 1) * 0.5f }
+        val bytes = TernaryCodec.encode(encoding, values)
+        return Triple(TestTensor(name, type, elements.toLong(), bytes), bytes, values)
     }
 
     /**

--- a/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
@@ -686,6 +686,39 @@ public final class sk/ainet/lang/memory/BlockDecoder$DefaultImpls {
 	public static fun decodeElement (Lsk/ainet/lang/memory/BlockDecoder;Lsk/ainet/lang/memory/Storage;Lsk/ainet/lang/memory/Layout;J)F
 }
 
+public final class sk/ainet/lang/memory/BlockSpec {
+	public static final field Companion Lsk/ainet/lang/memory/BlockSpec$Companion;
+	public static final field PER_TENSOR_BLOCK I
+	public fun <init> (IIDLsk/ainet/lang/memory/ScalePlacement;Lsk/ainet/lang/memory/Format;)V
+	public synthetic fun <init> (IIDLsk/ainet/lang/memory/ScalePlacement;Lsk/ainet/lang/memory/Format;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()D
+	public final fun component4 ()Lsk/ainet/lang/memory/ScalePlacement;
+	public final fun component5 ()Lsk/ainet/lang/memory/Format;
+	public final fun copy (IIDLsk/ainet/lang/memory/ScalePlacement;Lsk/ainet/lang/memory/Format;)Lsk/ainet/lang/memory/BlockSpec;
+	public static synthetic fun copy$default (Lsk/ainet/lang/memory/BlockSpec;IIDLsk/ainet/lang/memory/ScalePlacement;Lsk/ainet/lang/memory/Format;ILjava/lang/Object;)Lsk/ainet/lang/memory/BlockSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivation ()Lsk/ainet/lang/memory/Format;
+	public final fun getAmortisedBitsPerElement ()D
+	public final fun getBitsPerElement ()D
+	public final fun getBlockSize ()I
+	public final fun getBytesPerBlock ()I
+	public final fun getScale ()Lsk/ainet/lang/memory/ScalePlacement;
+	public fun hashCode ()I
+	public final fun isPerTensor ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/lang/memory/BlockSpec$Companion {
+	public final fun getINT8_ACTIVATION ()Lsk/ainet/lang/memory/Format;
+}
+
+public final class sk/ainet/lang/memory/BlockSpecKt {
+	public static final fun getBlockSpec (Lsk/ainet/lang/tensor/storage/TensorEncoding;)Lsk/ainet/lang/memory/BlockSpec;
+	public static final fun isTernary (Lsk/ainet/lang/tensor/storage/TensorEncoding;)Z
+}
+
 public final class sk/ainet/lang/memory/DescribeKt {
 	public static final fun describe (Lsk/ainet/lang/tensor/Tensor;)Ljava/lang/String;
 	public static final fun describe (Lsk/ainet/lang/tensor/storage/TensorStorage;Lsk/ainet/lang/tensor/TensorId;)Ljava/lang/String;
@@ -980,6 +1013,16 @@ public final class sk/ainet/lang/memory/PlatformStorageInfo {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class sk/ainet/lang/memory/ScalePlacement : java/lang/Enum {
+	public static final field BLOCK_HEAD Lsk/ainet/lang/memory/ScalePlacement;
+	public static final field BLOCK_TAIL Lsk/ainet/lang/memory/ScalePlacement;
+	public static final field NONE Lsk/ainet/lang/memory/ScalePlacement;
+	public static final field PER_TENSOR Lsk/ainet/lang/memory/ScalePlacement;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lsk/ainet/lang/memory/ScalePlacement;
+	public static fun values ()[Lsk/ainet/lang/memory/ScalePlacement;
+}
+
 public abstract interface class sk/ainet/lang/memory/Scope : java/lang/AutoCloseable {
 	public abstract fun allocate (JLsk/ainet/lang/tensor/storage/MemoryDomain;Lsk/ainet/lang/tensor/TensorId;)Lsk/ainet/lang/memory/Storage;
 	public static synthetic fun allocate$default (Lsk/ainet/lang/memory/Scope;JLsk/ainet/lang/tensor/storage/MemoryDomain;Lsk/ainet/lang/tensor/TensorId;ILjava/lang/Object;)Lsk/ainet/lang/memory/Storage;
@@ -1159,6 +1202,38 @@ public final class sk/ainet/lang/memory/TensorView$Companion {
 	public static synthetic fun dense$default (Lsk/ainet/lang/memory/TensorView$Companion;Lsk/ainet/lang/memory/Storage;Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/types/DType;Lsk/ainet/lang/tensor/TensorId;ILjava/lang/Object;)Lsk/ainet/lang/memory/TensorView;
 	public final fun packed (Lsk/ainet/lang/memory/Storage;Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/tensor/storage/TensorEncoding;Lsk/ainet/lang/memory/BlockDecoder;Lsk/ainet/lang/types/DType;Lsk/ainet/lang/tensor/TensorId;)Lsk/ainet/lang/memory/TensorView;
 	public static synthetic fun packed$default (Lsk/ainet/lang/memory/TensorView$Companion;Lsk/ainet/lang/memory/Storage;Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/tensor/storage/TensorEncoding;Lsk/ainet/lang/memory/BlockDecoder;Lsk/ainet/lang/types/DType;Lsk/ainet/lang/tensor/TensorId;ILjava/lang/Object;)Lsk/ainet/lang/memory/TensorView;
+}
+
+public final class sk/ainet/lang/memory/TernaryBlockDecoder : sk/ainet/lang/memory/BlockDecoder {
+	public fun <init> (Lsk/ainet/lang/tensor/storage/TensorEncoding;)V
+	public fun decodeBlock (Lsk/ainet/lang/memory/Storage;J[FI)V
+	public fun decodeElement (Lsk/ainet/lang/memory/Storage;Lsk/ainet/lang/memory/Layout;J)F
+	public fun getBlockSize ()I
+	public fun getBytesPerBlock ()I
+}
+
+public final class sk/ainet/lang/memory/TernaryCodec {
+	public static final field INSTANCE Lsk/ainet/lang/memory/TernaryCodec;
+	public final fun bitNetScale ([BII)F
+	public static synthetic fun bitNetScale$default (Lsk/ainet/lang/memory/TernaryCodec;[BIIILjava/lang/Object;)F
+	public final fun codes (Lsk/ainet/lang/tensor/storage/TensorEncoding;[BII)[B
+	public static synthetic fun codes$default (Lsk/ainet/lang/memory/TernaryCodec;Lsk/ainet/lang/tensor/storage/TensorEncoding;[BIIILjava/lang/Object;)[B
+	public final fun codesTq1_0 ([BII)[B
+	public static synthetic fun codesTq1_0$default (Lsk/ainet/lang/memory/TernaryCodec;[BIIILjava/lang/Object;)[B
+	public final fun codesTq2_0 ([BII)[B
+	public static synthetic fun codesTq2_0$default (Lsk/ainet/lang/memory/TernaryCodec;[BIIILjava/lang/Object;)[B
+	public final fun decode (Lsk/ainet/lang/tensor/storage/TensorEncoding;[BII)[F
+	public static synthetic fun decode$default (Lsk/ainet/lang/memory/TernaryCodec;Lsk/ainet/lang/tensor/storage/TensorEncoding;[BIIILjava/lang/Object;)[F
+	public final fun decodeBitNet ([BII)[F
+	public static synthetic fun decodeBitNet$default (Lsk/ainet/lang/memory/TernaryCodec;[BIIILjava/lang/Object;)[F
+	public final fun decodeTq1_0 ([BII)[F
+	public static synthetic fun decodeTq1_0$default (Lsk/ainet/lang/memory/TernaryCodec;[BIIILjava/lang/Object;)[F
+	public final fun decodeTq2_0 ([BII)[F
+	public static synthetic fun decodeTq2_0$default (Lsk/ainet/lang/memory/TernaryCodec;[BIIILjava/lang/Object;)[F
+	public final fun encode (Lsk/ainet/lang/tensor/storage/TensorEncoding;[F)[B
+	public final fun encodeBitNet ([F)[B
+	public final fun encodeTq1_0 ([F)[B
+	public final fun encodeTq2_0 ([F)[B
 }
 
 public final class sk/ainet/lang/memory/plan/ActualMemory {
@@ -6716,6 +6791,16 @@ public abstract interface class sk/ainet/lang/tensor/storage/TensorEncoding {
 	public abstract fun physicalBytes (J)Ljava/lang/Long;
 }
 
+public final class sk/ainet/lang/tensor/storage/TensorEncoding$BITNET_B1_58 : sk/ainet/lang/tensor/storage/TensorEncoding {
+	public static final field INSTANCE Lsk/ainet/lang/tensor/storage/TensorEncoding$BITNET_B1_58;
+	public static final field SCALE_BYTES I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun physicalBytes (J)Ljava/lang/Long;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class sk/ainet/lang/tensor/storage/TensorEncoding$Dense : sk/ainet/lang/tensor/storage/TensorEncoding {
 	public fun <init> (I)V
 	public final fun component1 ()I
@@ -6813,6 +6898,28 @@ public final class sk/ainet/lang/tensor/storage/TensorEncoding$Q8_0 : sk/ainet/l
 	public static final field BLOCK_SIZE I
 	public static final field BYTES_PER_BLOCK I
 	public static final field INSTANCE Lsk/ainet/lang/tensor/storage/TensorEncoding$Q8_0;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun physicalBytes (J)Ljava/lang/Long;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/lang/tensor/storage/TensorEncoding$TQ1_0 : sk/ainet/lang/tensor/storage/TensorEncoding {
+	public static final field BLOCK_SIZE I
+	public static final field BYTES_PER_BLOCK I
+	public static final field INSTANCE Lsk/ainet/lang/tensor/storage/TensorEncoding$TQ1_0;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun physicalBytes (J)Ljava/lang/Long;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class sk/ainet/lang/tensor/storage/TensorEncoding$TQ2_0 : sk/ainet/lang/tensor/storage/TensorEncoding {
+	public static final field BLOCK_SIZE I
+	public static final field BYTES_PER_BLOCK I
+	public static final field INSTANCE Lsk/ainet/lang/tensor/storage/TensorEncoding$TQ2_0;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getName ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/memory/BlockSpec.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/memory/BlockSpec.kt
@@ -1,0 +1,100 @@
+package sk.ainet.lang.memory
+
+import sk.ainet.lang.tensor.storage.TensorEncoding
+import sk.ainet.lang.types.Int8
+
+/** Where an encoding keeps the scale that turns a stored code back into a value. */
+@ExperimentalMemoryApi
+public enum class ScalePlacement {
+    /** No scale in the bytes — the codes *are* the values, or the scale lives outside the buffer. */
+    NONE,
+
+    /** One or more scales at the start of each block (Q4_0's `d`, Q4_K's `d`/`dmin`). */
+    BLOCK_HEAD,
+
+    /** One or more scales at the end of each block (TQ1_0, TQ2_0, Q6_K). */
+    BLOCK_TAIL,
+
+    /** A single scale for the whole tensor, after the packed codes (BitNet b1.58). */
+    PER_TENSOR,
+}
+
+/**
+ * The block geometry of a packed [TensorEncoding] — the descriptor a decoder, a planner and a
+ * fixture generator can all be driven from, so they cannot drift apart (SKEEP-003 §5.3; #988).
+ *
+ * `blockSize` elements occupy `bytesPerBlock` bytes. An encoding whose whole tensor is one block
+ * (SKaiNET's own ternary packing, BitNet b1.58) reports [PER_TENSOR_BLOCK] and a `bytesPerBlock`
+ * of `0`: for those, ask [TensorEncoding.physicalBytes] for the byte count and use
+ * [bitsPerElement] for the rate.
+ *
+ * @property bitsPerElement payload bits per element, *excluding* per-block scales — the number
+ *   that names the format ("1.58-bit", "4-bit"), not its on-disk rate; [amortisedBitsPerElement]
+ *   is the honest one.
+ * @property activation the format a kernel is expected to quantize the *other* operand to
+ *   (`W1.58A8` → `Format(Int8, Dense(1))`), or `null` when the kernel consumes floats.
+ */
+@ExperimentalMemoryApi
+public data class BlockSpec(
+    val blockSize: Int,
+    val bytesPerBlock: Int,
+    val bitsPerElement: Double,
+    val scale: ScalePlacement,
+    val activation: Format? = null,
+) {
+    /** True when the tensor is a single block rather than a sequence of fixed-size ones. */
+    public val isPerTensor: Boolean get() = blockSize == PER_TENSOR_BLOCK
+
+    /**
+     * Bits per element actually written, scales included — `bytesPerBlock * 8 / blockSize`
+     * (2.06 for TQ2_0, 1.6875 for TQ1_0), or [bitsPerElement] for a per-tensor encoding.
+     */
+    public val amortisedBitsPerElement: Double
+        get() = if (isPerTensor) bitsPerElement else bytesPerBlock * 8.0 / blockSize
+
+    public companion object {
+        /** [blockSize] value meaning "the whole tensor is one block". */
+        public const val PER_TENSOR_BLOCK: Int = 0
+
+        /** The activation format of the ternary kernels: int8, one byte per element (`W1.58A8`). */
+        public val INT8_ACTIVATION: Format = Format(Int8, TensorEncoding.Dense(1))
+    }
+}
+
+/**
+ * The [BlockSpec] of this encoding, or `null` when it is not block-structured ([TensorEncoding.Dense])
+ * or its layout is unknown ([TensorEncoding.Opaque]).
+ *
+ * This table is the single source for the block geometry: the reference decoders
+ * ([TernaryCodec]), the fixture generators and `EncodingSpecTest` all read it, so a wrong constant
+ * fails a test rather than silently mis-decoding a file.
+ */
+@ExperimentalMemoryApi
+public val TensorEncoding.blockSpec: BlockSpec?
+    get() = when (this) {
+        is TensorEncoding.Dense -> null
+        is TensorEncoding.Opaque -> null
+        TensorEncoding.Q4_0 -> BlockSpec(32, 18, 4.0, ScalePlacement.BLOCK_HEAD)
+        TensorEncoding.Q5_0 -> BlockSpec(32, 22, 5.0, ScalePlacement.BLOCK_HEAD)
+        TensorEncoding.Q5_1 -> BlockSpec(32, 24, 5.0, ScalePlacement.BLOCK_HEAD)
+        TensorEncoding.Q8_0 -> BlockSpec(32, 34, 8.0, ScalePlacement.BLOCK_HEAD)
+        TensorEncoding.Q4_K -> BlockSpec(256, 144, 4.0, ScalePlacement.BLOCK_HEAD)
+        TensorEncoding.Q5_K -> BlockSpec(256, 176, 5.0, ScalePlacement.BLOCK_HEAD)
+        TensorEncoding.Q6_K -> BlockSpec(256, 210, 6.0, ScalePlacement.BLOCK_TAIL)
+        TensorEncoding.TQ1_0 -> BlockSpec(256, 54, 1.625, ScalePlacement.BLOCK_TAIL, BlockSpec.INT8_ACTIVATION)
+        TensorEncoding.TQ2_0 -> BlockSpec(256, 66, 2.0, ScalePlacement.BLOCK_TAIL, BlockSpec.INT8_ACTIVATION)
+        TensorEncoding.TernaryPacked ->
+            BlockSpec(BlockSpec.PER_TENSOR_BLOCK, 0, 2.0, ScalePlacement.NONE, BlockSpec.INT8_ACTIVATION)
+        TensorEncoding.BITNET_B1_58 ->
+            BlockSpec(BlockSpec.PER_TENSOR_BLOCK, 0, 2.0, ScalePlacement.PER_TENSOR, BlockSpec.INT8_ACTIVATION)
+        is TensorEncoding.TurboQuantPolar ->
+            BlockSpec(blockSize, (physicalBytes(blockSize.toLong()) ?: 0L).toInt(), bitsPerElement.toDouble(), ScalePlacement.BLOCK_HEAD)
+        is TensorEncoding.TurboQuantPolarQjl ->
+            BlockSpec(blockSize, (physicalBytes(blockSize.toLong()) ?: 0L).toInt(), (bitsPerElement + residualBits).toDouble(), ScalePlacement.BLOCK_HEAD)
+    }
+
+/** True when this encoding stores ternary values (`-1, 0, +1`) — the M2 kernel family. */
+@ExperimentalMemoryApi
+public val TensorEncoding.isTernary: Boolean
+    get() = this == TensorEncoding.TQ1_0 || this == TensorEncoding.TQ2_0 ||
+        this == TensorEncoding.TernaryPacked || this == TensorEncoding.BITNET_B1_58

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/memory/TernaryCodec.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/memory/TernaryCodec.kt
@@ -1,0 +1,330 @@
+package sk.ainet.lang.memory
+
+import sk.ainet.lang.tensor.storage.TensorEncoding
+import sk.ainet.lang.types.Fp16Codec
+import kotlin.math.abs
+import kotlin.math.round
+
+/**
+ * Reference encoder/decoder for the ternary encodings, driven by their [BlockSpec].
+ *
+ * These are the *semantics* of `TQ1_0`, `TQ2_0` and BitNet b1.58 — plain, allocation-simple Kotlin
+ * that runs on every target, the thing a NEON or SIMD kernel is later checked against (M2-F1/F2,
+ * #1040/#1041). The GGML layouts are reproduced exactly as `ggml-quants.c`'s
+ * `quantize_row_tq{1,2}_0_ref` / `dequantize_row_tq{1,2}_0` define them, **interleaving included**:
+ *
+ * - `TQ2_0`: byte `j + m` of a 32-byte chunk holds four elements 32 apart, element
+ *   `chunk*128 + l*32 + m` in bit pair `l`.
+ * - `TQ1_0`: five base-3 digits per byte, most significant first, the byte scaled by `256/243`;
+ *   digits are read back with `(b * 3^n) mod 256 * 3 shr 8`. The first 32 bytes carry elements
+ *   `n*32 + m`, the next 16 bytes `160 + n*16 + m`, the four `qh` bytes `240 + n*4 + j`.
+ *
+ * Both round-trip exactly for ternary input: `decode(encode(v)) == v * fp16(amax)`.
+ */
+@ExperimentalMemoryApi
+public object TernaryCodec {
+
+    /** Powers of three, as `dequantize_row_tq1_0`'s `pow3` table. */
+    private val POW3 = intArrayOf(1, 3, 9, 27, 81, 243)
+
+    private const val QK: Int = 256
+
+    // --- TQ2_0 -------------------------------------------------------------------------------
+
+    /**
+     * Encode [values] (a whole number of 256-element blocks) to `TQ2_0` bytes, quantizing each
+     * block by its own absmax as `quantize_row_tq2_0_ref` does.
+     */
+    public fun encodeTq2_0(values: FloatArray): ByteArray {
+        val blocks = blockCountOf(values.size, TensorEncoding.TQ2_0)
+        val out = ByteArray(blocks * TensorEncoding.TQ2_0.BYTES_PER_BLOCK)
+        for (b in 0 until blocks) {
+            val base = b * QK
+            val d = absmax(values, base)
+            val id = if (d != 0f) 1f / d else 0f
+            val off = b * TensorEncoding.TQ2_0.BYTES_PER_BLOCK
+            for (chunk in 0 until 2) {                       // two 32-byte chunks of 128 elements
+                for (m in 0 until 32) {
+                    var q = 0
+                    for (n in 0 until 4) {
+                        val xi = round(values[base + chunk * 128 + m + n * 32] * id).toInt() + 1
+                        q = q or ((xi and 3) shl (2 * n))
+                    }
+                    out[off + chunk * 32 + m] = q.toByte()
+                }
+            }
+            le16(out, off + 64, Fp16Codec.encode(d))
+        }
+        return out
+    }
+
+    /** Decode [elementCount] elements of `TQ2_0` [bytes] starting at [byteOffset]. */
+    public fun decodeTq2_0(bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): FloatArray {
+        val codes = codesTq2_0(bytes, elementCount, byteOffset)
+        return scaleByBlock(codes, bytes, byteOffset, TensorEncoding.TQ2_0.BYTES_PER_BLOCK, scaleOffset = 64)
+    }
+
+    /** The raw ternary codes (`-1, 0, +1`) of `TQ2_0` [bytes] — the form a ternary kernel wants. */
+    public fun codesTq2_0(bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): ByteArray {
+        val out = ByteArray(elementCount)
+        val blocks = (elementCount + QK - 1) / QK
+        var w = 0
+        for (b in 0 until blocks) {
+            val off = byteOffset + b * TensorEncoding.TQ2_0.BYTES_PER_BLOCK
+            for (chunk in 0 until 2) {
+                for (l in 0 until 4) {
+                    for (m in 0 until 32) {
+                        if (w >= elementCount) return out
+                        val q = (bytes[off + chunk * 32 + m].toInt() shr (l * 2)) and 3
+                        out[w++] = (q - 1).toByte()
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    // --- TQ1_0 -------------------------------------------------------------------------------
+
+    /** Encode [values] (a whole number of 256-element blocks) to `TQ1_0` bytes. */
+    public fun encodeTq1_0(values: FloatArray): ByteArray {
+        val blocks = blockCountOf(values.size, TensorEncoding.TQ1_0)
+        val out = ByteArray(blocks * TensorEncoding.TQ1_0.BYTES_PER_BLOCK)
+        for (b in 0 until blocks) {
+            val base = b * QK
+            val d = absmax(values, base)
+            val id = if (d != 0f) 1f / d else 0f
+            val off = b * TensorEncoding.TQ1_0.BYTES_PER_BLOCK
+            var e = base                                     // element cursor within the block
+            for (m in 0 until 32) {                          // qs[0..31]: 5 digits, stride 32
+                out[off + m] = base3Byte(values, e + m, 32, 5, id, extraTriple = false)
+            }
+            e += 5 * 32
+            for (m in 0 until 16) {                          // qs[32..47]: 5 digits, stride 16
+                out[off + 32 + m] = base3Byte(values, e + m, 16, 5, id, extraTriple = false)
+            }
+            e += 5 * 16
+            for (j in 0 until 4) {                           // qh[0..3]: 4 digits, stride 4
+                out[off + 48 + j] = base3Byte(values, e + j, 4, 4, id, extraTriple = true)
+            }
+            le16(out, off + 52, Fp16Codec.encode(d))
+        }
+        return out
+    }
+
+    /** Decode [elementCount] elements of `TQ1_0` [bytes] starting at [byteOffset]. */
+    public fun decodeTq1_0(bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): FloatArray {
+        val codes = codesTq1_0(bytes, elementCount, byteOffset)
+        return scaleByBlock(codes, bytes, byteOffset, TensorEncoding.TQ1_0.BYTES_PER_BLOCK, scaleOffset = 52)
+    }
+
+    /** The raw ternary codes (`-1, 0, +1`) of `TQ1_0` [bytes]. */
+    public fun codesTq1_0(bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): ByteArray {
+        val out = ByteArray(elementCount)
+        val blocks = (elementCount + QK - 1) / QK
+        var w = 0
+        for (b in 0 until blocks) {
+            val off = byteOffset + b * TensorEncoding.TQ1_0.BYTES_PER_BLOCK
+            for (n in 0 until 5) {                           // 32-byte section → 160 elements
+                for (m in 0 until 32) {
+                    if (w >= elementCount) return out
+                    out[w++] = digit(bytes[off + m].toInt(), n)
+                }
+            }
+            for (n in 0 until 5) {                           // 16-byte section → 80 elements
+                for (m in 0 until 16) {
+                    if (w >= elementCount) return out
+                    out[w++] = digit(bytes[off + 32 + m].toInt(), n)
+                }
+            }
+            for (n in 0 until 4) {                           // qh → the last 16 elements
+                for (j in 0 until 4) {
+                    if (w >= elementCount) return out
+                    out[w++] = digit(bytes[off + 48 + j].toInt(), n)
+                }
+            }
+        }
+        return out
+    }
+
+    // --- BitNet b1.58 ------------------------------------------------------------------------
+
+    /**
+     * Encode [values] as BitNet b1.58: ternary codes four per byte in element order, followed by
+     * one FP32 scale for the whole tensor (the absmean quantizer's `1/scale` rounding, clamped to
+     * `-1, 0, +1`).
+     */
+    public fun encodeBitNet(values: FloatArray): ByteArray {
+        val scale = absmean(values)
+        val id = if (scale != 0f) 1f / scale else 0f
+        val payload = (values.size + 3) / 4
+        val out = ByteArray(payload + TensorEncoding.BITNET_B1_58.SCALE_BYTES)
+        for (i in values.indices) {
+            val code = round(values[i] * id).toInt().coerceIn(-1, 1) + 1
+            val byteIndex = i / 4
+            val shift = (i % 4) * 2
+            out[byteIndex] = (out[byteIndex].toInt() or (code shl shift)).toByte()
+        }
+        le32(out, payload, scale.toRawBits())
+        return out
+    }
+
+    /** Decode [elementCount] BitNet b1.58 elements: `code - 1` times the tensor's FP32 scale. */
+    public fun decodeBitNet(bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): FloatArray {
+        val payload = (elementCount + 3) / 4
+        val scale = Float.fromBits(le32(bytes, byteOffset + payload))
+        val out = FloatArray(elementCount)
+        for (i in 0 until elementCount) {
+            val code = (bytes[byteOffset + i / 4].toInt() shr ((i % 4) * 2)) and 3
+            out[i] = (code - 1).toFloat() * scale
+        }
+        return out
+    }
+
+    /** The FP32 scale of a BitNet b1.58 buffer holding [elementCount] elements. */
+    public fun bitNetScale(bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): Float =
+        Float.fromBits(le32(bytes, byteOffset + (elementCount + 3) / 4))
+
+    // --- dispatch ----------------------------------------------------------------------------
+
+    /**
+     * Decode [elementCount] elements of any ternary [encoding] — the entry point a kernel, a
+     * fixture generator or [TernaryBlockDecoder] uses instead of switching on the encoding itself.
+     *
+     * @throws IllegalArgumentException if [encoding] is not one of the ternary encodings with bytes
+     *   of their own ([TensorEncoding.TernaryPacked] keeps its scale outside the buffer — decode it
+     *   through its `TensorData`).
+     */
+    public fun decode(encoding: TensorEncoding, bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): FloatArray =
+        when (encoding) {
+            TensorEncoding.TQ1_0 -> decodeTq1_0(bytes, elementCount, byteOffset)
+            TensorEncoding.TQ2_0 -> decodeTq2_0(bytes, elementCount, byteOffset)
+            TensorEncoding.BITNET_B1_58 -> decodeBitNet(bytes, elementCount, byteOffset)
+            else -> throw IllegalArgumentException("$encoding is not a self-contained ternary encoding")
+        }
+
+    /**
+     * The ternary codes (`-1, 0, +1`) of any self-contained ternary [encoding], scale not applied —
+     * what a `bitnet_gemv` kernel consumes (#1040).
+     */
+    public fun codes(encoding: TensorEncoding, bytes: ByteArray, elementCount: Int, byteOffset: Int = 0): ByteArray =
+        when (encoding) {
+            TensorEncoding.TQ1_0 -> codesTq1_0(bytes, elementCount, byteOffset)
+            TensorEncoding.TQ2_0 -> codesTq2_0(bytes, elementCount, byteOffset)
+            TensorEncoding.BITNET_B1_58 -> ByteArray(elementCount) {
+                (((bytes[byteOffset + it / 4].toInt() shr ((it % 4) * 2)) and 3) - 1).toByte()
+            }
+            else -> throw IllegalArgumentException("$encoding is not a self-contained ternary encoding")
+        }
+
+    /** Encode [values] in any ternary [encoding] — the inverse of [decode]. */
+    public fun encode(encoding: TensorEncoding, values: FloatArray): ByteArray =
+        when (encoding) {
+            TensorEncoding.TQ1_0 -> encodeTq1_0(values)
+            TensorEncoding.TQ2_0 -> encodeTq2_0(values)
+            TensorEncoding.BITNET_B1_58 -> encodeBitNet(values)
+            else -> throw IllegalArgumentException("$encoding is not a self-contained ternary encoding")
+        }
+
+    // --- helpers -----------------------------------------------------------------------------
+
+    private fun blockCountOf(elementCount: Int, encoding: TensorEncoding): Int {
+        val spec = encoding.blockSpec ?: throw IllegalArgumentException("$encoding has no block spec")
+        require(elementCount % spec.blockSize == 0) {
+            "${encoding.name} encodes whole blocks of ${spec.blockSize}; got $elementCount elements"
+        }
+        return elementCount / spec.blockSize
+    }
+
+    /** `q * 3^n mod 256`, then the leading base-3 digit — `dequantize_row_tq1_0`'s extraction. */
+    private fun digit(byte: Int, n: Int): Byte {
+        val q = ((byte and 0xFF) * POW3[n]) and 0xFF
+        return (((q * 3) shr 8) - 1).toByte()
+    }
+
+    /** Multiply per-block codes by that block's FP16 scale, read at [scaleOffset] within the block. */
+    private fun scaleByBlock(codes: ByteArray, bytes: ByteArray, byteOffset: Int, bytesPerBlock: Int, scaleOffset: Int): FloatArray {
+        val out = FloatArray(codes.size)
+        for (i in codes.indices) {
+            val block = i / QK
+            val d = Fp16Codec.decode(le16(bytes, byteOffset + block * bytesPerBlock + scaleOffset))
+            out[i] = codes[i].toFloat() * d
+        }
+        return out
+    }
+
+    /**
+     * Pack [digits] ternary values starting at [first], spaced [stride] apart, into one base-3 byte
+     * scaled by `256/243` — `quantize_row_tq1_0_ref`. [extraTriple] applies the extra `*3` the
+     * reference does for the four-digit `qh` bytes.
+     */
+    private fun base3Byte(values: FloatArray, first: Int, stride: Int, digits: Int, id: Float, extraTriple: Boolean): Byte {
+        var q = 0
+        for (n in 0 until digits) {
+            val xi = round(values[first + n * stride] * id).toInt() + 1
+            q = q * 3 + xi
+        }
+        if (extraTriple) q *= 3
+        return ((q * 256 + 242) / 243).toByte()
+    }
+
+    private fun absmax(values: FloatArray, base: Int): Float {
+        var amax = 0f
+        for (j in 0 until QK) amax = maxOf(amax, abs(values[base + j]))
+        return amax
+    }
+
+    private fun absmean(values: FloatArray): Float {
+        if (values.isEmpty()) return 0f
+        var sum = 0.0
+        for (v in values) sum += abs(v)
+        return (sum / values.size).toFloat()
+    }
+
+    private fun le16(b: ByteArray, off: Int, v: Int) {
+        b[off] = (v and 0xFF).toByte()
+        b[off + 1] = ((v ushr 8) and 0xFF).toByte()
+    }
+
+    private fun le16(b: ByteArray, off: Int): Int =
+        (b[off].toInt() and 0xFF) or ((b[off + 1].toInt() and 0xFF) shl 8)
+
+    private fun le32(b: ByteArray, off: Int, v: Int) {
+        b[off] = (v and 0xFF).toByte()
+        b[off + 1] = ((v ushr 8) and 0xFF).toByte()
+        b[off + 2] = ((v ushr 16) and 0xFF).toByte()
+        b[off + 3] = ((v ushr 24) and 0xFF).toByte()
+    }
+
+    private fun le32(b: ByteArray, off: Int): Int =
+        (b[off].toInt() and 0xFF) or ((b[off + 1].toInt() and 0xFF) shl 8) or
+            ((b[off + 2].toInt() and 0xFF) shl 16) or ((b[off + 3].toInt() and 0xFF) shl 24)
+}
+
+/**
+ * A [BlockDecoder] for a ternary [encoding], reading its bytes straight out of the storage —
+ * the descriptor-driven path a `TensorView` over `TQ1_0`/`TQ2_0`/BitNet bytes decodes through
+ * (SKEEP-003 §4.4: `get()` decodes, never a raw byte).
+ */
+@ExperimentalMemoryApi
+public class TernaryBlockDecoder(private val encoding: TensorEncoding) : BlockDecoder {
+
+    private val spec: BlockSpec = encoding.blockSpec
+        ?: throw IllegalArgumentException("$encoding has no block spec")
+
+    init {
+        require(encoding.isTernary) { "$encoding is not a ternary encoding" }
+        require(!spec.isPerTensor) { "${encoding.name} is a per-tensor encoding; decode it through its TensorData" }
+    }
+
+    override val blockSize: Int get() = spec.blockSize
+    override val bytesPerBlock: Int get() = spec.bytesPerBlock
+
+    override fun decodeBlock(storage: Storage, blockIndex: Long, out: FloatArray, outOffset: Int) {
+        val heap = storage as? Storage.Heap
+            ?: throw UnsupportedOperationException("ternary views need heap storage in this milestone")
+        val bytes = heap.bytes ?: throw UnsupportedOperationException("ternary views need byte storage")
+        val off = heap.arrayOffset + (blockIndex * bytesPerBlock).toInt()
+        TernaryCodec.decode(encoding, bytes, blockSize, off).copyInto(out, outOffset)
+    }
+}

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/data/TernaryTensorData.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/data/TernaryTensorData.kt
@@ -134,11 +134,15 @@ public class Ternary2BitTensorData(
         public fun fromTQ2_0Block(blockData: ByteArray, shape: Shape): Ternary2BitTensorData {
             require(blockData.size >= 66) { "TQ2_0 block must be at least 66 bytes" }
 
-            val qsData = blockData.copyOfRange(0, 64)
             val scaleBits = (blockData[65].toInt() and 0xFF shl 8) or (blockData[64].toInt() and 0xFF)
             val scale = halfToFloat(scaleBits)
 
-            return Ternary2BitTensorData(shape, qsData, scale)
+            // TQ2_0 interleaves: byte `j + m` holds four elements 32 apart, so the bytes cannot be
+            // adopted verbatim — decode them through the reference codec (#1033) and re-pack into
+            // this type's four-consecutive-elements-per-byte layout.
+            @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
+            val codes = sk.ainet.lang.memory.TernaryCodec.codesTq2_0(blockData, minOf(shape.volume, 256))
+            return fromTernaryValues(shape, codes.copyOf(shape.volume), scale)
         }
 
         /**

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/TensorEncoding.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/TensorEncoding.kt
@@ -112,11 +112,74 @@ public sealed interface TensorEncoding {
         }
     }
 
-    /** Ternary encoding: 2 bits per element, packed 4 elements per byte. */
+    /**
+     * SKaiNET's own ternary packing: 2 bits per element, four **consecutive** elements per byte
+     * (element `i` in bits `2*(i % 4)`), code `0,1,2` → `-1,0,+1`, and the scale held out of band
+     * by the tensor ([sk.ainet.lang.tensor.data.TernaryTensorData.scale]) rather than in the bytes.
+     *
+     * This is *not* the GGML on-disk layout: [TQ2_0] carries an FP16 scale per 256-element block
+     * and interleaves its elements 32 apart. Use [TQ1_0]/[TQ2_0] for GGUF bytes and this encoding
+     * for tensors SKaiNET packs itself.
+     */
     public data object TernaryPacked : TensorEncoding {
         override val name: String get() = "Ternary"
         override fun physicalBytes(elementCount: Long): Long =
             (elementCount + 3) / 4
+    }
+
+    /**
+     * GGML `TQ1_0` — ternary at ~1.69 bits/element: 256 elements per 54-byte block, made of 48
+     * base-3 bytes (five ternary digits each, most-significant digit first, scaled by `256/243`),
+     * 4 bytes holding the last 16 elements four at a time, and an FP16 block scale.
+     *
+     * Element order follows `dequantize_row_tq1_0`: the first 32 bytes carry elements
+     * `n*32 + m` (`n` = digit, `m` = byte), the next 16 bytes elements `160 + n*16 + m`, and the
+     * four `qh` bytes elements `240 + n*4 + j` — decoded by
+     * [sk.ainet.lang.memory.TernaryCodec.decodeTq1_0].
+     */
+    public data object TQ1_0 : TensorEncoding {
+        public const val BLOCK_SIZE: Int = 256
+        public const val BYTES_PER_BLOCK: Int = 54
+
+        override val name: String get() = "TQ1_0"
+        override fun physicalBytes(elementCount: Long): Long {
+            val blocks = (elementCount + BLOCK_SIZE - 1) / BLOCK_SIZE
+            return blocks * BYTES_PER_BLOCK
+        }
+    }
+
+    /**
+     * GGML `TQ2_0` — ternary at ~2.06 bits/element: 256 elements per 66-byte block (64 payload
+     * bytes + an FP16 scale). Each byte holds four elements **32 apart**, not four consecutive
+     * ones: byte `j + m` of a 32-byte chunk carries element `chunk*128 + l*32 + m` in bit pair `l`
+     * (`dequantize_row_tq2_0`) — see [sk.ainet.lang.memory.TernaryCodec.decodeTq2_0].
+     */
+    public data object TQ2_0 : TensorEncoding {
+        public const val BLOCK_SIZE: Int = 256
+        public const val BYTES_PER_BLOCK: Int = 66
+
+        override val name: String get() = "TQ2_0"
+        override fun physicalBytes(elementCount: Long): Long {
+            val blocks = (elementCount + BLOCK_SIZE - 1) / BLOCK_SIZE
+            return blocks * BYTES_PER_BLOCK
+        }
+    }
+
+    /**
+     * BitNet b1.58 weights: ternary at 2 bits per element, four consecutive elements per byte, with
+     * **one FP32 scale for the whole tensor** (b1.58 quantizes per tensor by absmean) stored little
+     * endian in the four bytes after the payload.
+     *
+     * Distinct from [TQ1_0]/[TQ2_0], which are how a b1.58 checkpoint is usually *shipped* in GGUF:
+     * this is the in-memory form the ternary kernels consume, whose activations are int8
+     * (`W1.58A8` — see [sk.ainet.lang.memory.blockSpec] and its `activation` hint).
+     */
+    public data object BITNET_B1_58 : TensorEncoding {
+        /** Bytes of per-tensor scale appended after the packed codes. */
+        public const val SCALE_BYTES: Int = 4
+
+        override val name: String get() = "BitNet-b1.58"
+        override fun physicalBytes(elementCount: Long): Long = (elementCount + 3) / 4 + SCALE_BYTES
     }
 
     /**

--- a/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/memory/TernaryEncodingTest.kt
+++ b/skainet-lang/skainet-lang-core/src/commonTest/kotlin/sk/ainet/lang/memory/TernaryEncodingTest.kt
@@ -1,0 +1,221 @@
+package sk.ainet.lang.memory
+
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.storage.TensorEncoding
+import sk.ainet.lang.types.FP32
+import sk.ainet.lang.types.Fp16Codec
+import sk.ainet.lang.types.Int8
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * #1033 (M2-F1/F2): the ternary encodings and the descriptor that drives their reference decoder.
+ *
+ * The layout assertions are transcribed from `ggml-quants.c` — `quantize_row_tq{1,2}_0_ref` and
+ * `dequantize_row_tq{1,2}_0`. They are the point of this test: a ternary format that decodes in
+ * the wrong element order still produces plausible-looking numbers, so the interleave is pinned
+ * explicitly rather than only round-tripped.
+ */
+@OptIn(ExperimentalMemoryApi::class)
+class TernaryEncodingTest {
+
+    private fun ternary(n: Int, seed: Int = 1): FloatArray {
+        var s = seed
+        return FloatArray(n) {
+            s = s * 1103515245 + 12345
+            ((s ushr 16) % 3 - 1).toFloat()
+        }
+    }
+
+    // --- the descriptor ------------------------------------------------------------------------
+
+    @Test
+    fun everyBlockSpecAgreesWithTheEncodingsOwnByteCount() {
+        val blocked = listOf(
+            TensorEncoding.Q4_0, TensorEncoding.Q5_0, TensorEncoding.Q5_1, TensorEncoding.Q8_0,
+            TensorEncoding.Q4_K, TensorEncoding.Q5_K, TensorEncoding.Q6_K,
+            TensorEncoding.TQ1_0, TensorEncoding.TQ2_0,
+            TensorEncoding.TurboQuantPolar(4, 128), TensorEncoding.TurboQuantPolarQjl(4, 1, 128),
+        )
+        for (e in blocked) {
+            val spec = e.blockSpec ?: error("${e.name} must have a block spec")
+            assertEquals(
+                spec.bytesPerBlock.toLong(), e.physicalBytes(spec.blockSize.toLong()),
+                "${e.name}: spec says ${spec.bytesPerBlock} B per ${spec.blockSize} elements",
+            )
+            assertTrue(spec.bitsPerElement <= spec.amortisedBitsPerElement, "${e.name}: payload bits exceed the on-disk rate")
+        }
+    }
+
+    @Test
+    fun theTernaryFamilyIsDescribedAsTernaryWithInt8Activations() {
+        for (e in listOf(TensorEncoding.TQ1_0, TensorEncoding.TQ2_0, TensorEncoding.TernaryPacked, TensorEncoding.BITNET_B1_58)) {
+            assertTrue(e.isTernary, "${e.name} must be ternary")
+            assertEquals(Format(Int8, TensorEncoding.Dense(1)), e.blockSpec?.activation, "${e.name}: W1.58A8")
+        }
+        assertTrue(!TensorEncoding.Q4_K.isTernary)
+        assertNull(TensorEncoding.Dense(4).blockSpec, "dense is not block-structured")
+        assertNull(TensorEncoding.Opaque("X", 10).blockSpec, "an opaque encoding has no known geometry")
+    }
+
+    @Test
+    fun theTernaryRatesAreWhatTheNamesClaim() {
+        assertEquals(1.625, TensorEncoding.TQ1_0.blockSpec!!.bitsPerElement, "TQ1_0 payload: 52 B per 256 elements")
+        assertEquals(1.6875, TensorEncoding.TQ1_0.blockSpec!!.amortisedBitsPerElement, "with the FP16 block scale")
+        assertEquals(2.0, TensorEncoding.TQ2_0.blockSpec!!.bitsPerElement)
+        assertEquals(2.0625, TensorEncoding.TQ2_0.blockSpec!!.amortisedBitsPerElement)
+        assertEquals(ScalePlacement.BLOCK_TAIL, TensorEncoding.TQ2_0.blockSpec!!.scale)
+        assertEquals(ScalePlacement.PER_TENSOR, TensorEncoding.BITNET_B1_58.blockSpec!!.scale)
+        assertEquals(ScalePlacement.NONE, TensorEncoding.TernaryPacked.blockSpec!!.scale, "its scale lives on the TensorData")
+    }
+
+    @Test
+    fun thePerTensorEncodingsSizeThemselvesFromTheElementCount() {
+        assertEquals(64L + 4, TensorEncoding.BITNET_B1_58.physicalBytes(256))
+        assertEquals(64L, TensorEncoding.TernaryPacked.physicalBytes(256))
+        assertTrue(TensorEncoding.BITNET_B1_58.blockSpec!!.isPerTensor)
+    }
+
+    // --- TQ2_0 ---------------------------------------------------------------------------------
+
+    @Test
+    fun tq2_0PacksFourElementsThirtyTwoApartPerByte() {
+        // ggml: byte `j + m` of a 32-byte chunk carries element `chunk*128 + l*32 + m` in bit pair `l`.
+        val values = FloatArray(256)
+        values[0] = -1f; values[32] = 0f; values[64] = 1f; values[96] = -1f
+        values[255] = 1f                                    // fixes absmax at 1.0 (exact in FP16)
+        val bytes = TernaryCodec.encodeTq2_0(values)
+        assertEquals(66, bytes.size)
+        val codes = (0 until 4).map { l -> (bytes[0].toInt() shr (2 * l)) and 3 }
+        assertEquals(listOf(0, 1, 2, 0), codes, "bit pairs of byte 0 are elements 0, 32, 64, 96")
+        assertEquals(1.0f, Fp16Codec.decode((bytes[64].toInt() and 0xFF) or ((bytes[65].toInt() and 0xFF) shl 8)), "the FP16 scale is the block tail")
+
+        // element 128 opens the second 32-byte chunk, not byte 32's second bit pair
+        val second = FloatArray(256); second[128] = 1f
+        val b2 = TernaryCodec.encodeTq2_0(second)
+        assertEquals(2, b2[32].toInt() and 3, "element 128 is byte 32, bit pair 0")
+    }
+
+    @Test
+    fun tq2_0RoundTripsExactly() {
+        val values = ternary(256 * 3, seed = 7).also { it[0] = 1f }
+        val decoded = TernaryCodec.decodeTq2_0(TernaryCodec.encodeTq2_0(values), values.size)
+        assertTrue(values.contentEquals(decoded), "TQ2_0 must round-trip ternary values exactly")
+    }
+
+    // --- TQ1_0 ---------------------------------------------------------------------------------
+
+    @Test
+    fun tq1_0PacksFiveBaseThreeDigitsPerByteMostSignificantFirst() {
+        // ggml: qs[m] holds elements m, m+32, m+64, m+96, m+128 as base-3 digits, scaled by 256/243.
+        val values = FloatArray(256)
+        values[0] = 1f                                       // digit 0 (most significant) = 2
+        values[128] = -1f                                    // digit 4 = 0
+        val bytes = TernaryCodec.encodeTq1_0(values)
+        assertEquals(54, bytes.size)
+        val v = 2 * 81 + 1 * 27 + 1 * 9 + 1 * 3 + 0          // digits 2,1,1,1,0 → codes for +1,0,0,0,-1
+        assertEquals(((v * 256 + 242) / 243).toByte(), bytes[0], "byte 0 is the scaled base-3 word")
+        assertEquals(1.0f, Fp16Codec.decode((bytes[52].toInt() and 0xFF) or ((bytes[53].toInt() and 0xFF) shl 8)))
+
+        val decoded = TernaryCodec.decodeTq1_0(bytes, 256)
+        assertEquals(1f, decoded[0]); assertEquals(0f, decoded[32]); assertEquals(-1f, decoded[128])
+    }
+
+    @Test
+    fun tq1_0PutsTheLastSixteenElementsInTheFourQhBytes() {
+        val values = FloatArray(256)
+        values[240] = 1f; values[244] = -1f; values[255] = 1f
+        val bytes = TernaryCodec.encodeTq1_0(values)
+        val decoded = TernaryCodec.decodeTq1_0(bytes, 256)
+        assertEquals(1f, decoded[240], "qh byte 0, digit 0")
+        assertEquals(-1f, decoded[244], "qh byte 0, digit 1")
+        assertEquals(1f, decoded[255], "qh byte 3, digit 3 — the last element of the block")
+        assertEquals(0f, decoded[241])
+    }
+
+    @Test
+    fun tq1_0RoundTripsExactly() {
+        val values = ternary(256 * 2, seed = 11).also { it[5] = 1f; it[256] = 1f }
+        val decoded = TernaryCodec.decodeTq1_0(TernaryCodec.encodeTq1_0(values), values.size)
+        assertTrue(values.contentEquals(decoded), "TQ1_0 must round-trip ternary values exactly")
+    }
+
+    @Test
+    fun tq1_0IsSmallerThanTq2_0WhichIsSmallerThanTwoBitsPlusNothing() {
+        val n = 256L * 40
+        assertTrue(TensorEncoding.TQ1_0.physicalBytes(n)!! < TensorEncoding.TQ2_0.physicalBytes(n)!!)
+        assertEquals(54L * 40, TensorEncoding.TQ1_0.physicalBytes(n))
+        assertEquals(66L * 40, TensorEncoding.TQ2_0.physicalBytes(n))
+    }
+
+    // --- BitNet b1.58 --------------------------------------------------------------------------
+
+    @Test
+    fun bitNetKeepsOneScaleForTheWholeTensorAndFourElementsPerByte() {
+        val values = FloatArray(64) { if (it % 3 == 0) 0.75f else if (it % 3 == 1) -0.75f else 0f }
+        val bytes = TernaryCodec.encodeBitNet(values)
+        assertEquals(64 / 4 + 4, bytes.size)
+        val scale = TernaryCodec.bitNetScale(bytes, 64)
+        assertTrue(scale > 0f, "absmean scale")
+        val decoded = TernaryCodec.decodeBitNet(bytes, 64)
+        for (i in values.indices) {
+            val expected = when {
+                values[i] > 0f -> scale
+                values[i] < 0f -> -scale
+                else -> 0f
+            }
+            assertEquals(expected, decoded[i], "element $i")
+        }
+        // four consecutive elements per byte, low pair first: codes (+1,-1,0,+1) → 2 | 0<<2 | 1<<4 | 2<<6
+        assertEquals((2 or (0 shl 2) or (1 shl 4) or (2 shl 6)).toByte(), bytes[0])
+    }
+
+    @Test
+    fun theSameValuesProduceDifferentBytesInEachTernaryEncoding() {
+        val values = ternary(256, seed = 3).also { it[0] = 1f }
+        val tq1 = TernaryCodec.encode(TensorEncoding.TQ1_0, values)
+        val tq2 = TernaryCodec.encode(TensorEncoding.TQ2_0, values)
+        val bit = TernaryCodec.encode(TensorEncoding.BITNET_B1_58, values)
+        assertNotEquals(tq1.size, tq2.size)
+        assertNotEquals(tq2.size, bit.size)
+        for (e in listOf(TensorEncoding.TQ1_0, TensorEncoding.TQ2_0)) {
+            assertTrue(TernaryCodec.decode(e, TernaryCodec.encode(e, values), 256).contentEquals(values), "${e.name} dispatch round-trip")
+        }
+        assertFailsWith<IllegalArgumentException> { TernaryCodec.encode(TensorEncoding.TernaryPacked, values) }
+        assertFailsWith<IllegalArgumentException> { TernaryCodec.encode(TensorEncoding.Q4_K, values) }
+    }
+
+    @Test
+    fun encodingRefusesAPartialBlock() {
+        assertFailsWith<IllegalArgumentException> { TernaryCodec.encodeTq2_0(FloatArray(100)) }
+        assertFailsWith<IllegalArgumentException> { TernaryCodec.encodeTq1_0(FloatArray(300)) }
+    }
+
+    // --- through a TensorView ------------------------------------------------------------------
+
+    @Test
+    fun aTernaryViewDecodesThroughTheDescriptorDrivenDecoder() {
+        val values = ternary(256 * 2, seed = 5).also { it[0] = 1f; it[300] = 1f }
+        for (encoding in listOf(TensorEncoding.TQ1_0, TensorEncoding.TQ2_0)) {
+            val bytes = TernaryCodec.encode(encoding, values)
+            val storage = Storage.Heap.wrap(bytes)
+            val decoder = TernaryBlockDecoder(encoding)
+            val view = TensorView.packed(storage, Shape(2, 256), encoding, decoder)
+            assertEquals(Format(FP32, encoding), view.format)
+            assertEquals(values[0], view.get(0, 0), "${encoding.name}: first element")
+            assertEquals(values[300], view.get(1, 44), "${encoding.name}: second row")
+            assertEquals(values[511], view.get(1, 255), "${encoding.name}: last element")
+            assertTrue(values.contentEquals(view.toFloatArray()), "${encoding.name}: whole-view decode")
+        }
+    }
+
+    @Test
+    fun perTensorEncodingsAreNotBlockDecoders() {
+        assertFailsWith<IllegalArgumentException> { TernaryBlockDecoder(TensorEncoding.TernaryPacked) }
+        assertFailsWith<IllegalArgumentException> { TernaryBlockDecoder(TensorEncoding.Q4_K) }
+    }
+}


### PR DESCRIPTION
Closes #1033 · Phase P6 · Milestone M2 · PRD: M2-F1, M2-F2 · Proposal §5.3, §10 decision #5 · #988 tie-in

## What was wrong

`TQ1_0` and `TQ2_0` existed in the GGUF type table and nowhere else:

- `ggufFormat` and `ggmlTypeToEncoding` returned `Opaque`, so nothing downstream — planner, memory report, dispatch — knew their geometry;
- `StreamingGgufParametersLoader` rejected any file containing them;
- and the two hand-written decoders in `DequantOps` walked the elements in **the wrong order**. ggml's `dequantize_row_tq2_0` packs four elements **32 apart** per byte (byte `j+m` of a 32-byte chunk holds element `chunk*128 + l*32 + m` in bit pair `l`); the old code took four *consecutive* elements per byte. `TQ1_0` was likewise read as low-to-high `%3` digits instead of `(b * 3ⁿ mod 256) * 3 shr 8` over the ggml section order, and its `qh` tail missed the extra `*3` the reference encoder applies.

A mis-ordered ternary decode still yields plausible-looking numbers — it never fails loudly — so this was pinned with explicit layout assertions rather than round-trips alone.

## What this adds

**Encodings.** `TensorEncoding.TQ1_0` (256 elements / 54 B), `TQ2_0` (256 / 66) and `BITNET_B1_58` (2 bits/element, four consecutive per byte, one FP32 tensor scale — the in-memory form the ternary kernels consume; b1.58 checkpoints ship as TQ1_0/TQ2_0). `TernaryPacked`'s KDoc no longer claims to be TQ2_0-compatible: it is SKaiNET's own packing with the scale held outside the buffer.

**Descriptor.** `BlockSpec` + `TensorEncoding.blockSpec` — block size, bytes per block, payload vs amortised bits per element, scale placement (`BLOCK_HEAD`/`BLOCK_TAIL`/`PER_TENSOR`/`NONE`), and the `activation` hint `Format(Int8, Dense(1))` (W1.58A8 — what #1040's requant adapter will produce). One table for every block encoding, so the decoder, the planner and the fixture generator cannot drift; each spec is asserted against the encoding's own `physicalBytes`.

**Reference codec.** `TernaryCodec` — encoder *and* decoder for all three, transcribed from `ggml-quants.c` (`quantize_row_tq{1,2}_0_ref` / `dequantize_row_tq{1,2}_0`), plus `codes()` returning raw `-1/0/+1` for kernels that want codes rather than floats. `TernaryBlockDecoder` makes a `TensorView` over ternary bytes decode through it — the descriptor-driven path `BlockDecoder`'s KDoc was written for ("`Encoding` descriptors in M2").

**GGUF.** Both TQ types map to real encodings in `ggufFormat` and in the reader; the loader accepts them; `DequantOps` delegates to the shared codec instead of keeping its own idea of the layout. Ternary tensors currently widen to FP32 on load — the values are right, the memory saving is not, because a packed ternary `TensorData` with per-block scales arrives with the kernels (#1040/#1041). That is stated in the code where it happens, not left to be discovered.

## Acceptance

- **`TernaryEncodingTest`** (15 cases): every `BlockSpec` agrees with its encoding's byte count; the TQ2_0 interleave and the TQ1_0 base-3 byte are checked against hand-computed values; the `qh` tail carries elements 240–255; exact round-trips over multiple blocks; a `TensorView` decodes identically; per-tensor encodings are refused as block decoders.
- **`GgufTernaryLoadTest`**: synthetic `TQ1_0`/`TQ2_0` GGUFs load through `StreamingGgufParametersLoader` with their values intact, the header reports 54 B per 256 elements and 1.625 bits/element instead of `Opaque`, and the loader's output is identical to the reference codec's.
- **Golden gate extended**: `packed/`, `decode/` and `view/` digests for TQ1_0, TQ2_0 and BitNet. TQ1_0 and TQ2_0 share a `decode` digest deliberately — the same ternary values in two different byte layouts must come back identical.
- **One golden re-baselined**: `decode/TERNARY_tq2_0`, because `Ternary2BitTensorData.fromTQ2_0Block` used to adopt the interleaved TQ2_0 payload verbatim and now decodes and re-packs. The reason is recorded next to the value.

## Gate

`scripts/pr-gate.sh` — **all legs passed**: `jvmTest` · `apiCheck` (dump regenerated, additive only) · `verifyNpmPins jsTest wasmJsTest wasmWasiTest` · `linuxX64Test` · `assemble` · `:skainet-test:skainet-test-java:test`.
`scripts/pr-gate.sh --golden` — **passed** on JVM and linuxX64.

## Keeps develop green by

New encodings are additive members of a sealed interface with no new abstract members anywhere; `blockSpec` is an extension, so `TensorEncoding` itself is untouched apart from the three additions. Every existing encoding keeps its behaviour, and the golden gate proves the other nine decode bit-identically. The only intentional behaviour changes are the two ternary decoders that were wrong, both covered by new tests and one re-baselined golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)