### PR TITLE
docs: virtual-tensors explanation + Android classifier tutorial (CI-verified samples)

### DIFF
--- a/docs/modules/ROOT/examples/kotlin/sk/ainet/docs/samples/IrisClassifier.kt
+++ b/docs/modules/ROOT/examples/kotlin/sk/ainet/docs/samples/IrisClassifier.kt
@@ -1,0 +1,103 @@
+package sk.ainet.docs.samples
+
+// tag::imports[]
+import sk.ainet.context.DirectCpuExecutionContext
+import sk.ainet.context.Phase
+import sk.ainet.data.iris.Iris
+import sk.ainet.lang.graph.DefaultGradientTape
+import sk.ainet.lang.graph.DefaultGraphExecutionContext
+import sk.ainet.lang.nn.dsl.sequential
+import sk.ainet.lang.nn.dsl.training
+import sk.ainet.lang.nn.loss.CrossEntropyLoss
+import sk.ainet.lang.nn.optim.sgd
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.relu
+import sk.ainet.lang.types.FP32
+import kotlin.random.Random
+// end::imports[]
+
+/**
+ * The classifier the Android getting-started tutorial builds: a `[4, 16, 3]` MLP
+ * trained on the embedded Iris dataset with cross-entropy over one-hot targets.
+ *
+ * Every API used here is `commonMain` and available on the Android target; this
+ * module compiles and runs it in CI on the JVM so the tutorial cannot rot.
+ */
+object IrisClassifier {
+
+    data class Result(val firstLoss: Float, val lastLoss: Float, val accuracy: Float)
+
+    suspend fun run(): Result {
+        // tag::data[]
+        // 150 rows, embedded in skainet-data-simple — no download, works on every target.
+        // Features [n, 4], targets one-hot [n, 3]; stratified split keeps class balance.
+        val (trainSet, testSet) = Iris.load().split(0.8, seed = 42L, stratified = true)
+        val train = trainSet.dataBatch<FP32, Float>(0, trainSet.size)
+        val test = testSet.dataBatch<FP32, Float>(0, testSet.size)
+        // end::data[]
+
+        // tag::model[]
+        // A graph (autograd) context for training; a plain CPU context for inference.
+        val baseCtx = DirectCpuExecutionContext()
+        val trainCtx = DefaultGraphExecutionContext(
+            baseOps = baseCtx.ops,
+            phase = Phase.TRAIN,
+            createTapeFactory = { _ -> DefaultGradientTape() },
+        )
+
+        val rng = Random(42)
+        val model = sequential<FP32, Float>(trainCtx) {
+            input(4)                                              // sepal/petal measurements
+            dense(16) { weights { randn(std = 0.5f, random = rng) } }
+            activation { it.relu() }
+            dense(3) { weights { randn(std = 0.5f, random = rng) } } // class logits
+        }
+        // end::model[]
+
+        // tag::train[]
+        val x = train.x[0]
+        val y = train.y
+        val runner = training<FP32, Float> {
+            model { model }
+            loss { CrossEntropyLoss() } // applies softmax internally — the model outputs logits
+            optimizer {
+                sgd(lr = 0.05).apply {
+                    model.trainableParameters().forEach { addParameter(it) }
+                }
+            }
+        }
+
+        var firstLoss = 0f
+        var lastLoss = 0f
+        repeat(300) { epoch ->
+            val loss = runner.step(trainCtx, x, y).data.get()
+            if (epoch == 0) firstLoss = loss
+            lastLoss = loss
+        }
+        // end::train[]
+
+        // tag::evaluate[]
+        // Held-out accuracy on a fresh inference context: argmax of the logits.
+        val evalCtx = DirectCpuExecutionContext()
+        val preds = model.forward(test.x[0], evalCtx)
+        val n = testSet.size
+        var correct = 0
+        for (i in 0 until n) {
+            var best = 0
+            var bestScore = preds.data.get(i, 0)
+            var target = 0
+            var targetScore = test.y.data.get(i, 0)
+            for (c in 1 until 3) {
+                val s = preds.data.get(i, c)
+                if (s > bestScore) { best = c; bestScore = s }
+                val t = test.y.data.get(i, c)
+                if (t > targetScore) { target = c; targetScore = t }
+            }
+            if (best == target) correct++
+        }
+        val accuracy = correct.toFloat() / n
+        // end::evaluate[]
+
+        return Result(firstLoss, lastLoss, accuracy)
+    }
+}

