### PR TITLE
feat(tensor): `w.t()` returns Wᵀ unmaterialized instead of refusing

### DIFF
--- a/skainet-backends/skainet-backend-cpu/api/jvm/skainet-backend-cpu.api
+++ b/skainet-backends/skainet-backend-cpu/api/jvm/skainet-backend-cpu.api
@@ -306,6 +306,7 @@ public class sk/ainet/exec/tensor/ops/DefaultCpuOpsBase : sk/ainet/lang/tensor/o
 	public fun tril (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
 	public fun unfold (Lsk/ainet/lang/tensor/Tensor;III)Lsk/ainet/lang/tensor/Tensor;
 	public fun unsqueeze (Lsk/ainet/lang/tensor/Tensor;I)Lsk/ainet/lang/tensor/Tensor;
+	protected final fun untransposedWeight (Lsk/ainet/lang/tensor/Tensor;)Lsk/ainet/lang/tensor/Tensor;
 	public fun upsample2d (Lsk/ainet/lang/tensor/Tensor;Lkotlin/Pair;Lsk/ainet/lang/tensor/ops/UpsampleMode;Z)Lsk/ainet/lang/tensor/Tensor;
 	public fun variance (Lsk/ainet/lang/tensor/Tensor;Ljava/lang/Integer;)Lsk/ainet/lang/tensor/Tensor;
 }

--- a/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOps.kt
@@ -14,6 +14,7 @@ import sk.ainet.lang.tensor.data.RowDequantSource
 import sk.ainet.lang.tensor.data.FloatArrayTensorData
 import sk.ainet.lang.tensor.data.IntArrayTensorData
 import sk.ainet.lang.tensor.data.NarrowFloatInputMajorTensorData
+import sk.ainet.lang.tensor.data.TransposedWeightTensorData
 import sk.ainet.lang.tensor.data.Q4_0TensorData
 import sk.ainet.lang.tensor.data.Q8_0TensorData
 import sk.ainet.lang.tensor.data.Q4_KTensorData
@@ -595,6 +596,13 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
         require(a.rank >= 1 && b.rank >= 1) { "Matrix multiplication requires tensors with at least 1 dimension per operand" }
         require(a.dtype == b.dtype) { "DType mismatch: ${a.dtype} vs ${b.dtype}" }
 
+        // `x · Wᵀ` written as two steps (#1108). Must be first: below this line the weight would be
+        // probed with `is PackedBlockStorage` and friends, and the marker deliberately answers no
+        // to all of them, so it would fall through to a dense path and read a packed payload as
+        // floats. Routing it here is what makes `x.matmul(w.t())` mean the same thing whatever the
+        // weight is stored as.
+        untransposedWeight(b)?.let { return matmulWeightTransposed(a, it) }
+
         // Packed-quant fast path (FP32 input × packed weight), resolved via KernelRegistry.
         KernelProfile.timeQuant { chooseQuantizedMatmulHeap(a, b) }?.let { return it }
 
@@ -895,6 +903,18 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
      * For a block-quantized weight this relayouts **once** and reuses the result; for anything else
      * it is the ordinary `matmul(x, transpose(w))`, which for dense data is a free shape swap.
      */
