### PR TITLE
feat(tensor): fluent `x.matmulWeightTransposed(w)` beside matmul and t()

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/MatmulWeightTransposedTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/MatmulWeightTransposedTest.kt
@@ -3,6 +3,7 @@ package sk.ainet.exec.tensor.ops
 import sk.ainet.context.DirectCpuExecutionContext
 import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.matmulWeightTransposed
 import sk.ainet.lang.tensor.data.Q8_0BlockTensorData
 import sk.ainet.lang.tensor.data.TensorData
 import sk.ainet.lang.types.FP32
@@ -91,5 +92,25 @@ class MatmulWeightTransposedTest {
         for (i in viaPrimitive.indices) {
             assertTrue(abs(viaPrimitive[i] - viaTranspose[i]) < 1e-4f, "[$i]: ${viaPrimitive[i]} vs ${viaTranspose[i]}")
         }
+    }
+
+    @Test
+    fun `the extension is the ops call for packed and dense alike`() {
+        val x = activation()
+
+        val packed = weight()
+        assertContentEquals(
+            ctx.ops.matmulWeightTransposed(x, packed).data.copyToFloatArray(),
+            x.matmulWeightTransposed(packed).data.copyToFloatArray(),
+            "x.matmulWeightTransposed(w) must be ops.matmulWeightTransposed(x, w) for a packed weight",
+        )
+
+        val dense: Tensor<FP32, Float> =
+            ctx.fromFloatArray<FP32, Float>(Shape(outDim, inDim), FP32::class, FloatArray(outDim * inDim) { it * 0.01f })
+        assertContentEquals(
+            ctx.ops.matmulWeightTransposed(x, dense).data.copyToFloatArray(),
+            x.matmulWeightTransposed(dense).data.copyToFloatArray(),
+            "and for a dense one",
+        )
     }
 }

--- a/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
@@ -4241,6 +4241,7 @@ public final class sk/ainet/lang/tensor/TensorExtensionsKt {
 	public static synthetic fun logSoftmax$default (Lsk/ainet/lang/tensor/Tensor;IILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun lt (Lsk/ainet/lang/tensor/Tensor;F)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun matmul (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
+	public static final fun matmulWeightTransposed (Lsk/ainet/lang/tensor/Tensor;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun mean (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 	public static synthetic fun mean$default (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;ILjava/lang/Object;)Lsk/ainet/lang/tensor/Tensor;
 	public static final fun minus (Ljava/lang/Number;Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/TensorExtensions.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/TensorExtensions.kt
@@ -36,6 +36,20 @@ public fun <T : DType, V> Tensor<T, V>.cosineDistance(
 // Tensor extension functions that delegate to the ops component
 public fun <T : DType, V> Tensor<T, V>.t(): Tensor<T, V> = ops.transpose(this)
 public fun <T : DType, V> Tensor<T, V>.matmul(other: Tensor<T, V>): Tensor<T, V> = ops.matmul(this, other)
+
+/**
+ * `this · Wᵀ` with [weight] as `[out, in]` — the fluent form of [sk.ainet.lang.tensor.ops.TensorOps.matmulWeightTransposed].
+ *
+ * Reads like `x.matmul(w.t())` and means the same product, but says it as one request instead of
+ * two steps. That matters for a block-quantized weight, where the two steps cannot express it:
+ * `t()` on packed data is a layout conversion, not a transpose, and doing it per call copies the
+ * whole weight every forward pass (#973/#1096). Asked for as a product, an implementation can
+ * relayout once and reuse, or skip the work entirely when the bytes are already in kernel order.
+ *
+ * For a dense weight this is exactly `matmul(this, weight.t())` — a free shape swap, as before.
+ */
+public fun <T : DType, V> Tensor<T, V>.matmulWeightTransposed(weight: Tensor<T, V>): Tensor<T, V> =
+    ops.matmulWeightTransposed(this, weight)
 public fun <T : DType, V> Tensor<T, V>.flatten(startDim: Int = 0, endDim: Int = -1): Tensor<T, V> = 
     ops.flatten(this, startDim, endDim)
 


### PR DESCRIPTION
#1096 made `x · Wᵀ` a primitive on `TensorOps`, but only there. Asking for it meant reaching through `ctx.ops` while every neighbouring operation had a `Tensor` extension:

```kotlin
val y = x.matmul(w.t()) + bias                       // dense
val y = ctx.ops.matmulWeightTransposed(x, w) + bias  // packed — different in kind
```

`Linear` calls the primitive itself, so models built through the DSL never noticed. Hand-written tensor code did.

## The change

One extension in `TensorExtensions.kt`, next to `t()` and `matmul()`:

```kotlin
public fun <T : DType, V> Tensor<T, V>.matmulWeightTransposed(weight: Tensor<T, V>): Tensor<T, V> =
    ops.matmulWeightTransposed(this, weight)
```

so it reads `x.matmulWeightTransposed(w) + bias`. It is the same call — the added test asserts bit-identical output against the `ops` form for a packed weight and for a dense one — so dispatch, the relayout cache and the #1096 allocation behaviour are all untouched.

API surface: one added line in `api/jvm`, additive.

## What this does not fix

The reason the two forms exist at all: `w.t()` still throws for a block-quantized weight, so the code you write depends on how the weight happened to be stored — which is a function of the file the user loaded and the device it runs on, not of the model. A nicer spelling of the explicit form is not an answer to that.

The two halves of the actual answer are filed:

- **#1108** — `transpose` on a packed weight returns a transposed-weight *view* that `matmul` recognises and routes to the primitive, so `x.matmul(w.t())` works whatever the weight is. Notably this must not be the old lazy transpose, which was a bare metadata relabel and returned plausible garbage (`NativeLazyTransposeGroundTruthReproTest`).
- **#1109** — a declared in-memory weight form resolved from the file × `PlannerProfile` × backend kernel capabilities, so repack and dequant are stated intent priced in the `MemoryPlan` rather than per-call accidents.

## Gate

`scripts/pr-gate.sh` — all legs passed.

Note for anyone hitting it locally: the first two runs died in `compileTestDevelopmentExecutableKotlinWasmJs` with `NoSuchElementException: Key ic#69:kotlin.text/replace … is missing in the map`. That is a poisoned Kotlin/Wasm incremental cache, not a code error — `rm -rf **/build/kotlin .kotlin` and it compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)