--- a/docs/modules/ROOT/images/tensor-view-anatomy.svg
+++ b/docs/modules/ROOT/images/tensor-view-anatomy.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 360" role="img" aria-label="Three TensorViews — dense, transposed, narrowed — share one Storage byte region; each carries its own Shape, Format and Layout. Only materialize() copies, producing a new Storage." font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace">
+  <defs>
+    <marker id="tva" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1F2733"/>
+    </marker>
+    <marker id="tvc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#C2762A"/>
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="940" height="360" fill="#FFFFFF"/>
+
+  <!-- three view cards -->
+  <g>
+    <rect x="40" y="36" width="240" height="108" rx="8" fill="#E3ECF6" stroke="#4C7FB8" stroke-width="1.5"/>
+    <text x="160" y="60" text-anchor="middle" font-size="12.5" font-weight="600" fill="#1F2733">TensorView · dense</text>
+    <text x="160" y="82" text-anchor="middle" font-size="11" fill="#5C6675">shape [4, 6] · FP32</text>
+    <text x="160" y="100" text-anchor="middle" font-size="11" fill="#5C6675">strides [6, 1] · offset 0</text>
+    <text x="160" y="122" text-anchor="middle" font-size="10.5" fill="#4C7FB8">the loaded weight</text>
+  </g>
+  <g>
+    <rect x="350" y="36" width="240" height="108" rx="8" fill="#E3ECF6" stroke="#4C7FB8" stroke-width="1.5"/>
+    <text x="470" y="60" text-anchor="middle" font-size="12.5" font-weight="600" fill="#1F2733">.transpose()</text>
+    <text x="470" y="82" text-anchor="middle" font-size="11" fill="#5C6675">shape [6, 4] · FP32</text>
+    <text x="470" y="100" text-anchor="middle" font-size="11" fill="#5C6675">strides [1, 6] · offset 0</text>
+    <text x="470" y="122" text-anchor="middle" font-size="10.5" fill="#4C7FB8">strides swapped — no bytes moved</text>
+  </g>
+  <g>
+    <rect x="660" y="36" width="240" height="108" rx="8" fill="#E3ECF6" stroke="#4C7FB8" stroke-width="1.5"/>
+    <text x="780" y="60" text-anchor="middle" font-size="12.5" font-weight="600" fill="#1F2733">.narrow(row 2)</text>
+    <text x="780" y="82" text-anchor="middle" font-size="11" fill="#5C6675">shape [1, 6] · FP32</text>
+    <text x="780" y="100" text-anchor="middle" font-size="11" fill="#5C6675">strides [6, 1] · offset 12</text>
+    <text x="780" y="122" text-anchor="middle" font-size="10.5" fill="#4C7FB8">a window, not a copy</text>
+  </g>
+
+  <!-- shared storage strip -->
+  <g>
+    <rect x="190" y="226" width="560" height="40" rx="6" fill="#F6EADB" stroke="#C2762A" stroke-width="1.5"/>
+    <g stroke="#C2762A" stroke-width="0.75" opacity="0.4">
+      <path d="M225 226 V266 M260 226 V266 M295 226 V266 M330 226 V266 M365 226 V266 M400 226 V266 M435 226 V266 M470 226 V266 M505 226 V266 M540 226 V266 M575 226 V266 M610 226 V266 M645 226 V266 M680 226 V266 M715 226 V266"/>
+    </g>
+    <text x="470" y="251" text-anchor="middle" font-size="12" font-weight="600" fill="#1F2733">Storage — one byte region (Heap / Mapped / OffHeap)</text>
+  </g>
+  <text x="190" y="292" font-size="11" fill="#5C6675">owner · scope · isAlive — closing the scope invalidates every view</text>
+
+  <!-- arrows from views to the one storage -->
+  <line x1="160" y1="148" x2="330" y2="222" stroke="#1F2733" stroke-width="1.4" marker-end="url(#tva)"/>
+  <line x1="470" y1="148" x2="470" y2="222" stroke="#1F2733" stroke-width="1.4" marker-end="url(#tva)"/>
+  <line x1="780" y1="148" x2="612" y2="222" stroke="#1F2733" stroke-width="1.4" marker-end="url(#tva)"/>
+  <text x="300" y="182" font-size="10.5" fill="#5C6675">reads</text>
+  <text x="478" y="182" font-size="10.5" fill="#5C6675">reads</text>
+  <text x="640" y="182" font-size="10.5" fill="#5C6675">reads</text>
+
+  <!-- materialize: the only copy -->
+  <line x1="754" y1="246" x2="812" y2="246" stroke="#C2762A" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#tvc)"/>
+  <rect x="816" y="226" width="96" height="40" rx="6" fill="none" stroke="#C2762A" stroke-width="1.5"/>
+  <text x="864" y="245" text-anchor="middle" font-size="10.5" font-weight="600" fill="#C2762A">materialize()</text>
+  <text x="864" y="259" text-anchor="middle" font-size="10" fill="#5C6675">new Storage</text>
+  <text x="816" y="292" font-size="10.5" fill="#C2762A">the only copy point</text>
+</svg>