+    /**
+     * The weight behind a `Wᵀ` marker (#1108), or `null` when [b] is an ordinary operand.
+     *
+     * `protected` because every `matmul` override has to consult it *before* its own fast paths:
+     * the marker reports no packed storage by design, so any check that asks "is this packed?"
+     * gets the wrong answer and a dense path would read the packed payload as floats.
+     */
+    protected fun <T : DType, V> untransposedWeight(b: Tensor<T, V>): Tensor<T, V>? {
+        val marker = b.data as? TransposedWeightTensorData<T, V> ?: return null
+        return newTensor(marker.weight, b.dtype, b)
+    }
+
     @Suppress("UNCHECKED_CAST")
     override fun <T : DType, V> matmulWeightTransposed(x: Tensor<T, V>, weight: Tensor<T, V>): Tensor<T, V> {
         if (weight.shape.rank != 2 || !isHeapPackedWeight(weight.data)) return matmul(x, transpose(weight))
@@ -1004,23 +1024,30 @@ public open class DefaultCpuOpsBase(protected val dataFactory: TensorDataFactory
         val rows = tensor.shape[rank - 2]
         val cols = tensor.shape[rank - 1]
 
+        // Transposing a transposed weight is the weight (#1108). Restoring this involution is half
+        // the point of the marker: `w.t().t()` has not been `w` for as long as packed data existed.
+        val alreadyTransposed = tensor.data as? TransposedWeightTensorData<T, V>
+        if (alreadyTransposed != null) {
+            return newTensor(alreadyTransposed.weight, tensor.dtype, tensor)
+        }
+
         // Only the *heap* packed types, whose kernels read input-block-major bytes. The
         // MemorySegment tier reads canonical bytes, so for those a shape swap is genuinely correct
         // and stays where it is — census contradiction #3, now stated instead of implied.
         val heapPacked = rank == 2 && isHeapPackedWeight(tensor.data)
         if (heapPacked) {
-            val packedData = tensor.data as sk.ainet.lang.tensor.storage.PackedBlockStorage
-            // Transposing block-quantized data is not a representable operation (#973): blocks
-            // quantize runs along the input dimension, so a real transpose needs requantization.
-            // What used to happen here was a layout conversion wearing transpose's name — an
-            // O(bytes) copy per call, not an involution, and a lie about what the result means.
-            throw UnsupportedOperationException(
-                "transpose() is not defined for a ${packedData.encoding.name} weight: blocks quantize runs " +
-                    "along the input dimension, so transposing them needs requantization, and what this used to " +
-                    "do was a per-call layout copy that is not its own inverse (#973). Use " +
-                    "ops.matmulWeightTransposed(x, weight) with the weight as [out, in], or relayout explicitly " +
-                    "with PackedWeights.prepackForMatmul. See the Packed weight layout page in the docs site (explanation/packed-weight-layout).",
-            )
+            // Transposing block-quantized bytes is still not a representable operation (#973):
+            // blocks quantize runs along the input dimension, so a real transpose needs
+            // requantization. #1096 answered that by making `x · Wᵀ` a primitive and having this
+            // throw; #1108 keeps the primitive and drops the throw, because refusing here forced
+            // the *caller* to know how the weight was stored — which depends on the file loaded and
+            // the device it runs on, not on the model.
+            //
+            // So this returns `Wᵀ` as an unmaterialized marker instead. It carries no `packedData`,
+            // so no kernel can read the bytes through it as if they were the transpose's; `matmul`
+            // recognises it and asks `matmulWeightTransposed` for the product, which relayouts
+            // properly and once per weight. That is the distinction from the relabel this replaced.
+            return newTensor(TransposedWeightTensorData(tensor.data), tensor.dtype, tensor)
         }
 
         // Narrow floats (FP16/BF16) relaid input-major at load are a *view* rewrap, not a packed

--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/MatmulWeightTransposedTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/MatmulWeightTransposedTest.kt
@@ -6,11 +6,11 @@ import sk.ainet.lang.tensor.Tensor
 import sk.ainet.lang.tensor.matmulWeightTransposed
 import sk.ainet.lang.tensor.data.Q8_0BlockTensorData
 import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.data.TransposedWeightTensorData
 import sk.ainet.lang.types.FP32
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
@@ -71,13 +71,11 @@ class MatmulWeightTransposedTest {
     }
 
     @Test
-    fun `transpose refuses a packed weight and says what to use instead`() {
-        val failure = assertFailsWith<UnsupportedOperationException> { ctx.ops.transpose(weight()) }
-        val message = failure.message!!
-        assertTrue(message.contains("not defined for a Q8_0 weight"), message)
-        assertTrue(message.contains("matmulWeightTransposed"), "it names the primitive: $message")
-        assertTrue(message.contains("prepackForMatmul"), "and the explicit relayout: $message")
-        assertTrue(message.contains("requantization"), "and why: $message")
+    fun `transpose of a packed weight is the transposed-weight marker`() {
+        // #1108 replaced #1096's refusal: `t()` no longer throws, it returns `Wᵀ` unmaterialized.
+        val t = ctx.ops.transpose(weight())
+        assertTrue(t.shape == Shape(inDim, outDim), "the shape is the transpose: ${t.shape}")
+        assertTrue(t.data is TransposedWeightTensorData<*, *>, "and the data says so: ${t.data::class.simpleName}")
     }
 
     @Test

--- a/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/TransposedWeightViewTest.kt
+++ b/skainet-backends/skainet-backend-cpu/src/commonTest/kotlin/sk/ainet/exec/tensor/ops/TransposedWeightViewTest.kt
@@ -1,0 +1,249 @@
+package sk.ainet.exec.tensor.ops
+
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.Q4_0BlockTensorData
+import sk.ainet.lang.tensor.data.Q4_KBlockTensorData
+import sk.ainet.lang.tensor.data.Q5_0BlockTensorData
+import sk.ainet.lang.tensor.data.Q5_1BlockTensorData
+import sk.ainet.lang.tensor.data.Q5_KBlockTensorData
+import sk.ainet.lang.tensor.data.Q6_KBlockTensorData
+import sk.ainet.lang.tensor.data.Q8_0BlockTensorData
+import sk.ainet.lang.tensor.data.TensorData
+import sk.ainet.lang.tensor.data.TransposedWeightTensorData
+import sk.ainet.lang.tensor.matmul
+import sk.ainet.lang.tensor.matmulWeightTransposed
+import sk.ainet.lang.tensor.storage.PackedBlockStorage
+import sk.ainet.lang.tensor.t
+import sk.ainet.lang.types.FP32
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * #1108: `w.t()` works for a packed weight, and means the same product it means for a dense one.
+ *
+ * #973 made `transpose` refuse packed weights, because transposing block-quantized bytes needs
+ * requantization and what the code did instead was an O(bytes) relabel that fed kernels the wrong
+ * order. Refusing was right about the operation and wrong about the caller: it made the code an
+ * author writes depend on how the weight happened to be stored, which is a property of the file
+ * loaded and the device it runs on.
+ *
+ * So `transpose` now returns `Wᵀ` unmaterialized and `matmul` recognises it. These tests hold that
+ * to two standards: the product must be **bit-identical** to the primitive it routes to, and the
+ * marker must not be usable as packed data by anything that goes looking.
+ *
+ * Every fixture is **three blocks per row**. At one block per row the canonical and kernel-feed
+ * orders coincide, so a layout bug passes such a test vacuously (#968).
+ */
+class TransposedWeightViewTest {
+
+    private val ctx = DirectCpuExecutionContext()
+    private val outDim = 4
+    private val blocksPerRow = 3
+
+    /** name → (elements per block, bytes per block, builder) */
+    private val encodings: List<Triple<String, Pair<Int, Int>, (Shape, ByteArray) -> TensorData<FP32, Float>>> =
+        listOf(
+            Triple("Q4_0", 32 to 18) { s, b -> Q4_0BlockTensorData(s, b) as TensorData<FP32, Float> },
+            Triple("Q5_0", 32 to 22) { s, b -> Q5_0BlockTensorData(s, b) as TensorData<FP32, Float> },
+            Triple("Q5_1", 32 to 24) { s, b -> Q5_1BlockTensorData(s, b) as TensorData<FP32, Float> },
+            Triple("Q8_0", 32 to 34) { s, b -> Q8_0BlockTensorData(s, b) as TensorData<FP32, Float> },
+            Triple("Q4_K", 256 to 144) { s, b -> Q4_KBlockTensorData(s, b) as TensorData<FP32, Float> },
+            Triple("Q5_K", 256 to 176) { s, b -> Q5_KBlockTensorData(s, b) as TensorData<FP32, Float> },
+            Triple("Q6_K", 256 to 210) { s, b -> Q6_KBlockTensorData(s, b) as TensorData<FP32, Float> },
+        )
+
+    /**
+     * The encodings whose block layout is simple enough to hand-build a *valid* block: an fp16
+     * scale (and for Q5_1 an fp16 min) at the front, codes after. The K-quants pack hierarchical
+     * sub-block scales, and random bytes there dequantize to NaN — which says nothing about block
+     * order, so those are covered by the routing and safety tests above and by the existing golden
+     * parity suite, not by the hand-rolled reference below.
+     */
+    private val simpleEncodings: List<Triple<String, Pair<Int, Int>, (Shape, ByteArray) -> TensorData<FP32, Float>>> =
+        encodings.filter { it.first in setOf("Q4_0", "Q5_0", "Q5_1", "Q8_0") }
+
+    /** [weight] with each block's scale set to 1.0 and min to 0.0, so dequantization is finite. */
+    private fun validWeight(
+        name: String,
+        blockElems: Int,
+        bytesPerBlock: Int,
+        build: (Shape, ByteArray) -> TensorData<FP32, Float>,
+    ): Pair<Tensor<FP32, Float>, Int> {
+        val inDim = blockElems * blocksPerRow
+        val bytes = ByteArray(outDim * blocksPerRow * bytesPerBlock)
+        var seed = 7
+        for (i in bytes.indices) {
+            seed = seed * 1103515245 + 12345
+            bytes[i] = ((seed ushr 16) and 0xFF).toByte()
+        }
+        for (b in 0 until outDim * blocksPerRow) {
+            val base = b * bytesPerBlock
+            bytes[base] = 0x00; bytes[base + 1] = 0x3C          // fp16 1.0
+            if (name == "Q5_1") { bytes[base + 2] = 0x00; bytes[base + 3] = 0x00 }   // fp16 min 0.0
+        }
+        return ctx.fromData(build(Shape(outDim, inDim), bytes), FP32::class) to inDim
+    }
+
+    /** A weight with content that differs per block, so a wrong block order cannot go unnoticed. */
+    private fun weight(blockElems: Int, bytesPerBlock: Int, build: (Shape, ByteArray) -> TensorData<FP32, Float>):
+        Pair<Tensor<FP32, Float>, Int> {
+        val inDim = blockElems * blocksPerRow
+        val bytes = ByteArray(outDim * blocksPerRow * bytesPerBlock)
+        var seed = 7
+        for (i in bytes.indices) {
+            seed = seed * 1103515245 + 12345
+            bytes[i] = ((seed ushr 16) and 0xFF).toByte()
+        }
+        return ctx.fromData(build(Shape(outDim, inDim), bytes), FP32::class) to inDim
+    }
+
+    private fun activation(inDim: Int): Tensor<FP32, Float> =
+        ctx.fromFloatArray<FP32, Float>(Shape(1, inDim), FP32::class, FloatArray(inDim) { (it % 11) * 0.0625f })
+
+    @Test
+    fun `matmul over a transposed packed weight equals the primitive it routes to`() {
+        for ((name, geom, build) in encodings) {
+            val (w, inDim) = weight(geom.first, geom.second, build)
+            val x = activation(inDim)
+
+            val viaTranspose = x.matmul(w.t()).data.copyToFloatArray()
+            val viaPrimitive = x.matmulWeightTransposed(w).data.copyToFloatArray()
+
+            assertContentEquals(viaPrimitive, viaTranspose, "$name: x.matmul(w.t()) must be x · Wᵀ, bit for bit")
+        }
+    }
+
+    @Test
+    fun `transposing twice gives the weight back`() {
+        for ((name, geom, build) in encodings) {
+            val (w, _) = weight(geom.first, geom.second, build)
+            val back = w.t().t()
+            assertEquals(w.shape, back.shape, "$name: shape after two transposes")
+            assertSame(w.data, back.data, "$name: t().t() must be the original data, not a copy of it")
+        }
+    }
+
+    @Test
+    fun `the marker refuses to look like packed storage`() {
+        for ((name, geom, build) in encodings) {
+            val (w, _) = weight(geom.first, geom.second, build)
+            val t = w.t()
+
+            assertTrue(t.data is TransposedWeightTensorData<*, *>, "$name: transpose produced ${t.data::class.simpleName}")
+            // The whole safety argument: a kernel that asks "are you packed bytes I can read?" must
+            // hear no. The relabel this replaced said yes and handed over the wrong order (#973).
+            assertFalse(
+                t.data is PackedBlockStorage,
+                "$name: the marker must not be PackedBlockStorage — that is how the old relabel fed kernels garbage",
+            )
+        }
+    }
+
+    @Test
+    fun `reading the marker mirrors the weight with the indices swapped`() {
+        val (w, inDim) = weight(32, 34) { s, b -> Q8_0BlockTensorData(s, b) as TensorData<FP32, Float> }
+        val t = w.t()
+        assertEquals(Shape(inDim, outDim), t.shape)
+        // Read through a star projection: the fixture is really `TensorData<FP32, Byte>` wearing a
+        // `<FP32, Float>` cast (the repo's fixture idiom), and asking it for a Float is a real
+        // ClassCastException on Kotlin/Wasm, which checks the cast the JVM erases. The element
+        // values are quantized codes either way — that is the point of the assertion.
+        val weightData: TensorData<*, *> = w.data
+        val markerData: TensorData<*, *> = t.data
+        for (o in 0 until outDim) {
+            for (i in 0 until inDim step 37) {
+                assertEquals(weightData[o, i], markerData[i, o], "element [$i, $o] of Wᵀ must be [$o, $i] of W")
+            }
+        }
+    }
+
+    @Test
+    fun `repeated use of the same transposed weight stays correct`() {
+        // The relayout behind the marker is cached per weight (#1096). Nothing may go stale.
+        val (w, inDim) = weight(32, 34) { s, b -> Q8_0BlockTensorData(s, b) as TensorData<FP32, Float> }
+        val x = activation(inDim)
+        val first = x.matmul(w.t()).data.copyToFloatArray()
+        repeat(5) {
+            assertContentEquals(first, x.matmul(w.t()).data.copyToFloatArray(), "answer drifted on reuse")
+        }
+    }
+
+    @Test
+    fun `a dense weight is untouched by any of this`() {
+        val inDim = 96
+        val dense = ctx.fromFloatArray<FP32, Float>(
+            Shape(outDim, inDim), FP32::class, FloatArray(outDim * inDim) { it * 0.01f },
+        )
+        val t = dense.t()
+        assertEquals(Shape(inDim, outDim), t.shape)
+        assertFalse(t.data is TransposedWeightTensorData<*, *>, "a dense transpose is a real transpose, not a marker")
+
+        val x = activation(inDim)
+        assertContentEquals(
+            x.matmulWeightTransposed(dense).data.copyToFloatArray(),
+            x.matmul(t).data.copyToFloatArray(),
+            "dense: the two spellings already agreed and must keep agreeing",
+        )
+    }
+
+    @Test
+    fun `the answer matches dequantizing the weight and doing it the slow honest way`() {
+        // Routing tests only prove the two spellings agree with each other. This one checks they
+        // agree with the *matrix*: dequantize W, compute `sum_i x[i] * W[o, i]` in plain floats,
+        // and compare. It is the shape of check that catches a wrong block order, which is the
+        // failure mode this whole area exists because of (#968) — a relabel produces numbers that
+        // look fine and are not these ones.
+        for ((name, geom, build) in simpleEncodings) {
+            val (w, inDim) = validWeight(name, geom.first, geom.second, build)
+            val x = activation(inDim)
+
+            val dequantized = (w.data as PackedBlockStorage).toFloatArray()   // [out, in], row-major
+            val xs = x.data.copyToFloatArray()
+            val expected = FloatArray(outDim) { o ->
+                var acc = 0.0f
+                for (i in 0 until inDim) acc += xs[i] * dequantized[o * inDim + i]
+                acc
+            }
+
+            val actual = x.matmul(w.t()).data.copyToFloatArray()
+            assertEquals(expected.size, actual.size, "$name: result length")
+            for (o in expected.indices) {
+                val tolerance = 1e-3f * maxOf(1.0f, abs(expected[o]))
+                assertTrue(
+                    abs(expected[o] - actual[o]) <= tolerance,
+                    "$name: output[$o] was ${actual[o]}, the dequantized matrix says ${expected[o]}",
+                )
+            }
+
+            // And the check has to be able to fail. Read the same blocks in the other order — which
+            // is precisely the mistake a relabel makes — and require a different answer. Without
+            // this the assertion above would pass vacuously on a fixture where the two orders
+            // happen to coincide, which is how #968 survived its own tests.
+            val blockElems = geom.first
+            val misordered = FloatArray(dequantized.size)
+            for (o in 0 until outDim) {
+                for (b in 0 until blocksPerRow) {
+                    val src = (b * outDim + o) * blockElems
+                    val dst = (o * blocksPerRow + b) * blockElems
+                    dequantized.copyInto(misordered, dst, src, src + blockElems)
+                }
+            }
+            val wrong = FloatArray(outDim) { o ->
+                var acc = 0.0f
+                for (i in 0 until inDim) acc += xs[i] * misordered[o * inDim + i]
+                acc
+            }
+            assertTrue(
+                expected.indices.any { abs(expected[it] - wrong[it]) > 1e-3f * maxOf(1.0f, abs(expected[it])) },
+                "$name: the two block orders give the same answer, so this fixture proves nothing",
+            )
+        }
+    }
+}

--- a/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOpsJvm.kt
+++ b/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOpsJvm.kt
@@ -181,6 +181,10 @@ internal class DefaultCpuOpsJvm(
     }
 
     override fun <T : DType, V> matmul(a: Tensor<T, V>, b: Tensor<T, V>): Tensor<T, V> {
+        // `x · Wᵀ` written as two steps (#1108) — before everything, including the strictness check
+        // below, which would otherwise report a missing kernel for an operand that has a perfectly
+        // good one behind the marker.
+        untransposedWeight(b)?.let { return matmulWeightTransposed(a, it) }
         // Try quantized matmul path first (FP32 input x quantized weights)
         chooseQuantizedMatmul(a, b)?.let { return it }
         // Fallback to standard FP32 matmul

--- a/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
@@ -5295,6 +5295,18 @@ public final class sk/ainet/lang/tensor/data/TernaryTensorDataKt {
 	public static final fun toFloatArray (Lsk/ainet/lang/tensor/data/TernaryTensorData;)[F
 }
 
+public final class sk/ainet/lang/tensor/data/TransposedWeightTensorData : sk/ainet/lang/tensor/data/TensorData {
+	public fun <init> (Lsk/ainet/lang/tensor/data/TensorData;)V
+	public fun copyToFloatArray ()[F
+	public fun get ([I)Ljava/lang/Object;
+	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
+	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
+	public fun getView ()Lsk/ainet/lang/memory/TensorView;
+	public final fun getWeight ()Lsk/ainet/lang/tensor/data/TensorData;
+	public fun set ([ILjava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class sk/ainet/lang/tensor/data/dense/DenseByteTensorArray : sk/ainet/lang/tensor/data/ItemsAccessor {
 	public fun <init> (Ljava/util/List;[B)V
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[BI)V

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/data/TransposedWeightTensorData.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/data/TransposedWeightTensorData.kt
@@ -1,0 +1,78 @@
+package sk.ainet.lang.tensor.data
+
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.types.DType
+
+/**
+ * `Wᵀ` for a weight whose bytes cannot be transposed — the shape is the transpose, the payload is
+ * still `W`'s, and nothing may read the payload as if it were `Wᵀ`'s (#1108, following #973).
+ *
+ * ## Why this exists
+ *
+ * Block-quantized weights quantize runs along the input dimension, so a real transpose needs
+ * requantization. #973 made `transpose` refuse them rather than keep doing the O(bytes) layout
+ * conversion it had been doing under transpose's name. That was right about the operation and
+ * wrong about the ergonomics: it meant `x.matmul(w.t())` compiled for a dense weight and threw for
+ * a packed one, so the code an author writes depended on which file the user loaded and which
+ * device it ran on — things the author cannot know.
+ *
+ * This restores one spelling for both. `transpose` on a packed weight returns this; `matmul`
+ * recognises it and asks for the product directly, which is the operation that *is* defined.
+ *
+ * ## Why this is not the old lazy transpose
+ *
+ * The transpose that #973 removed was a bare metadata relabel: same bytes, swapped shape, still
+ * claiming to be ordinary packed data. Kernels took it at its word and read canonical bytes as
+ * input-block-major ones, which is not an error — it is plausible garbage
+ * (`NativeLazyTransposeGroundTruthReproTest`, #968, SKaiNET-transformers#307).
+ *
+ * The difference here is that this **is not** [sk.ainet.lang.tensor.storage.PackedBlockStorage].
+ * It has no `packedData`, so no kernel can reach the bytes through it and no `is PackedBlockStorage`
+ * check will route it down a packed path by mistake. The only way to get a product out of it is the
+ * `matmulWeightTransposed` primitive, which relayouts properly and once.
+ *
+ * ## What reading it gives you
+ *
+ * Element access mirrors [weight] with the indices swapped — whatever `weight[j, i]` means,
+ * `this[i, j]` means the same thing. For packed data that is the quantized code, exactly as it is
+ * on the weight itself; this type invents no new semantics, it only transposes the ones it wraps.
+ *
+ * @property weight the untransposed weight; `[out, in]` where this is `[in, out]`
+ */
+public class TransposedWeightTensorData<T : DType, V>(
+    public val weight: TensorData<T, V>,
+) : TensorData<T, V> {
+
+    init {
+        require(weight.shape.rank == 2) {
+            "a transposed-weight view is only defined for a rank-2 weight, got ${weight.shape}"
+        }
+    }
+
+    override val shape: Shape = Shape(weight.shape[1], weight.shape[0])
+
+    /** The wrapped weight's encoding: transposing does not change how the bytes are packed. */
+    override val encoding: sk.ainet.lang.tensor.storage.TensorEncoding? get() = weight.encoding
+
+    /**
+     * The weight's view with its last two axes swapped, or `null` if the weight has none.
+     *
+     * Safe where a relabel is not, because [sk.ainet.lang.memory.TensorView] transposes a blocked
+     * layout by moving `blockAxis` with the axes (#1034) — the view knows where its blocks run, so
+     * decoding through it addresses the right elements.
+     */
+    @sk.ainet.lang.memory.ExperimentalMemoryApi
+    override val view: sk.ainet.lang.memory.TensorView? get() = weight.view?.transpose()
+
+    override fun get(vararg indices: Int): V {
+        require(indices.size == 2) { "expected 2 indices for shape $shape, got ${indices.size}" }
+        return weight[indices[1], indices[0]]
+    }
+
+    override fun set(vararg indices: Int, value: V) {
+        require(indices.size == 2) { "expected 2 indices for shape $shape, got ${indices.size}" }
+        weight[indices[1], indices[0]] = value
+    }
+
+    override fun toString(): String = "Wᵀ(${weight::class.simpleName}, $shape, unmaterialized)"
+}


### PR DESCRIPTION
Closes #1108.

## The problem

#973 made `transpose` throw for a block-quantized weight, so this compiled for one weight and threw for another:

```kotlin
x.matmul(w.t())          // dense: fine.  packed: UnsupportedOperationException
```

The refusal was right about the *operation*. Blocks quantize runs along the input dimension, so a real transpose needs requantization, and what the code did before was an O(bytes) relabel that handed kernels the wrong byte order. It was wrong about the *caller*: whether a weight arrives packed is a property of the file the user loaded and the device it runs on, and the model author knows neither. `Linear` hid this by calling the primitive itself; hand-written tensor code did not.

## The change

`transpose` returns `TransposedWeightTensorData` — shape transposed, payload still the weight's, nothing materialized. `matmul` recognises it and routes to `matmulWeightTransposed`, which relayouts once per weight and caches (#1096). Applied twice, `transpose` unwraps, so `w.t().t()` is `w` — an involution that has been broken for as long as packed data has existed.

## Why this is not the relabel that was removed

The transpose #973 deleted was a bare metadata relabel: same bytes, swapped shape, still claiming to be ordinary packed data. Kernels believed it and read canonical bytes as input-block-major ones — not an error, just plausible garbage (`NativeLazyTransposeGroundTruthReproTest`, #968, SKaiNET-transformers#307).

The marker **is not** `PackedBlockStorage`. It has no `packedData`, and every `is PackedBlockStorage` probe answers no, so no kernel can reach the bytes through it. The only route to a product is the primitive that relayouts properly.

That is also why the ordering in `matmul` is load-bearing: because the marker fails every "are you packed?" check, reaching a dense fast path would read a packed payload as floats. It is consulted first in both the common implementation and the JVM override — in the latter above the strict-kernel check, which would otherwise report a missing kernel for an operand that has a perfectly good one behind the marker. `AccelerateCpuOps` needs no change; its fast paths guard on `FloatArrayTensorData`, so the marker falls through to the base.

## Tests

`TransposedWeightViewTest`, seven cases: routing equals the primitive bit-for-bit across seven encodings, the involution, the marker refusing to look like packed storage, element access mirroring with swapped indices, stability under reuse, dense untouched, and a ground-truth check.

Two things about that ground-truth check are worth stating, because both were failures first:

**It failed on NaN.** Random fixture bytes make invalid fp16 scales, so the K-quants dequantized to NaN and `NaN != NaN`. That was the fixture's fault, not the code's. It now hand-builds valid blocks (scale 1.0, min 0.0) for the four encodings with a simple block layout, and leaves the K-quants to the routing and safety tests plus the existing golden parity suite — rather than pretend a NaN fixture proved anything.

**It has to be able to fail.** A ground-truth test here is worthless if the fixture cannot distinguish the two block orders — that is how #968 survived its own tests. So the test also computes the answer you would get reading the blocks in the other order and requires it to differ. If a future fixture ever makes the orders coincide, the test says so instead of passing quietly. Every fixture is three blocks per row for the same reason.

A third failure was mine and target-specific: the test read elements through the repo's fixture idiom, which casts `TensorData<FP32, Byte>` to `<FP32, Float>` for construction. The JVM erases that cast; Kotlin/Wasm checks it and threw `ClassCastException`. It now reads through a star projection — the values compared are quantized codes either way, which is the point of the assertion.

## What this does not do

The form a weight arrives in is still whatever the loader happened to produce, with no one consulting the backend about what its kernels can feed on. That is **#1109** — a declared in-memory form resolved from the file × `PlannerProfile` × kernel capabilities, with repack and dequant priced into the `MemoryPlan`. With it, the loader would usually hand the kernel bytes already in feed order and this marker would resolve to a matmul with no relayout at all.

API: additive — one new public class, one `protected` helper.

## Gate

`scripts/pr-gate.sh` — all legs passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)