--- a/docs/modules/ROOT/images/virtual-tensor-strides.svg
+++ b/docs/modules/ROOT/images/virtual-tensor-strides.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 330" role="img" aria-label="One highlighted logical cell (o=2, b=1) maps through a strides formula to two different physical positions: index 13 under row-major strides, index 6 under input-block-major strides." font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1F2733"/>
+    </marker>
+    <marker id="arrP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#C2762A"/>
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="940" height="330" fill="#FFFFFF"/>
+
+  <!-- logical grid: 6 cols x 4 rows, cell 28 -->
+  <text x="42" y="52" font-size="12" font-weight="600" fill="#4C7FB8">LOGICAL VIEW</text>
+  <text x="42" y="70" font-size="11.5" fill="#5C6675">index (o, b) · shape [4, 6]</text>
+  <g>
+    <rect x="42" y="84" width="168" height="112" rx="4" fill="none" stroke="#4C7FB8" stroke-width="1.5"/>
+    <path d="M70 84 V196 M98 84 V196 M126 84 V196 M154 84 V196 M182 84 V196 M42 112 H210 M42 140 H210 M42 168 H210" stroke="#4C7FB8" stroke-width="0.75" opacity="0.45"/>
+    <rect x="70" y="140" width="28" height="28" fill="#4C7FB8"/>
+  </g>
+  <text x="42" y="222" font-size="12" fill="#1F2733">cell (o=2, b=1)</text>
+
+  <!-- layout box -->
+  <rect x="286" y="112" width="200" height="70" rx="8" fill="#EEF1F5" stroke="#C2762A" stroke-width="1.5"/>
+  <text x="386" y="138" text-anchor="middle" font-size="12.5" font-weight="600" fill="#1F2733">Layout</text>
+  <text x="386" y="158" text-anchor="middle" font-size="11.5" fill="#5C6675">phys = o·s[0] + b·s[1]</text>
+  <line x1="216" y1="147" x2="280" y2="147" stroke="#1F2733" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- physical strip A: row-major -->
+  <text x="540" y="66" font-size="12" font-weight="600" fill="#C2762A">ROW_MAJOR · strides [6, 1]</text>
+  <g>
+    <rect x="540" y="76" width="360" height="26" rx="4" fill="none" stroke="#C2762A" stroke-width="1.25"/>
+    <g stroke="#C2762A" stroke-width="0.75" opacity="0.4">
+      <path d="M555 76 V102 M570 76 V102 M585 76 V102 M600 76 V102 M615 76 V102 M630 76 V102 M645 76 V102 M660 76 V102 M675 76 V102 M690 76 V102 M705 76 V102 M720 76 V102 M735 76 V102 M750 76 V102 M765 76 V102 M780 76 V102 M795 76 V102 M810 76 V102 M825 76 V102 M840 76 V102 M855 76 V102 M870 76 V102 M885 76 V102"/>
+    </g>
+    <rect x="735" y="76" width="15" height="26" fill="#C2762A"/>
+  </g>
+  <text x="742" y="118" text-anchor="middle" font-size="11.5" fill="#1F2733">idx 13</text>
+  <line x1="490" y1="132" x2="534" y2="96" stroke="#C2762A" stroke-width="1.5" marker-end="url(#arrP)"/>
+
+  <!-- physical strip B: input-block-major -->
+  <text x="540" y="196" font-size="12" font-weight="600" fill="#C2762A">INPUT_BLOCK_MAJOR · strides [1, 4]</text>
+  <g>
+    <rect x="540" y="206" width="360" height="26" rx="4" fill="none" stroke="#C2762A" stroke-width="1.25"/>
+    <g stroke="#C2762A" stroke-width="0.75" opacity="0.4">
+      <path d="M555 206 V232 M570 206 V232 M585 206 V232 M600 206 V232 M615 206 V232 M630 206 V232 M645 206 V232 M660 206 V232 M675 206 V232 M690 206 V232 M705 206 V232 M720 206 V232 M735 206 V232 M750 206 V232 M765 206 V232 M780 206 V232 M795 206 V232 M810 206 V232 M825 206 V232 M840 206 V232 M855 206 V232 M870 206 V232 M885 206 V232"/>
+    </g>
+    <rect x="630" y="206" width="15" height="26" fill="#C2762A"/>
+  </g>
+  <text x="637" y="248" text-anchor="middle" font-size="11.5" fill="#1F2733">idx 6</text>
+  <line x1="490" y1="162" x2="534" y2="212" stroke="#C2762A" stroke-width="1.5" marker-end="url(#arrP)"/>
+
+  <text x="540" y="290" font-size="11.5" fill="#5C6675">same kernel code · layout chosen per kernel, per device</text>
+</svg>

--- a/docs/modules/ROOT/images/weight-form-resolution.svg
+++ b/docs/modules/ROOT/images/weight-form-resolution.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 380" role="img" aria-label="Three inputs — what the file holds, the planner profile, and what the platform and kernels can do — feed WeightFormResolver, producing a WeightForm; AllocationResolver turns it into an AllocationSpec (domain and scope); the loader obeys. A user override lane outranks the resolver." font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace">
+  <defs>
+    <marker id="wfa" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1F2733"/>
+    </marker>
+    <marker id="wfg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3E9463"/>
+    </marker>
+  </defs>
+  <rect x="0" y="0" width="940" height="380" fill="#FFFFFF"/>
+
+  <!-- inputs -->
+  <g>
+    <rect x="36" y="96" width="190" height="54" rx="8" fill="#EEF1F5" stroke="#DCE1E8" stroke-width="1.5"/>
+    <text x="131" y="118" text-anchor="middle" font-size="12" font-weight="600" fill="#1F2733">what the file holds</text>
+    <text x="131" y="136" text-anchor="middle" font-size="10.5" fill="#5C6675">TensorEncoding · Q4_K, F32 …</text>
+  </g>
+  <g>
+    <rect x="36" y="166" width="190" height="54" rx="8" fill="#EEF1F5" stroke="#DCE1E8" stroke-width="1.5"/>
+    <text x="131" y="188" text-anchor="middle" font-size="12" font-weight="600" fill="#1F2733">what the profile says</text>
+    <text x="131" y="206" text-anchor="middle" font-size="10.5" fill="#5C6675">PlannerProfile · MOBILE_2GB …</text>
+  </g>
+  <g>
+    <rect x="36" y="236" width="190" height="54" rx="8" fill="#EEF1F5" stroke="#DCE1E8" stroke-width="1.5"/>
+    <text x="131" y="258" text-anchor="middle" font-size="12" font-weight="600" fill="#1F2733">what the device can do</text>
+    <text x="131" y="276" text-anchor="middle" font-size="10.5" fill="#5C6675">KernelCapabilities · mmap?</text>
+  </g>
+
+  <!-- resolver -->
+  <rect x="300" y="156" width="200" height="74" rx="8" fill="#E3ECF6" stroke="#4C7FB8" stroke-width="1.8"/>
+  <text x="400" y="186" text-anchor="middle" font-size="13" font-weight="600" fill="#1F2733">WeightFormResolver</text>
+  <text x="400" y="206" text-anchor="middle" font-size="10.5" fill="#5C6675">decides once, at load</text>
+  <line x1="230" y1="123" x2="294" y2="176" stroke="#1F2733" stroke-width="1.4" marker-end="url(#wfa)"/>
+  <line x1="230" y1="193" x2="294" y2="193" stroke="#1F2733" stroke-width="1.4" marker-end="url(#wfa)"/>
+  <line x1="230" y1="263" x2="294" y2="210" stroke="#1F2733" stroke-width="1.4" marker-end="url(#wfa)"/>
+
+  <!-- WeightForm value -->
+  <rect x="560" y="150" width="180" height="86" rx="8" fill="#F6EADB" stroke="#C2762A" stroke-width="1.5"/>
+  <text x="650" y="174" text-anchor="middle" font-size="12.5" font-weight="600" fill="#1F2733">WeightForm</text>
+  <text x="650" y="194" text-anchor="middle" font-size="10.5" fill="#5C6675">encoding · byte order</text>
+  <text x="650" y="210" text-anchor="middle" font-size="10.5" fill="#5C6675">shape · residency</text>
+  <line x1="504" y1="193" x2="554" y2="193" stroke="#1F2733" stroke-width="1.5" marker-end="url(#wfa)"/>
+
+  <!-- override lane -->
+  <rect x="300" y="42" width="440" height="44" rx="8" fill="none" stroke="#3E9463" stroke-width="1.6" stroke-dasharray="6 4"/>
+  <text x="520" y="61" text-anchor="middle" font-size="12" font-weight="600" fill="#3E9463">your override — weightFormFor(name) / weightForm</text>
+  <text x="520" y="77" text-anchor="middle" font-size="10.5" fill="#3E9463">whatever you pass wins; the resolver fills what you left unsaid</text>
+  <line x1="650" y1="86" x2="650" y2="144" stroke="#3E9463" stroke-width="1.6" marker-end="url(#wfg)"/>
+
+  <!-- consumers -->
+  <rect x="560" y="286" width="180" height="60" rx="8" fill="#EEF1F5" stroke="#DCE1E8" stroke-width="1.5"/>
+  <text x="650" y="310" text-anchor="middle" font-size="12" font-weight="600" fill="#1F2733">loader obeys</text>
+  <text x="650" y="328" text-anchor="middle" font-size="10.5" fill="#5C6675">ResolvedGguf · delivers the form</text>
+  <line x1="650" y1="236" x2="650" y2="280" stroke="#1F2733" stroke-width="1.5" marker-end="url(#wfa)"/>
+
+  <rect x="300" y="286" width="200" height="60" rx="8" fill="#E3ECF6" stroke="#4C7FB8" stroke-width="1.5"/>
+  <text x="400" y="310" text-anchor="middle" font-size="12" font-weight="600" fill="#1F2733">AllocationResolver</text>
+  <text x="400" y="328" text-anchor="middle" font-size="10.5" fill="#5C6675">domain + scope · explain()</text>
+  <line x1="556" y1="236" x2="470" y2="282" stroke="#1F2733" stroke-width="1.5" marker-end="url(#wfa)"/>
+  <text x="472" y="266" font-size="10.5" fill="#5C6675">prices &amp; places</text>
+
+  <text x="36" y="356" font-size="11" fill="#5C6675">the model author declares nothing — decisions are resolved, carried, and explainable before a byte of payload is read</text>
+</svg>

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -11,6 +11,7 @@
 ** xref:tutorials/minerva-getting-started.adoc[Minerva getting started]
 ** xref:tutorials/graph-dsl.adoc[Graph DSL]
 ** xref:tutorials/turboquant-getting-started.adoc[TurboQuant: KV-cache compression]
+** xref:tutorials/android-classifier-getting-started.adoc[Train a classifier on Android]
 * How-to guides
 ** xref:how-to/build-tensors.adoc[Build tensors with the data DSL]
 ** xref:how-to/tensor-ops.adoc[Apply tensor operations]
@@ -32,6 +33,7 @@
 ** xref:explanation/minerva-secure-mcu-export.adoc[How Minerva secure MCU export fits]
 ** xref:explanation/operator-design.adoc[Operator documentation system]
 ** xref:explanation/memory-model.adoc[The memory model]
+** xref:explanation/virtual-tensors.adoc[Virtual tensors: one logical tensor, many physical forms]
 ** xref:explanation/packed-weight-layout.adoc[Packed weight layout]
 ** xref:explanation/eager-execution.adoc[Eager execution: backends and kernels]
 ** xref:explanation/quantization-process.adoc[The quantization process]

--- a/docs/modules/ROOT/pages/explanation/virtual-tensors.adoc
+++ b/docs/modules/ROOT/pages/explanation/virtual-tensors.adoc
@@ -1,0 +1,127 @@
+= Virtual tensors: one logical tensor, many physical forms
+:description: How SKaiNET decouples what a tensor means from where and how its bytes live — the TensorView split, the strides algebra, and the resolvers that choose a physical form per device.
+
+A kernel wants bytes in one particular arrangement. A file holds them in another. A phone
+wants them off the managed heap; a browser has no choice but on it. The classic failure mode
+is to let each of these parties reshape the tensor for themselves — and pay a copy, a
+transpose, or a dequantization at every boundary.
+
+SKaiNET's answer, in the spirit of ML Drift's _tensor virtualization_, is to make the
+arrangement a *described property* instead of a hard-coded fact: operators address a tensor by
+its logical coordinates, and a per-tensor `Layout` translates those coordinates to a physical
+position. Because the translation is data, the runtime is free to pick the optimal physical
+object per kernel and per device — and nobody upstream notices.
+
+This page is the map. The neighbouring pages hold the depth:
+xref:explanation/memory-model.adoc[] for `Storage`/`Scope`/ownership,
+xref:explanation/packed-weight-layout.adoc[] for block orders and prepacking, and
+xref:explanation/eager-execution.adoc[] for how kernels are dispatched.
+
+== The strides algebra
+
+The mechanism is one multiplication per axis. A logical index `(o, b)` reaches physical
+position `o·s[0] + b·s[1]` — and *which* strides `s` the layout carries decides where the
+bytes actually are:
+
+image::virtual-tensor-strides.svg[One logical cell mapping to two different physical positions depending on the strides the layout carries]
+
+The same logical cell lands at physical index 13 under row-major strides and at index 6 under
+input-block-major strides. Transpose, narrow, and block reorder all become *metadata edits* —
+a strides swap, an offset, a block-order tag — not copies. This is
+`sk.ainet.lang.memory.Layout`: `strides`, `offsetElements`, and the block geometry
+(`blocked`, `blockAxis`, `blockOrder`), hardened by the wrong-block bugs (#968, #971, #973)
+that made the distinction impossible to ignore: for a block-quantized weight, canonical
+storage and kernel feed order hold *the same blocks at different physical positions*, and
+they coincide only at one block per row.
+
+== The four-way split
+
+A tensor's identity is four orthogonal questions, answered by four types that compose into a
+`TensorView`:
+
+[cols="1,2,2",options="header"]
+|===
+| Type | Question it answers | What it deliberately does not know
+
+| `Storage`
+| Who owns which bytes, and for how long — `Heap`, `OffHeap`, `Mapped` (file pages), with
+  `Owner` (owned / borrowed / alias) and liveness (`checkAlive()` throws after the scope
+  closes)
+| What the bytes mean
+
+| `Format`
+| What the elements are — dtype × encoding. A Q4_K weight is _logically_ FP32; the encoding
+  says how it is stored and never replaces the dtype
+| Where the bytes live
+
+| `Layout`
+| How a logical index reaches a physical position — strides, offset, block geometry
+| Anything about lifetime or meaning
+
+| `Scope`
+| How long allocations live — `MODEL` (until the model closes), `FORWARD` (recycled every
+  step), `AMBIENT` (GC, the default)
+| Which bytes; it only tracks and frees
+|===
+
+`TensorView = Shape + Format + Layout + Storage` is the value kernels unwrap once per call.
+Several views can address the same storage:
+
+image::tensor-view-anatomy.svg[Three views — dense, transposed, narrowed — sharing one storage; materialize() is the only copy point]
+
+`narrow` and `transpose` hand out windows and relabelings over the same bytes;
+`materialize()` is the *single* sanctioned copy point, and `prepack()` the single visible
+relayout (it moves blocks once, at load, and the result says so via `blockOrder` — so a
+reader walking the logical grid still fetches each block from where the new order put it).
+
+== Who decides the physical form? Resolvers.
+
+The model author never declares any of this — they cannot know it. What the file holds, what
+the device has, and what the backend's kernels can feed are all knowable at load time, in one
+place:
+
+image::weight-form-resolution.svg[File, profile and device capabilities feed WeightFormResolver; the WeightForm flows to the loader and to AllocationResolver; a user override lane outranks the resolver]
+
+* `WeightFormResolver.resolve(stored, profile, capabilities)` produces the `WeightForm` —
+  encoding request × byte order × shape orientation × residency. A format with a packed
+  kernel stays packed (and arrives in kernel feed order if the kernel wants it); a format
+  with no kernel is dequantized *once, at load, with the cost stated* — under a strict
+  profile such as `MOBILE_2GB` it refuses instead.
+* `AllocationResolver.resolve(weight, profile, platform)` turns the resolved form into an
+  `AllocationSpec` — memory domain and scope. Mapping from file pages requires all three:
+  the form asks for it, the platform can map, and the bytes really are the file's bytes (a
+  dequantized or re-ordered weight is a load-time copy, and a copy cannot be paged from a
+  file it no longer matches). `AllocationResolver.explain()` renders each decision with its
+  reason, so a plan can print where every tensor lands *before a byte of payload is read*.
+* *You outrank both.* The loader's precedence is explicit: per-tensor `weightFormFor` >
+  uniform `weightForm` > the resolver. `WeightForm(DequantizeTo(FP32), residency = HEAP)` —
+  everything dense, on the managed heap — is a supported one-liner, not a fight with the
+  planner.
+
+Consumers — the memory plan, the GGUF loader (`ResolvedGguf`), an execution context — carry
+and obey. None of them decide.
+
+== Lifetime without a graph
+
+Eager execution has no graph to run liveness analysis on, and does not need one: lifetimes
+follow call structure. A generation loop knows where a step ends, so
+`ctx.forwardScope(slabFloats) { scoped, scope -> … }` bump-allocates activations from one
+pre-sized slab and `scope.reset()` recycles it per step — steady-state decode allocates zero
+new slab bytes, and a read of a previous step's tensor throws `StorageClosedException`
+naming the storage instead of returning garbage. `ModelScope` is the weights-lifetime
+counterpart; `Scope.Ambient` (plain GC) remains the default everywhere.
+
+== Known limits, stated rather than implied
+
+* The virtualization described here is the *eager and IO* side. The compile pipeline
+  (tape → StableHLO) does not carry `Layout` yet; by decision (#1134), graph-level memory
+  planning stays in the downstream compiler, and core's future obligation there is metadata
+  carriage only (#1147), gated on an in-repo consumer (#1148).
+* `Storage.OffHeap` exists on every platform that can honour it, but no tensor factory
+  allocates through it yet — off the managed heap today means *mapped, read-only* weights
+  (dense F32; packed formats still land on the heap until the buffer-aware kernel SPI of
+  #973).
+* `ForwardScope`'s slab is a *heap* slab: it flattens allocation churn, it does not move
+  activations off-heap.
+* Trainable parameters are heap-resident by construction — a mapped page is read-only, and
+  no optimizer allocates from `PlatformStorage`.

--- a/docs/modules/ROOT/pages/tutorials/android-classifier-getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/android-classifier-getting-started.adoc
@@ -1,0 +1,154 @@
+= Train a classifier on Android
+:description: Define, train and evaluate a small Iris classifier with the Kotlin DSL on an Android device — and learn exactly where off-heap weights and the NEON kernels do and don't apply today.
+
+You will build a `[4, 16, 3]` multi-layer perceptron, train it on the embedded Iris dataset
+with cross-entropy, and evaluate it on a held-out split — all on-device, in Kotlin. Along the
+way this page is precise about two things people usually ask for on Android — *weights off
+the managed heap* and *NEON kernels* — because each applies to part of the story, and a
+tutorial that implies more would set you up for surprises.
+
+Every snippet below is real code: it lives in `skainet-docs-samples`, compiles in CI, and the
+training loop is executed with a held-out accuracy assertion. Every API used is `commonMain`
+and available on the Android target (minSdk 24); the Android-specific wiring (dependencies,
+`AndroidGguf`) is not exercised by CI — this repository has no device lane.
+
+== Prerequisites
+
+An Android project with Kotlin. Add the SKaiNET modules:
+
+[source,kotlin]
+----
+dependencies {
+    implementation("sk.ainet.core:skainet-lang-core:0.40.1")     // tensors, DSL, training
+    implementation("sk.ainet.core:skainet-backend-cpu:0.40.1")   // CPU ops
+    implementation("sk.ainet.core:skainet-compile-dag:0.40.1")   // autograd (training context)
+    implementation("sk.ainet.core:skainet-data-api:0.40.1")      // Dataset / DataBatch
+    implementation("sk.ainet.core:skainet-data-simple:0.40.1")   // embedded Iris
+    runtimeOnly("sk.ainet.core:skainet-backend-jni-cpu:0.40.1")  // NEON kernels (see below)
+}
+----
+
+The last line is optional for this tutorial and explained honestly in
+<<neon,the kernel section>>.
+
+== Step 1 — Data
+
+Iris ships embedded in `skainet-data-simple`: 150 rows, four measurements, three species.
+No download, no cache directory, works on every target. A stratified split keeps the class
+balance in both halves:
+
+[source,kotlin]
+----
+include::example$kotlin/sk/ainet/docs/samples/IrisClassifier.kt[tag=data]
+----
+
+`dataBatch` tensorizes a range: features arrive as `[n, 4]` FP32, targets as `[n, 3]`
+one-hot FP32.
+
+== Step 2 — Model and training context
+
+Training needs an autograd context (`DefaultGraphExecutionContext`, which records the tape
+and computes gradients); inference just needs the plain CPU context. The model ends at
+logits — no softmax head — because the loss applies softmax itself:
+
+[source,kotlin]
+----
+include::example$kotlin/sk/ainet/docs/samples/IrisClassifier.kt[tag=model]
+----
+
+[NOTE]
+.The training DSL is experimental
+====
+`training { }` is marked experimental in its own KDoc to avoid early API lock-in. The shapes
+below are what the in-repo end-to-end tests use; expect the spelling, not the concepts, to
+evolve.
+====
+
+== Step 3 — Train
+
+Cross-entropy over the one-hot targets, plain SGD, 300 epochs of full-batch steps — Iris is
+small enough that batching machinery would only obscure the loop:
+
+[source,kotlin]
+----
+include::example$kotlin/sk/ainet/docs/samples/IrisClassifier.kt[tag=train]
+----
+
+== Step 4 — Evaluate
+
+Argmax of the logits on a fresh inference context, compared against the held-out one-hot
+targets. The CI assertion on this exact code requires at least 0.80 held-out accuracy;
+typical runs land well above it:
+
+[source,kotlin]
+----
+include::example$kotlin/sk/ainet/docs/samples/IrisClassifier.kt[tag=evaluate]
+----
+
+On Android, run all of this off the main thread (`Iris.load()` is `suspend` for call-site
+symmetry with the downloading datasets; the training loop is ordinary CPU work).
+
+== Keeping memory flat: `forwardScope`
+
+A long-running loop that creates tensors every iteration produces a sawtooth of garbage on
+the ART heap. The Scope split gives you a flat line instead: one pre-sized slab, recycled
+every step —
+
+[source,kotlin]
+----
+ctx.forwardScope(slabFloats = 1 shl 16) { scoped, scope ->
+    while (running) {
+        val out = model.forward(scoped.fromFloatArray(Shape(1, 4), FP32::class, features), scoped)
+        consume(out)
+        scope.reset()   // steady state: zero new slab bytes per step
+    }
+}
+----
+
+Reading a previous step's tensor after `reset()` throws `StorageClosedException` — a loud
+error instead of silent garbage. Note what this is and isn't: the slab lives *on* the heap;
+it flattens allocation churn, it does not move activations off-heap.
+
+[#offheap]
+== Where "weights off the heap" applies today
+
+Off-heap applies to *loading*, not to training:
+
+* `AndroidGguf.loader(path)` serves dense F32 weights of a GGUF checkpoint from memory-mapped
+  file pages — bytes the OS pages in on demand, evicts under pressure, and that never count
+  against the ART heap cap. `AndroidGguf.profiledPlan(...).requireFits(device)` refuses
+  *before* a byte is allocated when the model won't fit.
+* Quantized tensors still land on the heap until the buffer-aware kernel SPI lands (#973) —
+  the packed matmul kernels take heap arrays today.
+* Trainable parameters are heap-resident by construction: a mapped page is read-only, and no
+  optimizer allocates through `PlatformStorage`. Off-heap `Storage` exists on Android (direct
+  `ByteBuffer`) and the planner can resolve to it, but no tensor factory allocates through it
+  yet.
+
+So: the classifier you just trained lives on the managed heap; a quantized GGUF you *load*
+for inference is where the off-heap machinery earns its keep. The full model of who decides
+placement is in xref:explanation/virtual-tensors.adoc[] and
+xref:explanation/memory-model.adoc[].
+
+[#neon]
+== Where the NEON kernels apply today
+
+Adding `skainet-backend-jni-cpu` costs one `runtimeOnly` line; the provider is discovered
+automatically via `ServiceLoader` (no registration call), smoke-tested at load, and picks a
+`+dotprod+fp16` build variant on CPUs that have it.
+
+What it accelerates is *quantized matmul*: Q8_0, Q4_0, Q4_K, Q5_0, Q5_1, Q5_K, Q6_K — the
+formats a GGUF checkpoint holds. Dense FP32 matmul — which is what this FP32 MLP uses — has
+no NEON kernel yet (#920) and runs on the scalar Kotlin path. On a Pixel 8a the difference
+for a quantized LLM decode is roughly 6× (see
+xref:explanation/perf/android-neon-jni-kernels.adoc[]); for this tutorial's model it changes
+nothing today. Add the line anyway: it is what makes the quantized-inference half of your app
+fast, and the dispatch is per-format, per-op — see
+xref:reference/kernel-support-matrix.adoc[] for the authoritative table.
+
+== Where to go next
+
+* xref:explanation/virtual-tensors.adoc[] — how one logical tensor takes many physical forms,
+  and who decides.
+* xref:tutorials/turboquant-getting-started.adoc[] — KV-cache compression for on-device LLMs.
+* xref:tutorials/kotlin-getting-started.adoc[] — the broader Kotlin API tour.

--- a/skainet-docs-samples/build.gradle.kts
+++ b/skainet-docs-samples/build.gradle.kts
@@ -30,10 +30,13 @@ kotlin {
                 implementation(project(":skainet-lang:skainet-lang-core"))
                 implementation(project(":skainet-backends:skainet-backend-cpu"))
                 implementation(project(":skainet-compile:skainet-compile-dag"))
+                implementation(project(":skainet-data:skainet-data-api"))
+                implementation(project(":skainet-data:skainet-data-simple"))
             }
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/skainet-docs-samples/src/commonTest/kotlin/sk/ainet/docs/samples/SamplesTest.kt
+++ b/skainet-docs-samples/src/commonTest/kotlin/sk/ainet/docs/samples/SamplesTest.kt
@@ -1,5 +1,6 @@
 package sk.ainet.docs.samples
 
+import kotlinx.coroutines.test.runTest
 import sk.ainet.context.DirectCpuExecutionContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,6 +35,13 @@ class SamplesTest {
         val pixels = FloatArray(784) { 0f }
         val scores = Quickstart.classify(pixels)
         assertEquals(listOf(1, 10), scores.shape.dimensions.toList())
+    }
+
+    @Test
+    fun iris_classifier_learns_and_generalizes() = runTest {
+        val r = IrisClassifier.run()
+        assertTrue(r.lastLoss < r.firstLoss, "loss should decrease: ${r.firstLoss} -> ${r.lastLoss}")
+        assertTrue(r.accuracy >= 0.80f, "held-out accuracy should be high on Iris, got ${r.accuracy}")
     }
 
     @Test


### PR DESCRIPTION
Closes #1160. Independent of #1162 (both branch from `develop`; merge in any order).

Two Antora pages with hand-drawn SVGs, one honest story:

**`explanation/virtual-tensors.adoc`** (developers) — the ML Drift-style tensor virtualization as implemented on the eager/IO side: the strides algebra (one logical cell, two physical positions), `TensorView = Shape + Format + Layout + Storage`, resolver-owned physical forms (`WeightFormResolver` → `AllocationResolver` → `explain()`, with the user-wins override lane), scope-based lifetime without a graph, and a "known limits, stated rather than implied" list (compile lane carries no Layout yet; `Storage.OffHeap` has no tensor-factory consumer; the ForwardScope slab is heap; trainable params are heap-resident). Heavy xrefs to `memory-model`, `packed-weight-layout`, `eager-execution` instead of duplication.

**`tutorials/android-classifier-getting-started.adoc`** (consumers) — define, train and evaluate a `[4,16,3]` Iris MLP with the Kotlin DSL on Android (minSdk 24, published coordinates), then two deliberately precise sections: *where off-heap applies today* (mapped GGUF loading — dense F32; not trainable parameters; #973 for packed) and *where NEON applies today* (quantized matmul via the auto-discovered JNI provider; FP32 is scalar until #920), with xrefs to the kernel-support matrix and the Pixel 8a perf page.

**The tutorial cannot rot:** its snippets are tagged regions of the new `IrisClassifier.kt` in `skainet-docs-samples`, compiled *and executed* in CI with a held-out accuracy ≥ 0.80 assertion. This is also the suite's first end-to-end `CrossEntropyLoss` training of a DSL model — a previously untested composition, now covered. (`skainet-docs-samples` gains `skainet-data-api`/`skainet-data-simple` and `kotlinx-coroutines-test` test deps.)

Full pr-gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
